### PR TITLE
fix: enforce tenant-scoped queries on all dashboard routes

### DIFF
--- a/packages/gateway/src/routes/ab-tests.ts
+++ b/packages/gateway/src/routes/ab-tests.ts
@@ -3,21 +3,24 @@ import type { Db } from "@provara/db";
 import { abTests, abTestVariants, requests, feedback, costLogs } from "@provara/db";
 import { eq, and, sql, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createAbTestRoutes(db: Db) {
   const app = new Hono();
 
   // List all A/B tests
   app.get("/", async (c) => {
-    const tests = await db.select().from(abTests).all();
+    const tenantId = getTenantId(c.req.raw);
+    const tests = await db.select().from(abTests).where(tenantId ? eq(abTests.tenantId, tenantId) : undefined).all();
     return c.json({ tests });
   });
 
   // Get a single A/B test with variants and results
   app.get("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const test = await db.select().from(abTests).where(eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
@@ -74,9 +77,14 @@ export function createAbTestRoutes(db: Db) {
 
   // List individual requests for an A/B test (with prompt, response, feedback)
   app.get("/:id/requests", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
     const limit = Math.min(parseInt(c.req.query("limit") || "20"), 100);
     const offset = parseInt(c.req.query("offset") || "0");
+
+    const abTestWhere = tenantId
+      ? and(eq(requests.abTestId, id), eq(requests.tenantId, tenantId))
+      : eq(requests.abTestId, id);
 
     const rows = await db
       .select({
@@ -97,7 +105,7 @@ export function createAbTestRoutes(db: Db) {
       .from(requests)
       .leftJoin(costLogs, eq(requests.id, costLogs.requestId))
       .leftJoin(feedback, eq(requests.id, feedback.requestId))
-      .where(eq(requests.abTestId, id))
+      .where(abTestWhere)
       .orderBy(desc(requests.createdAt))
       .limit(limit)
       .offset(offset)
@@ -106,7 +114,7 @@ export function createAbTestRoutes(db: Db) {
     const total = await db
       .select({ count: sql<number>`count(*)` })
       .from(requests)
-      .where(eq(requests.abTestId, id))
+      .where(abTestWhere)
       .get();
 
     return c.json({ requests: rows, total: total?.count || 0, limit, offset });
@@ -114,6 +122,7 @@ export function createAbTestRoutes(db: Db) {
 
   // Create a new A/B test
   app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const body = await c.req.json<{
       name: string;
       description?: string;
@@ -135,6 +144,7 @@ export function createAbTestRoutes(db: Db) {
         id: testId,
         name: body.name,
         description: body.description || null,
+        tenantId,
       })
       .run();
 
@@ -164,6 +174,7 @@ export function createAbTestRoutes(db: Db) {
 
   // Update A/B test status
   app.patch("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
     const body = await c.req.json<{
       status?: "active" | "paused" | "completed";
@@ -171,7 +182,7 @@ export function createAbTestRoutes(db: Db) {
       description?: string;
     }>();
 
-    const test = await db.select().from(abTests).where(eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
@@ -182,24 +193,25 @@ export function createAbTestRoutes(db: Db) {
     if (body.description !== undefined) updates.description = body.description;
 
     if (Object.keys(updates).length > 0) {
-      await db.update(abTests).set(updates).where(eq(abTests.id, id)).run();
+      await db.update(abTests).set(updates).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).run();
     }
 
-    const updated = await db.select().from(abTests).where(eq(abTests.id, id)).get();
+    const updated = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
     return c.json({ test: updated });
   });
 
   // Delete an A/B test
   app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const test = await db.select().from(abTests).where(eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
 
     await db.delete(abTestVariants).where(eq(abTestVariants.abTestId, id)).run();
-    await db.delete(abTests).where(eq(abTests.id, id)).run();
+    await db.delete(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).run();
 
     return c.json({ deleted: true });
   });

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -1,13 +1,15 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { requests, costLogs, abTests, feedback } from "@provara/db";
-import { desc, sql, eq } from "drizzle-orm";
+import { desc, sql, eq, and } from "drizzle-orm";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createAnalyticsRoutes(db: Db) {
   const app = new Hono();
 
   // List recent requests with pagination
   app.get("/requests", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const limit = Math.min(parseInt(c.req.query("limit") || "50"), 200);
     const offset = parseInt(c.req.query("offset") || "0");
     const provider = c.req.query("provider");
@@ -34,6 +36,7 @@ export function createAnalyticsRoutes(db: Db) {
       })
       .from(requests)
       .leftJoin(costLogs, eq(requests.id, costLogs.requestId))
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .orderBy(desc(requests.createdAt))
       .limit(limit)
       .offset(offset)
@@ -45,13 +48,14 @@ export function createAnalyticsRoutes(db: Db) {
         return true;
       });
 
-    const total = await db.select({ count: sql<number>`count(*)` }).from(requests).get();
+    const total = await db.select({ count: sql<number>`count(*)` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
 
     return c.json({ requests: rows, total: total?.count || 0, limit, offset });
   });
 
   // Cost summary by provider
   app.get("/costs/by-provider", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         provider: costLogs.provider,
@@ -61,6 +65,7 @@ export function createAnalyticsRoutes(db: Db) {
         requestCount: sql<number>`count(*)`,
       })
       .from(costLogs)
+      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
       .groupBy(costLogs.provider)
       .all();
 
@@ -69,6 +74,7 @@ export function createAnalyticsRoutes(db: Db) {
 
   // Cost summary by model
   app.get("/costs/by-model", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         provider: costLogs.provider,
@@ -80,6 +86,7 @@ export function createAnalyticsRoutes(db: Db) {
         avgCost: sql<number>`avg(${costLogs.cost})`,
       })
       .from(costLogs)
+      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
       .groupBy(costLogs.provider, costLogs.model)
       .all();
 
@@ -88,6 +95,7 @@ export function createAnalyticsRoutes(db: Db) {
 
   // Routing stats — traffic by task type × complexity
   app.get("/routing/stats", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         taskType: requests.taskType,
@@ -99,6 +107,7 @@ export function createAnalyticsRoutes(db: Db) {
         avgLatency: sql<number>`avg(${requests.latencyMs})`,
       })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .groupBy(requests.taskType, requests.complexity, requests.routedBy, requests.provider, requests.model)
       .all();
 
@@ -107,12 +116,14 @@ export function createAnalyticsRoutes(db: Db) {
 
   // Routing distribution — how many requests per task type
   app.get("/routing/distribution", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const byTaskType = await db
       .select({
         taskType: requests.taskType,
         count: sql<number>`count(*)`,
       })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .groupBy(requests.taskType)
       .all();
 
@@ -122,6 +133,7 @@ export function createAnalyticsRoutes(db: Db) {
         count: sql<number>`count(*)`,
       })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .groupBy(requests.complexity)
       .all();
 
@@ -130,13 +142,15 @@ export function createAnalyticsRoutes(db: Db) {
 
   // Overview stats
   app.get("/overview", async (c) => {
-    const totalRequests = await db.select({ count: sql<number>`count(*)` }).from(requests).get();
-    const totalCost = await db.select({ total: sql<number>`sum(${costLogs.cost})` }).from(costLogs).get();
-    const avgLatency = await db.select({ avg: sql<number>`avg(${requests.latencyMs})` }).from(requests).get();
+    const tenantId = getTenantId(c.req.raw);
+    const totalRequests = await db.select({ count: sql<number>`count(*)` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
+    const totalCost = await db.select({ total: sql<number>`sum(${costLogs.cost})` }).from(costLogs).where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined).get();
+    const avgLatency = await db.select({ avg: sql<number>`avg(${requests.latencyMs})` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
 
     const providerCount = await db
       .select({ count: sql<number>`count(distinct ${requests.provider})` })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .get();
 
     return c.json({
@@ -149,6 +163,7 @@ export function createAnalyticsRoutes(db: Db) {
 
   // Pipeline stage stats — per-stage request counts and latency
   app.get("/pipeline", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     // Requests by routing method
     const byRoutedBy = await db
       .select({
@@ -157,6 +172,7 @@ export function createAnalyticsRoutes(db: Db) {
         avgLatency: sql<number>`avg(${requests.latencyMs})`,
       })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .groupBy(requests.routedBy)
       .all();
 
@@ -164,25 +180,28 @@ export function createAnalyticsRoutes(db: Db) {
     const activeAbTests = await db
       .select({ count: sql<number>`count(*)` })
       .from(abTests)
-      .where(eq(abTests.status, "active"))
+      .where(tenantId ? and(eq(abTests.status, "active"), eq(abTests.tenantId, tenantId)) : eq(abTests.status, "active"))
       .get();
 
     // Total feedback count
     const feedbackCount = await db
       .select({ count: sql<number>`count(*)` })
       .from(feedback)
+      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
       .get();
 
     // Provider count
     const providerCount = await db
       .select({ count: sql<number>`count(distinct ${requests.provider})` })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .get();
 
     // Total requests
     const totalRequests = await db
       .select({ count: sql<number>`count(*)` })
       .from(requests)
+      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
       .get();
 
     const routedByMap: Record<string, { count: number; avgLatency: number }> = {};

--- a/packages/gateway/src/routes/api-keys.ts
+++ b/packages/gateway/src/routes/api-keys.ts
@@ -1,9 +1,10 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { apiKeys } from "@provara/db";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { encrypt, decrypt, maskKey, hasMasterKey } from "../crypto/index.js";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createApiKeyRoutes(db: Db) {
   const app = new Hono();
@@ -19,7 +20,8 @@ export function createApiKeyRoutes(db: Db) {
       return c.json({ error: { message: "PROVARA_MASTER_KEY not set", type: "configuration_error" } }, 503);
     }
 
-    const keys = await db.select().from(apiKeys).all();
+    const tenantId = getTenantId(c.req.raw);
+    const keys = await db.select().from(apiKeys).where(tenantId ? eq(apiKeys.tenantId, tenantId) : undefined).all();
     return c.json({
       keys: keys.map((k) => {
         let maskedValue: string;
@@ -51,6 +53,7 @@ export function createApiKeyRoutes(db: Db) {
       return c.json({ error: { message: "PROVARA_MASTER_KEY not set", type: "configuration_error" } }, 503);
     }
 
+    const tenantId = getTenantId(c.req.raw);
     const body = await c.req.json<{
       name: string;
       provider: string;
@@ -70,7 +73,7 @@ export function createApiKeyRoutes(db: Db) {
     const existing = await db
       .select()
       .from(apiKeys)
-      .where(eq(apiKeys.name, body.name))
+      .where(tenantId ? and(eq(apiKeys.name, body.name), eq(apiKeys.tenantId, tenantId)) : eq(apiKeys.name, body.name))
       .get();
 
     if (existing) {
@@ -105,6 +108,7 @@ export function createApiKeyRoutes(db: Db) {
         encryptedValue: encrypted,
         iv,
         authTag,
+        tenantId,
       })
       .run();
 
@@ -124,14 +128,16 @@ export function createApiKeyRoutes(db: Db) {
 
   // Delete an API key
   app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const key = await db.select().from(apiKeys).where(eq(apiKeys.id, id)).get();
+    const whereClause = tenantId ? and(eq(apiKeys.id, id), eq(apiKeys.tenantId, tenantId)) : eq(apiKeys.id, id);
+    const key = await db.select().from(apiKeys).where(whereClause).get();
     if (!key) {
       return c.json({ error: { message: "API key not found", type: "not_found" } }, 404);
     }
 
-    await db.delete(apiKeys).where(eq(apiKeys.id, id)).run();
+    await db.delete(apiKeys).where(whereClause).run();
     return c.json({ deleted: true });
   });
 

--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -1,15 +1,17 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { feedback, requests } from "@provara/db";
-import { eq, desc, sql } from "drizzle-orm";
+import { eq, desc, sql, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getTokenInfo } from "../auth/middleware.js";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createFeedbackRoutes(db: Db) {
   const app = new Hono();
 
   // Submit feedback for a request
   app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const body = await c.req.json<{
       requestId: string;
       score: number;
@@ -30,8 +32,8 @@ export function createFeedbackRoutes(db: Db) {
       );
     }
 
-    // Verify request exists
-    const request = await db.select().from(requests).where(eq(requests.id, body.requestId)).get();
+    // Verify request exists (scoped to tenant)
+    const request = await db.select().from(requests).where(tenantId ? and(eq(requests.id, body.requestId), eq(requests.tenantId, tenantId)) : eq(requests.id, body.requestId)).get();
     if (!request) {
       return c.json(
         { error: { message: "Request not found", type: "not_found" } },
@@ -46,7 +48,7 @@ export function createFeedbackRoutes(db: Db) {
       .values({
         id,
         requestId: body.requestId,
-        tenantId: tokenInfo?.tenant || null,
+        tenantId: tenantId || tokenInfo?.tenant || null,
         score: body.score,
         comment: body.comment || null,
         source: "user",
@@ -58,6 +60,7 @@ export function createFeedbackRoutes(db: Db) {
 
   // List recent feedback
   app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const limit = Math.min(parseInt(c.req.query("limit") || "50"), 200);
     const rows = await db
       .select({
@@ -75,6 +78,7 @@ export function createFeedbackRoutes(db: Db) {
       })
       .from(feedback)
       .leftJoin(requests, eq(feedback.requestId, requests.id))
+      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
       .orderBy(desc(feedback.createdAt))
       .limit(limit)
       .all();
@@ -84,6 +88,7 @@ export function createFeedbackRoutes(db: Db) {
 
   // Quality scores per model per routing cell
   app.get("/quality/by-cell", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         provider: requests.provider,
@@ -95,6 +100,7 @@ export function createFeedbackRoutes(db: Db) {
       })
       .from(feedback)
       .innerJoin(requests, eq(feedback.requestId, requests.id))
+      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
       .groupBy(requests.provider, requests.model, requests.taskType, requests.complexity)
       .all();
 
@@ -103,6 +109,7 @@ export function createFeedbackRoutes(db: Db) {
 
   // Quality summary per model
   app.get("/quality/by-model", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         provider: requests.provider,
@@ -114,6 +121,7 @@ export function createFeedbackRoutes(db: Db) {
       })
       .from(feedback)
       .innerJoin(requests, eq(feedback.requestId, requests.id))
+      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
       .groupBy(requests.provider, requests.model)
       .all();
 

--- a/packages/gateway/src/routes/providers.ts
+++ b/packages/gateway/src/routes/providers.ts
@@ -1,17 +1,19 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { customProviders, modelRegistry } from "@provara/db";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { discoverModels, validateCompatibility } from "../providers/openai-compatible.js";
 import { getDecryptedKeys } from "./api-keys.js";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createProviderCrudRoutes(db: Db) {
   const app = new Hono();
 
   // List custom providers
   app.get("/", async (c) => {
-    const providers = await db.select().from(customProviders).all();
+    const tenantId = getTenantId(c.req.raw);
+    const providers = await db.select().from(customProviders).where(tenantId ? eq(customProviders.tenantId, tenantId) : undefined).all();
     return c.json({
       providers: providers.map((p) => ({
         ...p,
@@ -22,8 +24,9 @@ export function createProviderCrudRoutes(db: Db) {
 
   // Get a custom provider
   app.get("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const provider = await db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    const provider = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id)).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }
@@ -32,6 +35,7 @@ export function createProviderCrudRoutes(db: Db) {
 
   // Create a custom provider
   app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const body = await c.req.json<{
       name: string;
       baseURL: string;
@@ -47,8 +51,8 @@ export function createProviderCrudRoutes(db: Db) {
       );
     }
 
-    // Check for duplicate name
-    const existing = await db.select().from(customProviders).where(eq(customProviders.name, body.name)).get();
+    // Check for duplicate name (scoped to tenant)
+    const existing = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.name, body.name), eq(customProviders.tenantId, tenantId)) : eq(customProviders.name, body.name)).get();
     if (existing) {
       return c.json(
         { error: { message: `Provider "${body.name}" already exists`, type: "validation_error" } },
@@ -92,6 +96,7 @@ export function createProviderCrudRoutes(db: Db) {
         baseURL: body.baseURL,
         apiKeyRef: body.apiKeyRef || null,
         models: JSON.stringify(models),
+        tenantId,
       })
       .run();
 
@@ -122,6 +127,7 @@ export function createProviderCrudRoutes(db: Db) {
 
   // Update a custom provider
   app.patch("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
     const body = await c.req.json<{
       name?: string;
@@ -131,7 +137,8 @@ export function createProviderCrudRoutes(db: Db) {
       enabled?: boolean;
     }>();
 
-    const provider = await db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    const whereClause = tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id);
+    const provider = await db.select().from(customProviders).where(whereClause).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }
@@ -144,29 +151,32 @@ export function createProviderCrudRoutes(db: Db) {
     if (body.enabled !== undefined) updates.enabled = body.enabled;
 
     if (Object.keys(updates).length > 0) {
-      await db.update(customProviders).set(updates).where(eq(customProviders.id, id)).run();
+      await db.update(customProviders).set(updates).where(whereClause).run();
     }
 
-    const updated = await db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    const updated = await db.select().from(customProviders).where(whereClause).get();
     return c.json({ provider: { ...updated!, models: JSON.parse(updated!.models) } });
   });
 
   // Delete a custom provider
   app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const provider = await db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    const whereClause = tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id);
+    const provider = await db.select().from(customProviders).where(whereClause).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }
 
-    await db.delete(customProviders).where(eq(customProviders.id, id)).run();
+    await db.delete(customProviders).where(whereClause).run();
     return c.json({ deleted: true });
   });
 
   // Discover models for a provider
   app.post("/:id/discover", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const provider = await db.select().from(customProviders).where(eq(customProviders.id, id)).get();
+    const provider = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id)).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }

--- a/packages/gateway/src/routes/tokens.ts
+++ b/packages/gateway/src/routes/tokens.ts
@@ -4,13 +4,15 @@ import { apiTokens, costLogs, requests } from "@provara/db";
 import { eq, and, gte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { generateToken, hashToken, maskToken } from "../auth/tokens.js";
+import { getTenantId } from "../auth/tenant.js";
 
 export function createTokenRoutes(db: Db) {
   const app = new Hono();
 
   // List all tokens (masked)
   app.get("/", async (c) => {
-    const tokens = await db.select().from(apiTokens).all();
+    const tenantId = getTenantId(c.req.raw);
+    const tokens = await db.select().from(apiTokens).where(tenantId ? eq(apiTokens.tenant, tenantId) : undefined).all();
     return c.json({
       tokens: tokens.map((t) => ({
         id: t.id,
@@ -28,8 +30,9 @@ export function createTokenRoutes(db: Db) {
 
   // Get token detail with usage stats
   app.get("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const token = await db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    const token = await db.select().from(apiTokens).where(tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id)).get();
 
     if (!token) {
       return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
@@ -152,6 +155,7 @@ export function createTokenRoutes(db: Db) {
 
   // Update a token
   app.patch("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
     const body = await c.req.json<{
       name?: string;
@@ -161,7 +165,8 @@ export function createTokenRoutes(db: Db) {
       expiresAt?: string | null;
     }>();
 
-    const token = await db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    const tokenWhere = tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id);
+    const token = await db.select().from(apiTokens).where(tokenWhere).get();
     if (!token) {
       return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
     }
@@ -176,28 +181,31 @@ export function createTokenRoutes(db: Db) {
     }
 
     if (Object.keys(updates).length > 0) {
-      await db.update(apiTokens).set(updates).where(eq(apiTokens.id, id)).run();
+      await db.update(apiTokens).set(updates).where(tokenWhere).run();
     }
 
-    const updated = await db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    const updated = await db.select().from(apiTokens).where(tokenWhere).get();
     return c.json({ token: updated });
   });
 
   // Delete (revoke) a token
   app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const token = await db.select().from(apiTokens).where(eq(apiTokens.id, id)).get();
+    const tokenWhere = tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id);
+    const token = await db.select().from(apiTokens).where(tokenWhere).get();
 
     if (!token) {
       return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
     }
 
-    await db.delete(apiTokens).where(eq(apiTokens.id, id)).run();
+    await db.delete(apiTokens).where(tokenWhere).run();
     return c.json({ deleted: true });
   });
 
   // Per-tenant usage summary
   app.get("/usage/by-tenant", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
     const rows = await db
       .select({
         tenant: costLogs.tenantId,
@@ -205,6 +213,7 @@ export function createTokenRoutes(db: Db) {
         requestCount: sql<number>`count(*)`,
       })
       .from(costLogs)
+      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
       .groupBy(costLogs.tenantId)
       .all();
 


### PR DESCRIPTION
## Summary

All dashboard route handlers now filter by tenant_id in multi_tenant mode. Previously, queries returned all data regardless of which user was logged in.

Routes updated: analytics, ab-tests, api-keys, feedback, providers, tokens (6 files, 106 insertions).

## Test plan

- [ ] Multi-tenant: user A's data not visible when logged in as user B
- [ ] Self-hosted: no behavior change (tenantId=null, no filtering)
- [ ] Create operations set tenantId on new records

🤖 Generated with [Claude Code](https://claude.com/claude-code)