### PR TITLE
feat(#7): dynamic provider registry with generic adapter, model discovery, and dashboard

### DIFF
--- a/apps/web/src/app/dashboard/providers/page.tsx
+++ b/apps/web/src/app/dashboard/providers/page.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:4000";
+
+interface BuiltinProvider {
+  name: string;
+  models: string[];
+}
+
+interface CustomProvider {
+  id: string;
+  name: string;
+  baseURL: string;
+  apiKeyRef: string | null;
+  models: string[];
+  enabled: boolean;
+  createdAt: string;
+}
+
+const WELL_KNOWN_PROVIDERS = [
+  { name: "together", baseURL: "https://api.together.xyz/v1", keyName: "TOGETHER_API_KEY" },
+  { name: "groq", baseURL: "https://api.groq.com/openai/v1", keyName: "GROQ_API_KEY" },
+  { name: "fireworks", baseURL: "https://api.fireworks.ai/inference/v1", keyName: "FIREWORKS_API_KEY" },
+  { name: "perplexity", baseURL: "https://api.perplexity.ai", keyName: "PERPLEXITY_API_KEY" },
+  { name: "deepseek", baseURL: "https://api.deepseek.com/v1", keyName: "DEEPSEEK_API_KEY" },
+  { name: "openrouter", baseURL: "https://openrouter.ai/api/v1", keyName: "OPENROUTER_API_KEY" },
+];
+
+function AddProviderForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [usePreset, setUsePreset] = useState(true);
+  const [preset, setPreset] = useState(WELL_KNOWN_PROVIDERS[0].name);
+  const [name, setName] = useState("");
+  const [baseURL, setBaseURL] = useState("");
+  const [apiKeyRef, setApiKeyRef] = useState("");
+  const [discover, setDiscover] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  function handlePresetChange(presetName: string) {
+    const p = WELL_KNOWN_PROVIDERS.find((w) => w.name === presetName);
+    if (p) {
+      setPreset(p.name);
+      setName(p.name);
+      setBaseURL(p.baseURL);
+      setApiKeyRef(p.keyName);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+
+    const finalName = usePreset ? WELL_KNOWN_PROVIDERS.find((w) => w.name === preset)?.name || name : name;
+    const finalBaseURL = usePreset ? WELL_KNOWN_PROVIDERS.find((w) => w.name === preset)?.baseURL || baseURL : baseURL;
+    const finalKeyRef = usePreset ? WELL_KNOWN_PROVIDERS.find((w) => w.name === preset)?.keyName || apiKeyRef : apiKeyRef;
+
+    try {
+      const res = await fetch(`${GATEWAY}/v1/admin/providers`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: finalName,
+          baseURL: finalBaseURL,
+          apiKeyRef: finalKeyRef || undefined,
+          discover,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error?.message || "Failed to create provider");
+        return;
+      }
+
+      // Reload providers
+      await fetch(`${GATEWAY}/v1/providers/reload`, { method: "POST" });
+
+      setOpen(false);
+      setName("");
+      setBaseURL("");
+      setApiKeyRef("");
+      onCreated();
+    } catch (err) {
+      setError("Failed to connect to gateway");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium transition-colors"
+      >
+        Add Provider
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg font-semibold">Add Custom Provider</h3>
+        <button type="button" onClick={() => setOpen(false)} className="text-zinc-400 hover:text-zinc-200">
+          Cancel
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-900/30 border border-red-800 rounded px-3 py-2 text-sm text-red-300">{error}</div>
+      )}
+
+      <div className="flex gap-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" checked={usePreset} onChange={() => setUsePreset(true)} />
+          Well-known provider
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input type="radio" checked={!usePreset} onChange={() => setUsePreset(false)} />
+          Custom
+        </label>
+      </div>
+
+      {usePreset ? (
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Provider</label>
+          <select
+            value={preset}
+            onChange={(e) => handlePresetChange(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+          >
+            {WELL_KNOWN_PROVIDERS.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name} — {p.baseURL}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-zinc-500 mt-1">
+            API key name: <code className="bg-zinc-800 px-1 rounded">{WELL_KNOWN_PROVIDERS.find((w) => w.name === preset)?.keyName}</code>
+            — add this key in the API Keys page first.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-zinc-400 mb-1">Name</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+              placeholder="e.g. my-provider"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-zinc-400 mb-1">Base URL</label>
+            <input
+              value={baseURL}
+              onChange={(e) => setBaseURL(e.target.value)}
+              required
+              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+              placeholder="https://api.example.com/v1"
+            />
+          </div>
+          <div className="col-span-2">
+            <label className="block text-sm text-zinc-400 mb-1">API Key Reference</label>
+            <input
+              value={apiKeyRef}
+              onChange={(e) => setApiKeyRef(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+              placeholder="Key name from API Keys page (e.g. MY_PROVIDER_KEY)"
+            />
+          </div>
+        </div>
+      )}
+
+      <label className="flex items-center gap-2 text-sm">
+        <input type="checkbox" checked={discover} onChange={(e) => setDiscover(e.target.checked)} />
+        Auto-discover models via GET /models
+      </label>
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-lg text-sm font-medium transition-colors"
+      >
+        {submitting ? "Adding..." : "Add Provider"}
+      </button>
+    </form>
+  );
+}
+
+function CustomProviderCard({ provider, onUpdate }: { provider: CustomProvider; onUpdate: () => void }) {
+  const [discovering, setDiscovering] = useState(false);
+
+  async function handleDiscover() {
+    setDiscovering(true);
+    try {
+      const res = await fetch(`${GATEWAY}/v1/admin/providers/${provider.id}/discover`, { method: "POST" });
+      if (res.ok) {
+        await fetch(`${GATEWAY}/v1/providers/reload`, { method: "POST" });
+        onUpdate();
+      }
+    } catch {
+    } finally {
+      setDiscovering(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Remove provider "${provider.name}"?`)) return;
+    await fetch(`${GATEWAY}/v1/admin/providers/${provider.id}`, { method: "DELETE" });
+    await fetch(`${GATEWAY}/v1/providers/reload`, { method: "POST" });
+    onUpdate();
+  }
+
+  async function handleToggle() {
+    await fetch(`${GATEWAY}/v1/admin/providers/${provider.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: !provider.enabled }),
+    });
+    await fetch(`${GATEWAY}/v1/providers/reload`, { method: "POST" });
+    onUpdate();
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div className={`w-2 h-2 rounded-full ${provider.enabled ? "bg-emerald-500" : "bg-zinc-600"}`} />
+          <span className="font-medium capitalize">{provider.name}</span>
+          <span className="text-xs text-zinc-500">custom</span>
+        </div>
+        <div className="flex gap-2">
+          <button onClick={handleDiscover} disabled={discovering} className="text-xs text-blue-400 hover:text-blue-300 disabled:opacity-50">
+            {discovering ? "Discovering..." : "Discover Models"}
+          </button>
+          <button onClick={handleToggle} className="text-xs text-zinc-400 hover:text-zinc-200">
+            {provider.enabled ? "Disable" : "Enable"}
+          </button>
+          <button onClick={handleDelete} className="text-xs text-red-400 hover:text-red-300">
+            Remove
+          </button>
+        </div>
+      </div>
+      <p className="text-xs text-zinc-500 font-mono mb-1">{provider.baseURL}</p>
+      {provider.apiKeyRef && (
+        <p className="text-xs text-zinc-500 mb-1">Key: <code className="bg-zinc-800 px-1 rounded">{provider.apiKeyRef}</code></p>
+      )}
+      <p className="text-xs text-zinc-400">
+        {provider.models.length > 0 ? provider.models.join(", ") : "No models — run discovery"}
+      </p>
+    </div>
+  );
+}
+
+export default function ProvidersPage() {
+  const [builtinProviders, setBuiltinProviders] = useState<BuiltinProvider[]>([]);
+  const [customProvidersList, setCustomProvidersList] = useState<CustomProvider[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function fetchData() {
+    try {
+      const [builtinRes, customRes] = await Promise.all([
+        fetch(`${GATEWAY}/v1/providers`),
+        fetch(`${GATEWAY}/v1/admin/providers`),
+      ]);
+      const builtinData = await builtinRes.json();
+      const customData = await customRes.json();
+      setBuiltinProviders(builtinData.providers || []);
+      setCustomProvidersList(customData.providers || []);
+    } catch (err) {
+      console.error("Failed to fetch providers:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-zinc-400">Loading providers...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Providers</h1>
+        <AddProviderForm onCreated={fetchData} />
+      </div>
+
+      {/* Active Providers (built-in) */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Built-in Providers</h2>
+        <div className="grid grid-cols-3 gap-3">
+          {builtinProviders.map((p) => (
+            <div key={p.name} className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <div className="w-2 h-2 rounded-full bg-emerald-500" />
+                <span className="font-medium capitalize">{p.name}</span>
+              </div>
+              <p className="text-xs text-zinc-500">
+                {p.models.length > 0 ? p.models.join(", ") : "Any model (local)"}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Custom Providers */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Custom Providers</h2>
+        {customProvidersList.length === 0 ? (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-8 text-center">
+            <p className="text-zinc-400">No custom providers yet.</p>
+            <p className="text-sm text-zinc-500 mt-1">
+              Add any OpenAI-compatible provider — Together AI, Groq, Fireworks, Perplexity, Deepseek, and more.
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {customProvidersList.map((p) => (
+              <CustomProviderCard key={p.id} provider={p} onUpdate={fetchData} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -19,6 +19,9 @@ function Nav() {
             <Link href="/dashboard" className="hover:text-zinc-100 transition-colors">
               Dashboard
             </Link>
+            <Link href="/dashboard/providers" className="hover:text-zinc-100 transition-colors">
+              Providers
+            </Link>
             <Link href="/dashboard/routing" className="hover:text-zinc-100 transition-colors">
               Routing
             </Link>

--- a/packages/db/drizzle/0004_orange_banshee.sql
+++ b/packages/db/drizzle/0004_orange_banshee.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `custom_providers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`base_url` text NOT NULL,
+	`api_key_ref` text,
+	`models` text DEFAULT '[]' NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `custom_providers_name_unique` ON `custom_providers` (`name`);--> statement-breakpoint
+CREATE TABLE `model_registry` (
+	`id` text PRIMARY KEY NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`input_price_per_1m` real,
+	`output_price_per_1m` real,
+	`source` text DEFAULT 'builtin' NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,728 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1e52edcb-ccd1-4706-a89c-9245275fa3fc",
+  "prevId": "45e43117-b828-4331-8d3e-c56bf2ff8480",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776198904624,
       "tag": "0003_whole_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1776199660168,
+      "tag": "0004_orange_banshee",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,32 @@
 import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
 
+export const customProviders = sqliteTable("custom_providers", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  baseURL: text("base_url").notNull(),
+  apiKeyRef: text("api_key_ref"), // name of the key in api_keys table, e.g. "TOGETHER_API_KEY"
+  models: text("models").notNull().default("[]"), // JSON array of model names
+  enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const modelRegistry = sqliteTable("model_registry", {
+  id: text("id").primaryKey(),
+  provider: text("provider").notNull(),
+  model: text("model").notNull(),
+  inputPricePer1M: real("input_price_per_1m"),
+  outputPricePer1M: real("output_price_per_1m"),
+  source: text("source", { enum: ["builtin", "custom", "discovered"] })
+    .notNull()
+    .default("builtin"),
+  enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const requests = sqliteTable("requests", {
   id: text("id").primaryKey(),
   provider: text("provider").notNull(),

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -10,12 +10,14 @@ import { createDb } from "@provara/db";
 import { createProviderRegistry } from "./providers/index.js";
 import { createRouter } from "./router.js";
 import { getDecryptedKeys } from "./routes/api-keys.js";
+import { loadCustomProviders } from "./providers/custom-loader.js";
 
 const port = parseInt(process.env.PORT || "4000", 10);
 
 const db = createDb();
 const registry = createProviderRegistry({
   getKeys: () => getDecryptedKeys(db),
+  getCustomProviders: () => loadCustomProviders(db),
 });
 const app = createRouter({ registry, db });
 

--- a/packages/gateway/src/providers/custom-loader.ts
+++ b/packages/gateway/src/providers/custom-loader.ts
@@ -1,0 +1,57 @@
+import type { Db } from "@provara/db";
+import { customProviders } from "@provara/db";
+import { eq } from "drizzle-orm";
+import type { OpenAICompatibleConfig } from "./openai-compatible.js";
+import { decrypt, hasMasterKey } from "../crypto/index.js";
+import { apiKeys } from "@provara/db";
+
+export function loadCustomProviders(db: Db): OpenAICompatibleConfig[] {
+  const rows = db
+    .select()
+    .from(customProviders)
+    .where(eq(customProviders.enabled, true))
+    .all();
+
+  const configs: OpenAICompatibleConfig[] = [];
+
+  for (const row of rows) {
+    let apiKey = "";
+
+    // Resolve API key from api_keys table if reference is set
+    if (row.apiKeyRef && hasMasterKey()) {
+      const keyRow = db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.name, row.apiKeyRef))
+        .get();
+
+      if (keyRow) {
+        try {
+          apiKey = decrypt({
+            encrypted: keyRow.encryptedValue,
+            iv: keyRow.iv,
+            authTag: keyRow.authTag,
+          });
+        } catch {
+          // Skip if decryption fails
+        }
+      }
+    }
+
+    let models: string[] = [];
+    try {
+      models = JSON.parse(row.models);
+    } catch {
+      models = [];
+    }
+
+    configs.push({
+      name: row.name,
+      baseURL: row.baseURL,
+      apiKey,
+      models,
+    });
+  }
+
+  return configs;
+}

--- a/packages/gateway/src/providers/index.ts
+++ b/packages/gateway/src/providers/index.ts
@@ -6,18 +6,23 @@ import { createMistralProvider } from "./mistral.js";
 import { createXAIProvider } from "./xai.js";
 import { createZAIProvider } from "./zai.js";
 import { createOllamaProvider } from "./ollama.js";
+import { createOpenAICompatibleProvider, type OpenAICompatibleConfig } from "./openai-compatible.js";
 
 export type { Provider, CompletionRequest, CompletionResponse, ChatMessage } from "./types.js";
+export { createOpenAICompatibleProvider, type OpenAICompatibleConfig } from "./openai-compatible.js";
 
 export interface ProviderRegistry {
   get(name: string): Provider | undefined;
   getForModel(model: string): Provider | undefined;
   list(): Provider[];
   reload(): void;
+  addCustom(config: OpenAICompatibleConfig): void;
+  removeCustom(name: string): void;
 }
 
 interface RegistryConfig {
   getKeys?: () => Record<string, string>;
+  getCustomProviders?: () => OpenAICompatibleConfig[];
 }
 
 export function createProviderRegistry(config?: RegistryConfig): ProviderRegistry {
@@ -27,24 +32,32 @@ export function createProviderRegistry(config?: RegistryConfig): ProviderRegistr
     providers = [];
     const dbKeys = config?.getKeys?.() || {};
 
-    // DB keys take precedence, fall back to env vars
+    // Built-in providers: DB keys take precedence, fall back to env vars
     const openaiKey = dbKeys["OPENAI_API_KEY"] || process.env.OPENAI_API_KEY;
     const anthropicKey = dbKeys["ANTHROPIC_API_KEY"] || process.env.ANTHROPIC_API_KEY;
     const googleKey = dbKeys["GOOGLE_API_KEY"] || process.env.GOOGLE_API_KEY;
     const mistralKey = dbKeys["MISTRAL_API_KEY"] || process.env.MISTRAL_API_KEY;
     const xaiKey = dbKeys["XAI_API_KEY"] || process.env.XAI_API_KEY;
+    const zaiKey = dbKeys["ZAI_API_KEY"] || process.env.ZAI_API_KEY;
 
     if (openaiKey) providers.push(createOpenAIProvider(openaiKey));
     if (anthropicKey) providers.push(createAnthropicProvider(anthropicKey));
     if (googleKey) providers.push(createGoogleProvider(googleKey));
     if (mistralKey) providers.push(createMistralProvider(mistralKey));
     if (xaiKey) providers.push(createXAIProvider(xaiKey));
-
-    const zaiKey = dbKeys["ZAI_API_KEY"] || process.env.ZAI_API_KEY;
     if (zaiKey) providers.push(createZAIProvider(zaiKey));
 
     // Ollama is always available (local)
     providers.push(createOllamaProvider());
+
+    // Load custom providers from DB
+    const customProviders = config?.getCustomProviders?.() || [];
+    for (const cp of customProviders) {
+      // Skip if a built-in provider already exists with this name
+      if (!providers.some((p) => p.name === cp.name)) {
+        providers.push(createOpenAICompatibleProvider(cp));
+      }
+    }
   }
 
   load();
@@ -64,6 +77,16 @@ export function createProviderRegistry(config?: RegistryConfig): ProviderRegistr
 
     reload() {
       load();
+    },
+
+    addCustom(customConfig: OpenAICompatibleConfig) {
+      // Remove existing provider with same name if present
+      providers = providers.filter((p) => p.name !== customConfig.name);
+      providers.push(createOpenAICompatibleProvider(customConfig));
+    },
+
+    removeCustom(name: string) {
+      providers = providers.filter((p) => p.name !== name);
     },
   };
 }

--- a/packages/gateway/src/providers/mistral.ts
+++ b/packages/gateway/src/providers/mistral.ts
@@ -1,41 +1,11 @@
-import OpenAI from "openai";
-import type { Provider, CompletionRequest, CompletionResponse } from "./types.js";
-import { nanoid } from "nanoid";
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { Provider } from "./types.js";
 
 export function createMistralProvider(apiKey?: string): Provider {
-  const client = new OpenAI({
-    apiKey: apiKey || process.env.MISTRAL_API_KEY,
-    baseURL: "https://api.mistral.ai/v1",
-  });
-
-  return {
+  return createOpenAICompatibleProvider({
     name: "mistral",
+    baseURL: "https://api.mistral.ai/v1",
+    apiKey: apiKey || process.env.MISTRAL_API_KEY || "",
     models: ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
-
-    async complete(request: CompletionRequest): Promise<CompletionResponse> {
-      const start = performance.now();
-
-      const response = await client.chat.completions.create({
-        model: request.model,
-        messages: request.messages,
-        temperature: request.temperature,
-        max_tokens: request.max_tokens,
-      });
-
-      const latencyMs = Math.round(performance.now() - start);
-      const choice = response.choices[0];
-
-      return {
-        id: nanoid(),
-        provider: "mistral",
-        model: request.model,
-        content: choice?.message?.content || "",
-        usage: {
-          inputTokens: response.usage?.prompt_tokens || 0,
-          outputTokens: response.usage?.completion_tokens || 0,
-        },
-        latencyMs,
-      };
-    },
-  };
+  });
 }

--- a/packages/gateway/src/providers/ollama.ts
+++ b/packages/gateway/src/providers/ollama.ts
@@ -1,41 +1,11 @@
-import OpenAI from "openai";
-import type { Provider, CompletionRequest, CompletionResponse } from "./types.js";
-import { nanoid } from "nanoid";
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { Provider } from "./types.js";
 
 export function createOllamaProvider(baseURL?: string): Provider {
-  const client = new OpenAI({
-    apiKey: "ollama",
-    baseURL: baseURL || process.env.OLLAMA_BASE_URL || "http://localhost:11434/v1",
-  });
-
-  return {
+  return createOpenAICompatibleProvider({
     name: "ollama",
-    models: [],
-
-    async complete(request: CompletionRequest): Promise<CompletionResponse> {
-      const start = performance.now();
-
-      const response = await client.chat.completions.create({
-        model: request.model,
-        messages: request.messages,
-        temperature: request.temperature,
-        max_tokens: request.max_tokens,
-      });
-
-      const latencyMs = Math.round(performance.now() - start);
-      const choice = response.choices[0];
-
-      return {
-        id: nanoid(),
-        provider: "ollama",
-        model: request.model,
-        content: choice?.message?.content || "",
-        usage: {
-          inputTokens: response.usage?.prompt_tokens || 0,
-          outputTokens: response.usage?.completion_tokens || 0,
-        },
-        latencyMs,
-      };
-    },
-  };
+    baseURL: baseURL || process.env.OLLAMA_BASE_URL || "http://localhost:11434/v1",
+    apiKey: "ollama",
+    models: [], // Ollama accepts any model
+  });
 }

--- a/packages/gateway/src/providers/openai-compatible.ts
+++ b/packages/gateway/src/providers/openai-compatible.ts
@@ -1,0 +1,63 @@
+import OpenAI from "openai";
+import type { Provider, CompletionRequest, CompletionResponse } from "./types.js";
+import { nanoid } from "nanoid";
+
+export interface OpenAICompatibleConfig {
+  name: string;
+  baseURL: string;
+  apiKey: string;
+  models: string[];
+}
+
+export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): Provider {
+  const client = new OpenAI({
+    apiKey: config.apiKey,
+    baseURL: config.baseURL,
+  });
+
+  return {
+    name: config.name,
+    models: [...config.models],
+
+    async complete(request: CompletionRequest): Promise<CompletionResponse> {
+      const start = performance.now();
+
+      const response = await client.chat.completions.create({
+        model: request.model,
+        messages: request.messages,
+        temperature: request.temperature,
+        max_tokens: request.max_tokens,
+      });
+
+      const latencyMs = Math.round(performance.now() - start);
+      const choice = response.choices[0];
+
+      return {
+        id: nanoid(),
+        provider: config.name,
+        model: request.model,
+        content: choice?.message?.content || "",
+        usage: {
+          inputTokens: response.usage?.prompt_tokens || 0,
+          outputTokens: response.usage?.completion_tokens || 0,
+        },
+        latencyMs,
+      };
+    },
+  };
+}
+
+// Discover models from an OpenAI-compatible /models endpoint
+export async function discoverModels(baseURL: string, apiKey: string): Promise<string[]> {
+  try {
+    const client = new OpenAI({ apiKey, baseURL });
+    const response = await client.models.list();
+    const models: string[] = [];
+    for await (const model of response) {
+      models.push(model.id);
+    }
+    return models;
+  } catch {
+    return [];
+  }
+}

--- a/packages/gateway/src/providers/xai.ts
+++ b/packages/gateway/src/providers/xai.ts
@@ -1,41 +1,11 @@
-import OpenAI from "openai";
-import type { Provider, CompletionRequest, CompletionResponse } from "./types.js";
-import { nanoid } from "nanoid";
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { Provider } from "./types.js";
 
 export function createXAIProvider(apiKey?: string): Provider {
-  const client = new OpenAI({
-    apiKey: apiKey || process.env.XAI_API_KEY,
-    baseURL: "https://api.x.ai/v1",
-  });
-
-  return {
+  return createOpenAICompatibleProvider({
     name: "xai",
+    baseURL: "https://api.x.ai/v1",
+    apiKey: apiKey || process.env.XAI_API_KEY || "",
     models: ["grok-3", "grok-3-mini"],
-
-    async complete(request: CompletionRequest): Promise<CompletionResponse> {
-      const start = performance.now();
-
-      const response = await client.chat.completions.create({
-        model: request.model,
-        messages: request.messages,
-        temperature: request.temperature,
-        max_tokens: request.max_tokens,
-      });
-
-      const latencyMs = Math.round(performance.now() - start);
-      const choice = response.choices[0];
-
-      return {
-        id: nanoid(),
-        provider: "xai",
-        model: request.model,
-        content: choice?.message?.content || "",
-        usage: {
-          inputTokens: response.usage?.prompt_tokens || 0,
-          outputTokens: response.usage?.completion_tokens || 0,
-        },
-        latencyMs,
-      };
-    },
-  };
+  });
 }

--- a/packages/gateway/src/providers/zai.ts
+++ b/packages/gateway/src/providers/zai.ts
@@ -1,41 +1,11 @@
-import OpenAI from "openai";
-import type { Provider, CompletionRequest, CompletionResponse } from "./types.js";
-import { nanoid } from "nanoid";
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { Provider } from "./types.js";
 
 export function createZAIProvider(apiKey?: string): Provider {
-  const client = new OpenAI({
-    apiKey: apiKey || process.env.ZAI_API_KEY,
-    baseURL: "https://api.z.ai/api/paas/v4",
-  });
-
-  return {
+  return createOpenAICompatibleProvider({
     name: "zai",
+    baseURL: "https://api.z.ai/api/paas/v4",
+    apiKey: apiKey || process.env.ZAI_API_KEY || "",
     models: ["glm-5.1", "glm-5-turbo", "glm-5v-turbo", "glm-4.7", "glm-4.7-flash", "glm-4.7-flashx"],
-
-    async complete(request: CompletionRequest): Promise<CompletionResponse> {
-      const start = performance.now();
-
-      const response = await client.chat.completions.create({
-        model: request.model,
-        messages: request.messages,
-        temperature: request.temperature,
-        max_tokens: request.max_tokens,
-      });
-
-      const latencyMs = Math.round(performance.now() - start);
-      const choice = response.choices[0];
-
-      return {
-        id: nanoid(),
-        provider: "zai",
-        model: request.model,
-        content: choice?.message?.content || "",
-        usage: {
-          inputTokens: response.usage?.prompt_tokens || 0,
-          outputTokens: response.usage?.completion_tokens || 0,
-        },
-        latencyMs,
-      };
-    },
-  };
+  });
 }

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -12,6 +12,7 @@ import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
+import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createJudge } from "./routing/judge.js";
 
 interface RouterContext {
@@ -45,6 +46,9 @@ export function createRouter(ctx: RouterContext) {
 
   // Mount token management routes (admin — no auth required)
   app.route("/v1/admin/tokens", createTokenRoutes(ctx.db));
+
+  // Mount custom provider CRUD routes (admin)
+  app.route("/v1/admin/providers", createProviderCrudRoutes(ctx.db));
 
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", (c) => {

--- a/packages/gateway/src/routes/providers.ts
+++ b/packages/gateway/src/routes/providers.ts
@@ -1,0 +1,205 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { customProviders, modelRegistry } from "@provara/db";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { discoverModels } from "../providers/openai-compatible.js";
+import { getDecryptedKeys } from "./api-keys.js";
+
+export function createProviderCrudRoutes(db: Db) {
+  const app = new Hono();
+
+  // List custom providers
+  app.get("/", (c) => {
+    const providers = db.select().from(customProviders).all();
+    return c.json({
+      providers: providers.map((p) => ({
+        ...p,
+        models: JSON.parse(p.models),
+      })),
+    });
+  });
+
+  // Get a custom provider
+  app.get("/:id", (c) => {
+    const { id } = c.req.param();
+    const provider = db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    if (!provider) {
+      return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
+    }
+    return c.json({ provider: { ...provider, models: JSON.parse(provider.models) } });
+  });
+
+  // Create a custom provider
+  app.post("/", async (c) => {
+    const body = await c.req.json<{
+      name: string;
+      baseURL: string;
+      apiKeyRef?: string;
+      models?: string[];
+      discover?: boolean;
+    }>();
+
+    if (!body.name || !body.baseURL) {
+      return c.json(
+        { error: { message: "name and baseURL are required", type: "validation_error" } },
+        400
+      );
+    }
+
+    // Check for duplicate name
+    const existing = db.select().from(customProviders).where(eq(customProviders.name, body.name)).get();
+    if (existing) {
+      return c.json(
+        { error: { message: `Provider "${body.name}" already exists`, type: "validation_error" } },
+        409
+      );
+    }
+
+    let models = body.models || [];
+
+    // Auto-discover models if requested
+    if (body.discover) {
+      let apiKey = "";
+      if (body.apiKeyRef) {
+        const keys = getDecryptedKeys(db);
+        apiKey = keys[body.apiKeyRef] || "";
+      }
+      if (apiKey) {
+        const discovered = await discoverModels(body.baseURL, apiKey);
+        if (discovered.length > 0) {
+          models = [...new Set([...models, ...discovered])];
+        }
+      }
+    }
+
+    const id = nanoid();
+    db.insert(customProviders)
+      .values({
+        id,
+        name: body.name,
+        baseURL: body.baseURL,
+        apiKeyRef: body.apiKeyRef || null,
+        models: JSON.stringify(models),
+      })
+      .run();
+
+    // Add models to registry
+    for (const model of models) {
+      const existingModel = db
+        .select()
+        .from(modelRegistry)
+        .where(eq(modelRegistry.model, model))
+        .get();
+      if (!existingModel) {
+        db.insert(modelRegistry)
+          .values({
+            id: nanoid(),
+            provider: body.name,
+            model,
+            source: body.discover ? "discovered" : "custom",
+          })
+          .run();
+      }
+    }
+
+    return c.json(
+      { provider: { id, name: body.name, baseURL: body.baseURL, models, apiKeyRef: body.apiKeyRef } },
+      201
+    );
+  });
+
+  // Update a custom provider
+  app.patch("/:id", async (c) => {
+    const { id } = c.req.param();
+    const body = await c.req.json<{
+      name?: string;
+      baseURL?: string;
+      apiKeyRef?: string | null;
+      models?: string[];
+      enabled?: boolean;
+    }>();
+
+    const provider = db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    if (!provider) {
+      return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (body.name !== undefined) updates.name = body.name;
+    if (body.baseURL !== undefined) updates.baseURL = body.baseURL;
+    if (body.apiKeyRef !== undefined) updates.apiKeyRef = body.apiKeyRef;
+    if (body.models !== undefined) updates.models = JSON.stringify(body.models);
+    if (body.enabled !== undefined) updates.enabled = body.enabled;
+
+    if (Object.keys(updates).length > 0) {
+      db.update(customProviders).set(updates).where(eq(customProviders.id, id)).run();
+    }
+
+    const updated = db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    return c.json({ provider: { ...updated!, models: JSON.parse(updated!.models) } });
+  });
+
+  // Delete a custom provider
+  app.delete("/:id", (c) => {
+    const { id } = c.req.param();
+    const provider = db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    if (!provider) {
+      return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
+    }
+
+    db.delete(customProviders).where(eq(customProviders.id, id)).run();
+    return c.json({ deleted: true });
+  });
+
+  // Discover models for a provider
+  app.post("/:id/discover", async (c) => {
+    const { id } = c.req.param();
+    const provider = db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    if (!provider) {
+      return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
+    }
+
+    let apiKey = "";
+    if (provider.apiKeyRef) {
+      const keys = getDecryptedKeys(db);
+      apiKey = keys[provider.apiKeyRef] || "";
+    }
+
+    if (!apiKey) {
+      return c.json({ error: { message: "No API key configured for this provider", type: "configuration_error" } }, 400);
+    }
+
+    const discovered = await discoverModels(provider.baseURL, apiKey);
+    const existingModels: string[] = JSON.parse(provider.models);
+    const merged = [...new Set([...existingModels, ...discovered])];
+
+    db.update(customProviders)
+      .set({ models: JSON.stringify(merged) })
+      .where(eq(customProviders.id, id))
+      .run();
+
+    // Add new models to registry
+    for (const model of discovered) {
+      const existingModel = db.select().from(modelRegistry).where(eq(modelRegistry.model, model)).get();
+      if (!existingModel) {
+        db.insert(modelRegistry)
+          .values({
+            id: nanoid(),
+            provider: provider.name,
+            model,
+            source: "discovered",
+          })
+          .run();
+      }
+    }
+
+    return c.json({
+      discovered: discovered.length,
+      total: merged.length,
+      models: merged,
+    });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

- Generic OpenAI-compatible adapter factory — new providers are config objects, not files
- Refactored Mistral/xAI/Z.ai/Ollama to use it (40 LOC each → ~8 LOC each)
- `custom_providers` and `model_registry` DB tables for dynamic provider management
- Auto-discovery of models via `GET /models` on OpenAI-compatible providers
- Provider CRUD API at `/v1/admin/providers` with discover endpoint
- Dashboard at `/dashboard/providers` with presets for Together AI, Groq, Fireworks, Perplexity, Deepseek, OpenRouter
- Adding a new provider = name + baseURL + API key in the dashboard. No code. No deploy.

Closes #7

---
Authored-by: claude/opus-4.6 (claude-code)
Last-code-by: claude/opus-4.6 (claude-code)
*Captain's log entry created by [shiplog](https://github.com/devallibus/shiplog)*
