### PR TITLE
feat(#3): multi-tenant auth with Bearer tokens, rate limits, and spend budgets

### DIFF
--- a/apps/web/src/app/dashboard/tokens/page.tsx
+++ b/apps/web/src/app/dashboard/tokens/page.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatCost, formatNumber, formatLatency } from "../../../lib/format";
+
+const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:4000";
+
+interface Token {
+  id: string;
+  name: string;
+  tenant: string;
+  tokenPrefix: string;
+  rateLimit: number | null;
+  spendLimit: number | null;
+  spendPeriod: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+interface TokenUsage {
+  totalCost: number;
+  totalRequests: number;
+  avgLatency: number;
+  currentPeriodCost: number;
+  currentPeriod: string;
+}
+
+interface TenantUsage {
+  tenant: string | null;
+  totalCost: number;
+  requestCount: number;
+}
+
+function CreateTokenForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [tenant, setTenant] = useState("");
+  const [rateLimit, setRateLimit] = useState("");
+  const [spendLimit, setSpendLimit] = useState("");
+  const [spendPeriod, setSpendPeriod] = useState("monthly");
+  const [submitting, setSubmitting] = useState(false);
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${GATEWAY}/v1/admin/tokens`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          tenant,
+          rateLimit: rateLimit ? parseInt(rateLimit) : undefined,
+          spendLimit: spendLimit ? parseFloat(spendLimit) : undefined,
+          spendPeriod,
+        }),
+      });
+      const data = await res.json();
+      if (data.plainToken) {
+        setCreatedToken(data.plainToken);
+      }
+      onCreated();
+    } catch (err) {
+      console.error("Failed to create token:", err);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleCopy() {
+    if (createdToken) {
+      navigator.clipboard.writeText(createdToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  function handleDone() {
+    setCreatedToken(null);
+    setName("");
+    setTenant("");
+    setRateLimit("");
+    setSpendLimit("");
+    setOpen(false);
+  }
+
+  // Show created token
+  if (createdToken) {
+    return (
+      <div className="bg-zinc-900 border border-emerald-800 rounded-lg p-6 space-y-4">
+        <div className="flex items-center gap-2">
+          <div className="w-2 h-2 rounded-full bg-emerald-500" />
+          <h3 className="text-lg font-semibold text-emerald-300">Token Created</h3>
+        </div>
+        <p className="text-sm text-amber-300">
+          Copy this token now. You won't be able to see it again.
+        </p>
+        <div className="flex gap-2">
+          <code className="flex-1 bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm font-mono break-all">
+            {createdToken}
+          </code>
+          <button
+            onClick={handleCopy}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium shrink-0"
+          >
+            {copied ? "Copied!" : "Copy"}
+          </button>
+        </div>
+        <button
+          onClick={handleDone}
+          className="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 rounded text-sm"
+        >
+          Done
+        </button>
+      </div>
+    );
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium transition-colors"
+      >
+        Create Token
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg font-semibold">Create API Token</h3>
+        <button type="button" onClick={() => setOpen(false)} className="text-zinc-400 hover:text-zinc-200">
+          Cancel
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+            placeholder="e.g. Production App"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Tenant</label>
+          <input
+            value={tenant}
+            onChange={(e) => setTenant(e.target.value)}
+            required
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+            placeholder="e.g. my-app"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Rate Limit (RPM)</label>
+          <input
+            type="number"
+            value={rateLimit}
+            onChange={(e) => setRateLimit(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+            placeholder="Unlimited"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Spend Limit (USD)</label>
+          <input
+            type="number"
+            step="0.01"
+            value={spendLimit}
+            onChange={(e) => setSpendLimit(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+            placeholder="Unlimited"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Billing Period</label>
+          <select
+            value={spendPeriod}
+            onChange={(e) => setSpendPeriod(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+          >
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        </div>
+      </div>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-lg text-sm font-medium transition-colors"
+      >
+        {submitting ? "Creating..." : "Create Token"}
+      </button>
+    </form>
+  );
+}
+
+function TokenCard({ token, onDelete }: { token: Token; onDelete: () => void }) {
+  const [usage, setUsage] = useState<TokenUsage | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    if (expanded) {
+      fetch(`${GATEWAY}/v1/admin/tokens/${token.id}`)
+        .then((r) => r.json())
+        .then((d) => setUsage(d.usage))
+        .catch(() => {});
+    }
+  }, [expanded, token.id]);
+
+  async function handleDelete() {
+    if (!confirm(`Revoke token "${token.name}"? This cannot be undone.`)) return;
+    await fetch(`${GATEWAY}/v1/admin/tokens/${token.id}`, { method: "DELETE" });
+    onDelete();
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-zinc-800/30"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <div className="flex items-center gap-3">
+          <code className="text-xs text-zinc-500 font-mono">{token.tokenPrefix}••••</code>
+          <span className="font-medium">{token.name}</span>
+          <span className="text-xs text-zinc-500">({token.tenant})</span>
+        </div>
+        <div className="flex items-center gap-3">
+          {token.rateLimit && (
+            <span className="text-xs text-zinc-500">{token.rateLimit} RPM</span>
+          )}
+          {token.spendLimit && (
+            <span className="text-xs text-zinc-500">{formatCost(token.spendLimit)}/{token.spendPeriod}</span>
+          )}
+          <span className="text-zinc-500 text-sm">{expanded ? "▾" : "▸"}</span>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-zinc-800 px-4 py-4 space-y-4">
+          {usage && (
+            <div className="grid grid-cols-4 gap-4">
+              <div>
+                <p className="text-xs text-zinc-500">Total Requests</p>
+                <p className="text-lg font-semibold">{formatNumber(usage.totalRequests)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500">Total Cost</p>
+                <p className="text-lg font-semibold">{formatCost(usage.totalCost)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500">Avg Latency</p>
+                <p className="text-lg font-semibold">{formatLatency(usage.avgLatency)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500">Current Period</p>
+                <p className="text-lg font-semibold">
+                  {formatCost(usage.currentPeriodCost)}
+                  {token.spendLimit && (
+                    <span className="text-xs text-zinc-500"> / {formatCost(token.spendLimit)}</span>
+                  )}
+                </p>
+              </div>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <button
+              onClick={handleDelete}
+              className="px-3 py-1 bg-red-900/50 hover:bg-red-800/50 text-red-300 rounded text-xs"
+            >
+              Revoke Token
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function TokensPage() {
+  const [tokens, setTokens] = useState<Token[]>([]);
+  const [tenantUsage, setTenantUsage] = useState<TenantUsage[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function fetchData() {
+    try {
+      const [tokensRes, usageRes] = await Promise.all([
+        fetch(`${GATEWAY}/v1/admin/tokens`),
+        fetch(`${GATEWAY}/v1/admin/tokens/usage/by-tenant`),
+      ]);
+      const tokensData = await tokensRes.json();
+      const usageData = await usageRes.json();
+      setTokens(tokensData.tokens || []);
+      setTenantUsage(usageData.tenants || []);
+    } catch (err) {
+      console.error("Failed to fetch tokens:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-zinc-400">Loading tokens...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">API Tokens</h1>
+        <CreateTokenForm onCreated={fetchData} />
+      </div>
+
+      {/* Auth Mode Indicator */}
+      <div className={`rounded-lg p-3 text-sm ${tokens.length === 0 ? "bg-amber-900/30 border border-amber-800 text-amber-300" : "bg-emerald-900/30 border border-emerald-800 text-emerald-300"}`}>
+        {tokens.length === 0
+          ? "Open mode — no tokens created. All API requests are allowed without authentication."
+          : `Auth enabled — ${tokens.length} token${tokens.length > 1 ? "s" : ""} active. API requests require a valid Bearer token.`}
+      </div>
+
+      {/* Per-Tenant Usage */}
+      {tenantUsage.length > 0 && (
+        <section>
+          <h2 className="text-lg font-semibold mb-3">Usage by Tenant</h2>
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-zinc-400 text-left">
+                  <th className="px-4 py-3">Tenant</th>
+                  <th className="px-4 py-3 text-right">Requests</th>
+                  <th className="px-4 py-3 text-right">Total Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tenantUsage.map((t) => (
+                  <tr key={t.tenant || "none"} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
+                    <td className="px-4 py-3">{t.tenant || "(no tenant)"}</td>
+                    <td className="px-4 py-3 text-right">{formatNumber(t.requestCount)}</td>
+                    <td className="px-4 py-3 text-right">{formatCost(t.totalCost)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Token List */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Tokens</h2>
+        {tokens.length === 0 ? (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-8 text-center">
+            <p className="text-zinc-400">No API tokens yet. Create one to enable authentication.</p>
+            <p className="text-sm text-zinc-500 mt-1">
+              The gateway runs in open mode until the first token is created.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {tokens.map((token) => (
+              <TokenCard key={token.id} token={token} onDelete={fetchData} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,6 +25,9 @@ function Nav() {
             <Link href="/dashboard/ab-tests" className="hover:text-zinc-100 transition-colors">
               A/B Tests
             </Link>
+            <Link href="/dashboard/tokens" className="hover:text-zinc-100 transition-colors">
+              Tokens
+            </Link>
             <Link href="/dashboard/api-keys" className="hover:text-zinc-100 transition-colors">
               API Keys
             </Link>

--- a/packages/db/drizzle/0002_quiet_nightcrawler.sql
+++ b/packages/db/drizzle/0002_quiet_nightcrawler.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `api_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`tenant` text NOT NULL,
+	`hashed_token` text NOT NULL,
+	`token_prefix` text NOT NULL,
+	`rate_limit` integer,
+	`spend_limit` real,
+	`spend_period` text DEFAULT 'monthly',
+	`expires_at` integer,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `api_tokens_hashed_token_unique` ON `api_tokens` (`hashed_token`);--> statement-breakpoint
+ALTER TABLE `cost_logs` ADD `tenant_id` text;--> statement-breakpoint
+ALTER TABLE `requests` ADD `tenant_id` text;

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,509 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c92a041d-6c11-4dc6-8fae-387488273441",
+  "prevId": "c5727438-05a5-4ba7-aa27-8dde09cb7fe6",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776196054194,
       "tag": "0001_typical_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776198276942,
+      "tag": "0002_quiet_nightcrawler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -13,6 +13,7 @@ export const requests = sqliteTable("requests", {
   taskType: text("task_type"),
   complexity: text("complexity"),
   routedBy: text("routed_by"),
+  tenantId: text("tenant_id"),
   abTestId: text("ab_test_id").references(() => abTests.id),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
@@ -43,6 +44,21 @@ export const abTestVariants = sqliteTable("ab_test_variants", {
   complexity: text("complexity"),
 });
 
+export const apiTokens = sqliteTable("api_tokens", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  tenant: text("tenant").notNull(),
+  hashedToken: text("hashed_token").notNull().unique(),
+  tokenPrefix: text("token_prefix").notNull(), // first 8 chars for display
+  rateLimit: integer("rate_limit"), // requests per minute, null = unlimited
+  spendLimit: real("spend_limit"), // USD per billing period, null = unlimited
+  spendPeriod: text("spend_period", { enum: ["monthly", "weekly", "daily"] }).default("monthly"),
+  expiresAt: integer("expires_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const apiKeys = sqliteTable("api_keys", {
   id: text("id").primaryKey(),
   name: text("name").notNull(), // e.g. "OPENAI_API_KEY"
@@ -61,6 +77,7 @@ export const apiKeys = sqliteTable("api_keys", {
 export const costLogs = sqliteTable("cost_logs", {
   id: text("id").primaryKey(),
   requestId: text("request_id").references(() => requests.id),
+  tenantId: text("tenant_id"),
   provider: text("provider").notNull(),
   model: text("model").notNull(),
   inputTokens: integer("input_tokens").notNull(),

--- a/packages/gateway/src/auth/index.ts
+++ b/packages/gateway/src/auth/index.ts
@@ -1,0 +1,3 @@
+export { generateToken, hashToken, maskToken, verifyToken, type TokenInfo } from "./tokens.js";
+export { createAuthMiddleware, getTokenInfo } from "./middleware.js";
+export { checkRateLimit, checkSpendLimit } from "./rate-limiter.js";

--- a/packages/gateway/src/auth/middleware.ts
+++ b/packages/gateway/src/auth/middleware.ts
@@ -1,0 +1,95 @@
+import type { Context, Next } from "hono";
+import type { Db } from "@provara/db";
+import { apiTokens } from "@provara/db";
+import { sql } from "drizzle-orm";
+import { verifyToken, type TokenInfo } from "./tokens.js";
+import { checkRateLimit, checkSpendLimit } from "./rate-limiter.js";
+
+// Store tenant info on the request context via a WeakMap keyed by request
+const tokenInfoMap = new WeakMap<Request, TokenInfo>();
+
+export function getTokenInfo(req: Request): TokenInfo | undefined {
+  return tokenInfoMap.get(req);
+}
+
+export function createAuthMiddleware(db: Db) {
+  return async (c: Context, next: Next) => {
+    // Skip auth for health check
+    if (c.req.path === "/health") {
+      return next();
+    }
+
+    // Skip auth for admin routes (accessed from dashboard)
+    if (c.req.path.startsWith("/v1/admin/")) {
+      return next();
+    }
+
+    // Check if any tokens exist — if not, run in open mode
+    const tokenCount = db
+      .select({ count: sql<number>`count(*)` })
+      .from(apiTokens)
+      .get();
+
+    if (!tokenCount || tokenCount.count === 0) {
+      return next();
+    }
+
+    // Extract Bearer token
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json(
+        { error: { message: "Missing or invalid Authorization header. Use: Bearer <token>", type: "auth_error" } },
+        401
+      );
+    }
+
+    const token = authHeader.slice(7);
+    const info = verifyToken(db, token);
+
+    if (!info) {
+      return c.json(
+        { error: { message: "Invalid or expired API token", type: "auth_error" } },
+        401
+      );
+    }
+
+    // Check rate limit
+    const rateResult = checkRateLimit(info.id, info.rateLimit);
+    if (!rateResult.allowed) {
+      c.header("Retry-After", String(Math.ceil(rateResult.resetMs / 1000)));
+      c.header("X-RateLimit-Limit", String(info.rateLimit));
+      c.header("X-RateLimit-Remaining", "0");
+      return c.json(
+        { error: { message: "Rate limit exceeded. Try again later.", type: "rate_limit_error" } },
+        429
+      );
+    }
+
+    // Check spend limit (only on completions endpoint to avoid overhead on reads)
+    if (c.req.path === "/v1/chat/completions" && c.req.method === "POST") {
+      const spendResult = checkSpendLimit(db, info);
+      if (!spendResult.allowed) {
+        return c.json(
+          {
+            error: {
+              message: `Spend limit exceeded. ${spendResult.spent.toFixed(4)} / ${spendResult.limit.toFixed(4)} USD (${spendResult.period})`,
+              type: "spend_limit_error",
+            },
+          },
+          402
+        );
+      }
+    }
+
+    // Set rate limit headers
+    if (info.rateLimit) {
+      c.header("X-RateLimit-Limit", String(info.rateLimit));
+      c.header("X-RateLimit-Remaining", String(rateResult.remaining));
+    }
+
+    // Attach tenant info to request for downstream use
+    tokenInfoMap.set(c.req.raw, info);
+
+    return next();
+  };
+}

--- a/packages/gateway/src/auth/rate-limiter.ts
+++ b/packages/gateway/src/auth/rate-limiter.ts
@@ -1,0 +1,78 @@
+import type { Db } from "@provara/db";
+import { costLogs } from "@provara/db";
+import { eq, and, gte, sql } from "drizzle-orm";
+import type { TokenInfo } from "./tokens.js";
+
+// In-memory sliding window counters (reset on restart — fine for single-instance)
+const windowCounters = new Map<string, { count: number; windowStart: number }>();
+const WINDOW_MS = 60_000; // 1 minute
+
+export function checkRateLimit(tokenId: string, rateLimit: number | null): { allowed: boolean; remaining: number; resetMs: number } {
+  if (!rateLimit) return { allowed: true, remaining: -1, resetMs: 0 };
+
+  const now = Date.now();
+  const entry = windowCounters.get(tokenId);
+
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
+    // New window
+    windowCounters.set(tokenId, { count: 1, windowStart: now });
+    return { allowed: true, remaining: rateLimit - 1, resetMs: WINDOW_MS };
+  }
+
+  if (entry.count >= rateLimit) {
+    const resetMs = WINDOW_MS - (now - entry.windowStart);
+    return { allowed: false, remaining: 0, resetMs };
+  }
+
+  entry.count++;
+  const resetMs = WINDOW_MS - (now - entry.windowStart);
+  return { allowed: true, remaining: rateLimit - entry.count, resetMs };
+}
+
+function getPeriodStart(period: string): Date {
+  const now = new Date();
+  switch (period) {
+    case "daily":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    case "weekly": {
+      const day = now.getDay();
+      const diff = now.getDate() - day + (day === 0 ? -6 : 1); // Monday start
+      return new Date(now.getFullYear(), now.getMonth(), diff);
+    }
+    case "monthly":
+    default:
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+  }
+}
+
+export function checkSpendLimit(
+  db: Db,
+  tokenInfo: TokenInfo
+): { allowed: boolean; spent: number; limit: number; period: string } {
+  if (!tokenInfo.spendLimit) {
+    return { allowed: true, spent: 0, limit: -1, period: "none" };
+  }
+
+  const period = tokenInfo.spendPeriod || "monthly";
+  const periodStart = getPeriodStart(period);
+
+  const result = db
+    .select({ total: sql<number>`coalesce(sum(${costLogs.cost}), 0)` })
+    .from(costLogs)
+    .where(
+      and(
+        eq(costLogs.tenantId, tokenInfo.tenant),
+        gte(costLogs.createdAt, periodStart)
+      )
+    )
+    .get();
+
+  const spent = result?.total || 0;
+
+  return {
+    allowed: spent < tokenInfo.spendLimit,
+    spent,
+    limit: tokenInfo.spendLimit,
+    period,
+  };
+}

--- a/packages/gateway/src/auth/tokens.ts
+++ b/packages/gateway/src/auth/tokens.ts
@@ -1,0 +1,58 @@
+import { randomBytes, createHash } from "node:crypto";
+import type { Db } from "@provara/db";
+import { apiTokens } from "@provara/db";
+import { eq } from "drizzle-orm";
+
+const TOKEN_PREFIX = "pvra_";
+const TOKEN_RANDOM_BYTES = 24; // 48 hex chars
+
+export interface TokenInfo {
+  id: string;
+  name: string;
+  tenant: string;
+  rateLimit: number | null;
+  spendLimit: number | null;
+  spendPeriod: string | null;
+  expiresAt: Date | null;
+}
+
+export function generateToken(): string {
+  const random = randomBytes(TOKEN_RANDOM_BYTES).toString("hex");
+  return `${TOKEN_PREFIX}${random}`;
+}
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function maskToken(token: string): string {
+  // Show prefix + first 4 random chars + masked + last 4
+  if (token.length <= 12) return token;
+  return token.slice(0, 9) + "••••" + token.slice(-4);
+}
+
+export function verifyToken(db: Db, token: string): TokenInfo | null {
+  const hashed = hashToken(token);
+  const row = db
+    .select()
+    .from(apiTokens)
+    .where(eq(apiTokens.hashedToken, hashed))
+    .get();
+
+  if (!row) return null;
+
+  // Check expiry
+  if (row.expiresAt && row.expiresAt < new Date()) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    name: row.name,
+    tenant: row.tenant,
+    rateLimit: row.rateLimit,
+    spendLimit: row.spendLimit,
+    spendPeriod: row.spendPeriod,
+    expiresAt: row.expiresAt,
+  };
+}

--- a/packages/gateway/src/cost/index.ts
+++ b/packages/gateway/src/cost/index.ts
@@ -11,6 +11,7 @@ export interface CostEntry {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  tenantId?: string | null;
 }
 
 export async function logCost(db: Db, entry: CostEntry): Promise<number> {
@@ -20,6 +21,7 @@ export async function logCost(db: Db, entry: CostEntry): Promise<number> {
     .values({
       id: nanoid(),
       requestId: entry.requestId,
+      tenantId: entry.tenantId || null,
       provider: entry.provider,
       model: entry.model,
       inputTokens: entry.inputTokens,

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -9,6 +9,8 @@ import { createRoutingEngine } from "./routing/index.js";
 import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
+import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
+import { createTokenRoutes } from "./routes/tokens.js";
 
 interface RouterContext {
   registry: ProviderRegistry;
@@ -22,6 +24,10 @@ export function createRouter(ctx: RouterContext) {
   // Enable CORS for web dashboard
   app.use("/*", cors());
 
+  // Auth middleware — checks Bearer token on /v1/* routes
+  // Runs in "open mode" (no auth) when no tokens have been created
+  app.use("/v1/*", createAuthMiddleware(ctx.db));
+
   // Mount A/B test CRUD routes
   app.route("/v1/ab-tests", createAbTestRoutes(ctx.db));
 
@@ -30,6 +36,9 @@ export function createRouter(ctx: RouterContext) {
 
   // Mount API key management routes
   app.route("/v1/api-keys", createApiKeyRoutes(ctx.db));
+
+  // Mount token management routes (admin — no auth required)
+  app.route("/v1/admin/tokens", createTokenRoutes(ctx.db));
 
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", (c) => {
@@ -66,6 +75,9 @@ export function createRouter(ctx: RouterContext) {
       model: routingResult.model,
     };
 
+    const tokenInfo = getTokenInfo(c.req.raw);
+    const tenantId = tokenInfo?.tenant || null;
+
     const start = performance.now();
     const response = await provider.complete(completionRequest);
     const latencyMs = Math.round(performance.now() - start);
@@ -85,6 +97,7 @@ export function createRouter(ctx: RouterContext) {
         taskType: routingResult.taskType,
         complexity: routingResult.complexity,
         routedBy: routingResult.routedBy,
+        tenantId,
         abTestId: routingResult.abTestId || null,
       })
       .run();
@@ -95,6 +108,7 @@ export function createRouter(ctx: RouterContext) {
       model: response.model,
       inputTokens: response.usage.inputTokens,
       outputTokens: response.usage.outputTokens,
+      tenantId,
     });
 
     // Return OpenAI-compatible response format

--- a/packages/gateway/src/routes/tokens.ts
+++ b/packages/gateway/src/routes/tokens.ts
@@ -1,0 +1,227 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { apiTokens, costLogs, requests } from "@provara/db";
+import { eq, and, gte, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { generateToken, hashToken, maskToken } from "../auth/tokens.js";
+
+export function createTokenRoutes(db: Db) {
+  const app = new Hono();
+
+  // List all tokens (masked)
+  app.get("/", (c) => {
+    const tokens = db.select().from(apiTokens).all();
+    return c.json({
+      tokens: tokens.map((t) => ({
+        id: t.id,
+        name: t.name,
+        tenant: t.tenant,
+        tokenPrefix: t.tokenPrefix,
+        rateLimit: t.rateLimit,
+        spendLimit: t.spendLimit,
+        spendPeriod: t.spendPeriod,
+        expiresAt: t.expiresAt,
+        createdAt: t.createdAt,
+      })),
+    });
+  });
+
+  // Get token detail with usage stats
+  app.get("/:id", (c) => {
+    const { id } = c.req.param();
+    const token = db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+
+    if (!token) {
+      return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
+    }
+
+    // Get usage stats for this tenant
+    const totalCost = db
+      .select({ total: sql<number>`coalesce(sum(${costLogs.cost}), 0)` })
+      .from(costLogs)
+      .where(eq(costLogs.tenantId, token.tenant))
+      .get();
+
+    const totalRequests = db
+      .select({ count: sql<number>`count(*)` })
+      .from(requests)
+      .where(eq(requests.tenantId, token.tenant))
+      .get();
+
+    const avgLatency = db
+      .select({ avg: sql<number>`avg(${requests.latencyMs})` })
+      .from(requests)
+      .where(eq(requests.tenantId, token.tenant))
+      .get();
+
+    // Current period spend
+    const periodStart = getPeriodStart(token.spendPeriod || "monthly");
+    const periodCost = db
+      .select({ total: sql<number>`coalesce(sum(${costLogs.cost}), 0)` })
+      .from(costLogs)
+      .where(
+        and(
+          eq(costLogs.tenantId, token.tenant),
+          gte(costLogs.createdAt, periodStart)
+        )
+      )
+      .get();
+
+    return c.json({
+      token: {
+        id: token.id,
+        name: token.name,
+        tenant: token.tenant,
+        tokenPrefix: token.tokenPrefix,
+        rateLimit: token.rateLimit,
+        spendLimit: token.spendLimit,
+        spendPeriod: token.spendPeriod,
+        expiresAt: token.expiresAt,
+        createdAt: token.createdAt,
+      },
+      usage: {
+        totalCost: totalCost?.total || 0,
+        totalRequests: totalRequests?.count || 0,
+        avgLatency: avgLatency?.avg || 0,
+        currentPeriodCost: periodCost?.total || 0,
+        currentPeriod: token.spendPeriod || "monthly",
+      },
+    });
+  });
+
+  // Create a new token
+  app.post("/", async (c) => {
+    const body = await c.req.json<{
+      name: string;
+      tenant: string;
+      rateLimit?: number;
+      spendLimit?: number;
+      spendPeriod?: "monthly" | "weekly" | "daily";
+      expiresAt?: string;
+    }>();
+
+    if (!body.name || !body.tenant) {
+      return c.json(
+        { error: { message: "name and tenant are required", type: "validation_error" } },
+        400
+      );
+    }
+
+    const plainToken = generateToken();
+    const hashed = hashToken(plainToken);
+    const id = nanoid();
+
+    db.insert(apiTokens)
+      .values({
+        id,
+        name: body.name,
+        tenant: body.tenant,
+        hashedToken: hashed,
+        tokenPrefix: plainToken.slice(0, 9), // "pvra_" + first 4 random chars
+        rateLimit: body.rateLimit || null,
+        spendLimit: body.spendLimit || null,
+        spendPeriod: body.spendPeriod || "monthly",
+        expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
+      })
+      .run();
+
+    // Return the full token — this is the ONLY time it's shown
+    return c.json(
+      {
+        token: {
+          id,
+          name: body.name,
+          tenant: body.tenant,
+          tokenPrefix: plainToken.slice(0, 9),
+          rateLimit: body.rateLimit || null,
+          spendLimit: body.spendLimit || null,
+          spendPeriod: body.spendPeriod || "monthly",
+          expiresAt: body.expiresAt || null,
+          createdAt: new Date().toISOString(),
+        },
+        // The full plaintext token — shown once, never again
+        plainToken,
+      },
+      201
+    );
+  });
+
+  // Update a token
+  app.patch("/:id", async (c) => {
+    const { id } = c.req.param();
+    const body = await c.req.json<{
+      name?: string;
+      rateLimit?: number | null;
+      spendLimit?: number | null;
+      spendPeriod?: "monthly" | "weekly" | "daily";
+      expiresAt?: string | null;
+    }>();
+
+    const token = db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    if (!token) {
+      return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (body.name !== undefined) updates.name = body.name;
+    if (body.rateLimit !== undefined) updates.rateLimit = body.rateLimit;
+    if (body.spendLimit !== undefined) updates.spendLimit = body.spendLimit;
+    if (body.spendPeriod !== undefined) updates.spendPeriod = body.spendPeriod;
+    if (body.expiresAt !== undefined) {
+      updates.expiresAt = body.expiresAt ? new Date(body.expiresAt) : null;
+    }
+
+    if (Object.keys(updates).length > 0) {
+      db.update(apiTokens).set(updates).where(eq(apiTokens.id, id)).run();
+    }
+
+    const updated = db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    return c.json({ token: updated });
+  });
+
+  // Delete (revoke) a token
+  app.delete("/:id", (c) => {
+    const { id } = c.req.param();
+    const token = db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+
+    if (!token) {
+      return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
+    }
+
+    db.delete(apiTokens).where(eq(apiTokens.id, id)).run();
+    return c.json({ deleted: true });
+  });
+
+  // Per-tenant usage summary
+  app.get("/usage/by-tenant", (c) => {
+    const rows = db
+      .select({
+        tenant: costLogs.tenantId,
+        totalCost: sql<number>`coalesce(sum(${costLogs.cost}), 0)`,
+        requestCount: sql<number>`count(*)`,
+      })
+      .from(costLogs)
+      .groupBy(costLogs.tenantId)
+      .all();
+
+    return c.json({ tenants: rows });
+  });
+
+  return app;
+}
+
+function getPeriodStart(period: string): Date {
+  const now = new Date();
+  switch (period) {
+    case "daily":
+      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    case "weekly": {
+      const day = now.getDay();
+      const diff = now.getDate() - day + (day === 0 ? -6 : 1);
+      return new Date(now.getFullYear(), now.getMonth(), diff);
+    }
+    case "monthly":
+    default:
+      return new Date(now.getFullYear(), now.getMonth(), 1);
+  }
+}


### PR DESCRIPTION
## Summary

- Bearer token auth (`Authorization: Bearer pvra_...`) on all `/v1/*` routes
- Automatic "open mode" when no tokens exist — zero config for local dev
- Per-token rate limiting (RPM) with sliding window and `X-RateLimit-*` headers
- Per-tenant spend budgets with configurable billing periods (daily/weekly/monthly)
- Token CRUD API at `/v1/admin/tokens` (admin routes skip auth — dashboard access only)
- Dashboard page: create tokens (shown once), per-tenant usage, revocation
- `tenantId` tracked on all requests and cost logs for per-tenant analytics

Closes #3

---
Authored-by: claude/opus-4.6 (claude-code)
Last-code-by: claude/opus-4.6 (claude-code)
*Captain's log entry created by [shiplog](https://github.com/devallibus/shiplog)*
