### PR TITLE
feat(#13): role-based access control

### DIFF
--- a/packages/gateway/src/auth/admin.ts
+++ b/packages/gateway/src/auth/admin.ts
@@ -3,9 +3,20 @@ import type { Db } from "@provara/db";
 import { getMode } from "../config.js";
 import { getSessionFromCookie, validateSession } from "./session.js";
 
+// Store authenticated user on request for downstream use
+const userMap = new WeakMap<Request, { id: string; tenantId: string; role: string }>();
+
+export function getAuthUser(req: Request) {
+  return userMap.get(req) || null;
+}
+
+/**
+ * Admin middleware for dashboard routes.
+ * - self_hosted: checks X-Admin-Key header
+ * - multi_tenant: checks session cookie, attaches user to request
+ */
 export function createAdminMiddleware(db?: Db) {
   return async (c: Context, next: Next) => {
-    // In multi_tenant mode, use session auth
     if (getMode() === "multi_tenant" && db) {
       const sessionId = getSessionFromCookie(c);
       if (!sessionId) {
@@ -21,6 +32,11 @@ export function createAdminMiddleware(db?: Db) {
           401
         );
       }
+      userMap.set(c.req.raw, {
+        id: result.user.id,
+        tenantId: result.user.tenantId,
+        role: result.user.role,
+      });
       return next();
     }
 
@@ -39,5 +55,41 @@ export function createAdminMiddleware(db?: Db) {
     }
 
     return next();
+  };
+}
+
+/**
+ * Role middleware — restricts access to users with the required role.
+ * Must run after createAdminMiddleware (which attaches the user).
+ * In self_hosted mode, this is a no-op.
+ */
+export function requireRole(role: "owner" | "member") {
+  return async (c: Context, next: Next) => {
+    if (getMode() !== "multi_tenant") {
+      return next();
+    }
+
+    const user = getAuthUser(c.req.raw);
+    if (!user) {
+      return c.json(
+        { error: { message: "Authentication required.", type: "auth_error" } },
+        401
+      );
+    }
+
+    // Owner has access to everything
+    if (user.role === "owner") {
+      return next();
+    }
+
+    // Member can only access member-level routes
+    if (role === "member") {
+      return next();
+    }
+
+    return c.json(
+      { error: { message: "Insufficient permissions. Owner access required.", type: "auth_error" } },
+      403
+    );
   };
 }

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -10,12 +10,13 @@ import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
-import { createAdminMiddleware } from "./auth/admin.js";
+import { createAdminMiddleware, requireRole } from "./auth/admin.js";
 import { createTenantMiddleware } from "./auth/tenant.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
+import { createTeamRoutes } from "./routes/team.js";
 import { createJudge } from "./routing/judge.js";
 import { getCached, putCache, cacheStats } from "./cache/index.js";
 import { getMode } from "./config.js";
@@ -55,6 +56,10 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/providers/*", adminAuth);
   app.use("/v1/cache/*", adminAuth);
 
+  // Role-based access — owner-only routes (after adminAuth attaches user)
+  app.use("/v1/admin/*", requireRole("owner"));
+  app.use("/v1/api-keys/*", requireRole("owner"));
+
   // Tenant middleware — enforces tenant context in multi_tenant mode
   app.use("/v1/*", createTenantMiddleware(ctx.db));
 
@@ -70,11 +75,14 @@ export async function createRouter(ctx: RouterContext) {
   // Mount feedback routes
   app.route("/v1/feedback", createFeedbackRoutes(ctx.db));
 
-  // Mount token management routes (admin — no auth required)
+  // Mount token management routes (owner only)
   app.route("/v1/admin/tokens", createTokenRoutes(ctx.db));
 
-  // Mount custom provider CRUD routes (admin)
+  // Mount custom provider CRUD routes (owner only)
   app.route("/v1/admin/providers", createProviderCrudRoutes(ctx.db));
+
+  // Mount team management routes (owner only, multi_tenant mode)
+  app.route("/v1/admin/team", createTeamRoutes(ctx.db));
 
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", async (c) => {

--- a/packages/gateway/src/routes/team.ts
+++ b/packages/gateway/src/routes/team.ts
@@ -1,0 +1,90 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { users, sessions } from "@provara/db";
+import { eq, and } from "drizzle-orm";
+import { getAuthUser } from "../auth/admin.js";
+
+export function createTeamRoutes(db: Db) {
+  const app = new Hono();
+
+  // List team members (same tenant)
+  app.get("/", async (c) => {
+    const authUser = getAuthUser(c.req.raw);
+    if (!authUser) return c.json({ members: [] });
+
+    const members = await db
+      .select({
+        id: users.id,
+        email: users.email,
+        name: users.name,
+        avatarUrl: users.avatarUrl,
+        role: users.role,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(eq(users.tenantId, authUser.tenantId))
+      .all();
+
+    return c.json({ members });
+  });
+
+  // Update a member's role (owner only)
+  app.patch("/:id", async (c) => {
+    const authUser = getAuthUser(c.req.raw);
+    if (!authUser || authUser.role !== "owner") {
+      return c.json({ error: { message: "Owner access required", type: "auth_error" } }, 403);
+    }
+
+    const targetId = c.req.param("id");
+    if (targetId === authUser.id) {
+      return c.json({ error: { message: "Cannot change your own role", type: "validation_error" } }, 400);
+    }
+
+    const body = await c.req.json<{ role: string }>();
+    if (body.role !== "owner" && body.role !== "member") {
+      return c.json({ error: { message: "Role must be 'owner' or 'member'", type: "validation_error" } }, 400);
+    }
+
+    const target = await db.select().from(users).where(
+      and(eq(users.id, targetId), eq(users.tenantId, authUser.tenantId))
+    ).get();
+
+    if (!target) {
+      return c.json({ error: { message: "Member not found", type: "not_found" } }, 404);
+    }
+
+    await db.update(users).set({ role: body.role as "owner" | "member" }).where(eq(users.id, targetId)).run();
+
+    const updated = await db.select().from(users).where(eq(users.id, targetId)).get();
+    return c.json({ member: updated });
+  });
+
+  // Remove a member (owner only)
+  app.delete("/:id", async (c) => {
+    const authUser = getAuthUser(c.req.raw);
+    if (!authUser || authUser.role !== "owner") {
+      return c.json({ error: { message: "Owner access required", type: "auth_error" } }, 403);
+    }
+
+    const targetId = c.req.param("id");
+    if (targetId === authUser.id) {
+      return c.json({ error: { message: "Cannot remove yourself", type: "validation_error" } }, 400);
+    }
+
+    const target = await db.select().from(users).where(
+      and(eq(users.id, targetId), eq(users.tenantId, authUser.tenantId))
+    ).get();
+
+    if (!target) {
+      return c.json({ error: { message: "Member not found", type: "not_found" } }, 404);
+    }
+
+    // Delete their sessions first
+    await db.delete(sessions).where(eq(sessions.userId, targetId)).run();
+    await db.delete(users).where(eq(users.id, targetId)).run();
+
+    return c.json({ deleted: true });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

- Add `requireRole()` middleware enforcing owner/member access in multi-tenant mode
- Owner-only: `/v1/admin/*` (tokens, providers, team), `/v1/api-keys`
- Member-accessible: `/v1/analytics`, `/v1/ab-tests`, `/v1/feedback`, `/v1/providers` (read), `/v1/cache`
- Team management endpoints: `GET /v1/admin/team`, `PATCH /v1/admin/team/:id`, `DELETE /v1/admin/team/:id`
- Self-hosted mode completely unaffected

## Test plan

- [ ] Self-hosted: role middleware is no-op, all routes work as before
- [ ] Multi-tenant owner: full access to all routes including admin
- [ ] Multi-tenant member: can access analytics, ab-tests, feedback; blocked from admin/api-keys with 403
- [ ] Owner can list team members, change roles, remove members
- [ ] Owner cannot change own role or remove self

Addresses #13 (completes T7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)