### PR TITLE
feat(#12): model stats API and catalog page

### DIFF
--- a/apps/web/src/app/models/page.tsx
+++ b/apps/web/src/app/models/page.tsx
@@ -1,15 +1,241 @@
 "use client";
 
+import { useEffect, useState, useMemo } from "react";
 import { PublicNav } from "../../components/public-nav";
+import { gatewayClientFetch } from "../../lib/gateway-client";
+
+interface ModelInfo {
+  provider: string;
+  model: string;
+  pricing: { inputPer1M: number; outputPer1M: number } | null;
+  stats: {
+    requestCount: number;
+    avgLatency: number;
+    avgInputTokens: number;
+    avgOutputTokens: number;
+  };
+  totalCost: number;
+  quality: { avgScore: number; feedbackCount: number } | null;
+}
+
+function formatPrice(price: number): string {
+  if (price === 0) return "Free";
+  if (price < 0.01) return `$${price.toFixed(4)}`;
+  return `$${price.toFixed(2)}`;
+}
+
+function formatLatency(ms: number): string {
+  if (ms === 0) return "--";
+  return `${ms}ms`;
+}
+
+const PROVIDER_COLORS: Record<string, string> = {
+  openai: "bg-emerald-900/40 text-emerald-300 border-emerald-800/50",
+  anthropic: "bg-orange-900/40 text-orange-300 border-orange-800/50",
+  google: "bg-blue-900/40 text-blue-300 border-blue-800/50",
+  mistral: "bg-purple-900/40 text-purple-300 border-purple-800/50",
+  xai: "bg-cyan-900/40 text-cyan-300 border-cyan-800/50",
+  zai: "bg-pink-900/40 text-pink-300 border-pink-800/50",
+  ollama: "bg-zinc-800 text-zinc-300 border-zinc-700",
+};
+
+type SortKey = "model" | "provider" | "inputPrice" | "outputPrice" | "latency" | "requests";
 
 export default function ModelsPage() {
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [providerFilter, setProviderFilter] = useState("");
+  const [sortBy, setSortBy] = useState<SortKey>("requests");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+
+  useEffect(() => {
+    gatewayClientFetch<{ models: ModelInfo[] }>("/v1/models/stats")
+      .then((data) => setModels(data.models || []))
+      .catch((err) => console.error("Failed to fetch models:", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const providers = useMemo(
+    () => [...new Set(models.map((m) => m.provider))].sort(),
+    [models]
+  );
+
+  const filtered = useMemo(() => {
+    let result = models;
+
+    if (search) {
+      const q = search.toLowerCase();
+      result = result.filter(
+        (m) => m.model.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q)
+      );
+    }
+
+    if (providerFilter) {
+      result = result.filter((m) => m.provider === providerFilter);
+    }
+
+    result = [...result].sort((a, b) => {
+      let cmp = 0;
+      switch (sortBy) {
+        case "model":
+          cmp = a.model.localeCompare(b.model);
+          break;
+        case "provider":
+          cmp = a.provider.localeCompare(b.provider);
+          break;
+        case "inputPrice":
+          cmp = (a.pricing?.inputPer1M || 0) - (b.pricing?.inputPer1M || 0);
+          break;
+        case "outputPrice":
+          cmp = (a.pricing?.outputPer1M || 0) - (b.pricing?.outputPer1M || 0);
+          break;
+        case "latency":
+          cmp = a.stats.avgLatency - b.stats.avgLatency;
+          break;
+        case "requests":
+          cmp = a.stats.requestCount - b.stats.requestCount;
+          break;
+      }
+      return sortDir === "desc" ? -cmp : cmp;
+    });
+
+    return result;
+  }, [models, search, providerFilter, sortBy, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortBy === key) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortBy(key);
+      setSortDir(key === "model" || key === "provider" ? "asc" : "desc");
+    }
+  }
+
+  function SortHeader({ label, sortKey }: { label: string; sortKey: SortKey }) {
+    const active = sortBy === sortKey;
+    return (
+      <button
+        onClick={() => handleSort(sortKey)}
+        className={`inline-flex items-center gap-1 hover:text-zinc-200 transition-colors ${active ? "text-zinc-200" : ""}`}
+      >
+        {label}
+        {active && <span className="text-blue-400">{sortDir === "asc" ? "\u25B2" : "\u25BC"}</span>}
+      </button>
+    );
+  }
+
   return (
     <>
       <PublicNav />
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <h1 className="text-3xl font-bold mb-4">Models</h1>
-        <p className="text-zinc-400">
-          Model catalog coming soon. Browse all available models across providers with pricing and performance data.
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">Models</h1>
+          <p className="text-zinc-400">
+            Browse all available models across providers. Pricing, latency, and usage stats.
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div className="flex gap-4 mb-6">
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search models..."
+            className="flex-1 bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 text-sm text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500"
+          />
+          <select
+            value={providerFilter}
+            onChange={(e) => setProviderFilter(e.target.value)}
+            className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 text-sm text-zinc-300 focus:outline-none focus:border-blue-500"
+          >
+            <option value="">All Providers</option>
+            {providers.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {loading ? (
+          <p className="text-zinc-400 py-8">Loading models...</p>
+        ) : filtered.length === 0 ? (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-12 text-center">
+            <p className="text-zinc-400">No models found.</p>
+          </div>
+        ) : (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-zinc-400 text-left">
+                  <th className="px-4 py-3"><SortHeader label="Model" sortKey="model" /></th>
+                  <th className="px-4 py-3"><SortHeader label="Provider" sortKey="provider" /></th>
+                  <th className="px-4 py-3 text-right"><SortHeader label="Input / 1M" sortKey="inputPrice" /></th>
+                  <th className="px-4 py-3 text-right"><SortHeader label="Output / 1M" sortKey="outputPrice" /></th>
+                  <th className="px-4 py-3 text-right"><SortHeader label="Avg Latency" sortKey="latency" /></th>
+                  <th className="px-4 py-3 text-right"><SortHeader label="Requests" sortKey="requests" /></th>
+                  <th className="px-4 py-3 text-right">Quality</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((m) => (
+                  <tr
+                    key={`${m.provider}/${m.model}`}
+                    className="border-b border-zinc-800/50 hover:bg-zinc-800/30 transition-colors"
+                  >
+                    <td className="px-4 py-3">
+                      <span className="font-mono text-xs text-zinc-200">{m.model}</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`px-2 py-0.5 rounded text-xs font-medium border ${
+                          PROVIDER_COLORS[m.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"
+                        }`}
+                      >
+                        {m.provider}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-400">
+                      {m.pricing ? formatPrice(m.pricing.inputPer1M) : "--"}
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-400">
+                      {m.pricing ? formatPrice(m.pricing.outputPer1M) : "--"}
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-400">
+                      {formatLatency(m.stats.avgLatency)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-zinc-400">
+                      {m.stats.requestCount > 0 ? m.stats.requestCount.toLocaleString() : "--"}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {m.quality ? (
+                        <span
+                          className={`font-medium ${
+                            m.quality.avgScore >= 4
+                              ? "text-emerald-400"
+                              : m.quality.avgScore >= 3
+                              ? "text-yellow-400"
+                              : "text-red-400"
+                          }`}
+                        >
+                          {m.quality.avgScore.toFixed(1)}/5
+                        </span>
+                      ) : (
+                        <span className="text-zinc-600">--</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <p className="text-xs text-zinc-600 mt-4">
+          {filtered.length} model{filtered.length !== 1 ? "s" : ""} available
+          {providerFilter ? ` from ${providerFilter}` : ""}
         </p>
       </div>
     </>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -58,24 +58,6 @@ const features = [
   },
 ];
 
-const steps = [
-  {
-    number: "1",
-    title: "Sign up or self-host",
-    description: "Create an account or deploy Provara on your own infrastructure with Docker.",
-  },
-  {
-    number: "2",
-    title: "Add your API keys",
-    description: "Connect OpenAI, Anthropic, Google, Mistral, xAI, or any OpenAI-compatible provider.",
-  },
-  {
-    number: "3",
-    title: "Route requests",
-    description: "Point your app at Provara. It works as a drop-in replacement for the OpenAI SDK.",
-  },
-];
-
 const providers = ["OpenAI", "Anthropic", "Google", "Mistral", "xAI", "Ollama", "Groq", "Together AI"];
 
 export default function Home() {
@@ -164,16 +146,58 @@ export default function Home() {
               <h2 className="text-3xl font-bold">Get started in minutes</h2>
               <p className="mt-4 text-zinc-400">Three steps to intelligent LLM routing.</p>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-              {steps.map((step) => (
-                <div key={step.number} className="text-center">
-                  <div className="w-12 h-12 rounded-full bg-blue-600 text-white text-lg font-bold flex items-center justify-center mx-auto mb-4">
-                    {step.number}
-                  </div>
-                  <h3 className="text-lg font-semibold mb-2">{step.title}</h3>
-                  <p className="text-sm text-zinc-400">{step.description}</p>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-0 relative">
+              {/* Connector lines (desktop only) */}
+              <div className="hidden md:block absolute top-10 left-1/6 right-1/6 h-px bg-gradient-to-r from-blue-600/0 via-blue-600/40 to-blue-600/0" />
+
+              {/* Step 1 */}
+              <div className="text-center px-6 relative">
+                <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-blue-600 to-blue-700 text-white flex items-center justify-center mx-auto mb-6 shadow-lg shadow-blue-600/20">
+                  <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+                  </svg>
                 </div>
-              ))}
+                <h3 className="text-lg font-semibold mb-2">Sign up or self-host</h3>
+                <p className="text-sm text-zinc-400 mb-4">Create an account with Google or GitHub, or deploy with Docker.</p>
+                <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3 text-left inline-block">
+                  <code className="text-xs text-zinc-400">
+                    <span className="text-zinc-600">$</span> docker compose up -d
+                  </code>
+                </div>
+              </div>
+
+              {/* Step 2 */}
+              <div className="text-center px-6 relative mt-8 md:mt-0">
+                <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-violet-600 to-violet-700 text-white flex items-center justify-center mx-auto mb-6 shadow-lg shadow-violet-600/20">
+                  <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold mb-2">Add your API keys</h3>
+                <p className="text-sm text-zinc-400 mb-4">Connect any provider through the dashboard. Keys are encrypted at rest.</p>
+                <div className="flex justify-center gap-2 flex-wrap">
+                  {["OpenAI", "Anthropic", "Google", "Mistral"].map((p) => (
+                    <span key={p} className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-zinc-400">{p}</span>
+                  ))}
+                  <span className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-zinc-500">+4 more</span>
+                </div>
+              </div>
+
+              {/* Step 3 */}
+              <div className="text-center px-6 relative mt-8 md:mt-0">
+                <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-emerald-600 to-emerald-700 text-white flex items-center justify-center mx-auto mb-6 shadow-lg shadow-emerald-600/20">
+                  <svg className="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold mb-2">Route requests</h3>
+                <p className="text-sm text-zinc-400 mb-4">Point your app at Provara. Drop-in OpenAI SDK compatible.</p>
+                <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-3 text-left inline-block">
+                  <code className="text-xs text-zinc-400">
+                    baseURL: <span className="text-emerald-400">&quot;https://provara/v1&quot;</span>
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
         </section>

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -17,6 +17,7 @@ import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import { createTeamRoutes } from "./routes/team.js";
+import { createModelRoutes } from "./routes/models.js";
 import { createJudge } from "./routing/judge.js";
 import { getCached, putCache, cacheStats } from "./cache/index.js";
 import { getMode } from "./config.js";
@@ -83,6 +84,9 @@ export async function createRouter(ctx: RouterContext) {
 
   // Mount team management routes (owner only, multi_tenant mode)
   app.route("/v1/admin/team", createTeamRoutes(ctx.db));
+
+  // Mount model stats routes (public — no admin auth needed)
+  app.route("/v1/models", createModelRoutes({ db: ctx.db, registry: ctx.registry }));
 
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", async (c) => {

--- a/packages/gateway/src/routes/models.ts
+++ b/packages/gateway/src/routes/models.ts
@@ -1,0 +1,118 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { requests, costLogs, feedback } from "@provara/db";
+import { sql, eq, and } from "drizzle-orm";
+import { getPricing } from "../cost/pricing.js";
+import type { ProviderRegistry } from "../providers/index.js";
+
+interface ModelStatsContext {
+  db: Db;
+  registry: ProviderRegistry;
+}
+
+export function createModelRoutes(ctx: ModelStatsContext) {
+  const app = new Hono();
+
+  // List all models with stats and pricing
+  app.get("/stats", async (c) => {
+    // Get all registered models from providers
+    const registeredModels: { provider: string; model: string }[] = [];
+    for (const provider of ctx.registry.list()) {
+      for (const model of provider.models) {
+        registeredModels.push({ provider: provider.name, model });
+      }
+    }
+
+    // Get aggregated stats from requests
+    const statsRows = await ctx.db
+      .select({
+        provider: requests.provider,
+        model: requests.model,
+        requestCount: sql<number>`count(*)`,
+        avgLatency: sql<number>`avg(${requests.latencyMs})`,
+        avgInputTokens: sql<number>`avg(${requests.inputTokens})`,
+        avgOutputTokens: sql<number>`avg(${requests.outputTokens})`,
+      })
+      .from(requests)
+      .groupBy(requests.provider, requests.model)
+      .all();
+
+    // Get cost data
+    const costRows = await ctx.db
+      .select({
+        model: costLogs.model,
+        totalCost: sql<number>`sum(${costLogs.cost})`,
+      })
+      .from(costLogs)
+      .groupBy(costLogs.model)
+      .all();
+
+    // Get quality scores
+    const qualityRows = await ctx.db
+      .select({
+        provider: requests.provider,
+        model: requests.model,
+        avgScore: sql<number>`avg(${feedback.score})`,
+        feedbackCount: sql<number>`count(${feedback.id})`,
+      })
+      .from(feedback)
+      .innerJoin(requests, eq(feedback.requestId, requests.id))
+      .groupBy(requests.provider, requests.model)
+      .all();
+
+    // Build lookup maps
+    const statsMap = new Map(statsRows.map((r) => [`${r.provider}/${r.model}`, r]));
+    const costMap = new Map(costRows.map((r) => [r.model, r]));
+    const qualityMap = new Map(qualityRows.map((r) => [`${r.provider}/${r.model}`, r]));
+
+    // Merge everything
+    const models = registeredModels.map(({ provider, model }) => {
+      const key = `${provider}/${model}`;
+      const stats = statsMap.get(key);
+      const cost = costMap.get(model);
+      const quality = qualityMap.get(key);
+      const pricing = getPricing(model);
+
+      return {
+        provider,
+        model,
+        pricing: pricing
+          ? { inputPer1M: pricing[0], outputPer1M: pricing[1] }
+          : null,
+        stats: stats
+          ? {
+              requestCount: stats.requestCount,
+              avgLatency: Math.round(stats.avgLatency || 0),
+              avgInputTokens: Math.round(stats.avgInputTokens || 0),
+              avgOutputTokens: Math.round(stats.avgOutputTokens || 0),
+            }
+          : { requestCount: 0, avgLatency: 0, avgInputTokens: 0, avgOutputTokens: 0 },
+        totalCost: cost?.totalCost || 0,
+        quality: quality
+          ? { avgScore: quality.avgScore, feedbackCount: quality.feedbackCount }
+          : null,
+      };
+    });
+
+    return c.json({ models });
+  });
+
+  // Full pricing table
+  app.get("/pricing", (c) => {
+    const registeredModels: { provider: string; model: string; inputPer1M: number; outputPer1M: number }[] = [];
+    for (const provider of ctx.registry.list()) {
+      for (const model of provider.models) {
+        const pricing = getPricing(model);
+        registeredModels.push({
+          provider: provider.name,
+          model,
+          inputPer1M: pricing ? pricing[0] : 0,
+          outputPer1M: pricing ? pricing[1] : 0,
+        });
+      }
+    }
+    return c.json({ models: registeredModels });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

- `GET /v1/models/stats` — all models with request count, avg latency, pricing, quality scores (public, no auth)
- `GET /v1/models/pricing` — full pricing table from registered providers
- `/models` page with searchable, sortable table of all models
- Filter by provider, sort by any column, color-coded provider badges
- Quality scores from feedback data displayed inline

## Test plan

- [ ] `/v1/models/stats` returns all registered models with pricing and stats
- [ ] `/v1/models/pricing` returns pricing for all models
- [ ] `/models` page renders with search and provider filter
- [ ] Sorting works for all columns
- [ ] Models with no requests show dashes for stats

Addresses #12 (completes T3, T4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)