### PR TITLE
feat(#28): configurable guardrails — PII detection, content filtering

### DIFF
--- a/apps/web/src/app/dashboard/guardrails/page.tsx
+++ b/apps/web/src/app/dashboard/guardrails/page.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { gatewayFetchRaw } from "../../../lib/gateway-client";
+
+interface GuardrailRule {
+  id: string;
+  name: string;
+  type: string;
+  target: string;
+  action: string;
+  pattern: string | null;
+  enabled: boolean;
+  builtIn: boolean;
+}
+
+interface GuardrailLog {
+  id: string;
+  ruleName: string;
+  target: string;
+  action: string;
+  matchedContent: string | null;
+  createdAt: string;
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  block: "bg-red-900/40 text-red-300 border-red-800/50",
+  redact: "bg-amber-900/40 text-amber-300 border-amber-800/50",
+  flag: "bg-blue-900/40 text-blue-300 border-blue-800/50",
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  pii: "PII Detection",
+  content: "Content Policy",
+  regex: "Custom Regex",
+  token_limit: "Token Limit",
+};
+
+function AddRuleForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [pattern, setPattern] = useState("");
+  const [type, setType] = useState("regex");
+  const [target, setTarget] = useState("both");
+  const [action, setAction] = useState("block");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError("");
+
+    try {
+      const res = await gatewayFetchRaw("/v1/admin/guardrails", {
+        method: "POST",
+        body: JSON.stringify({ name, pattern, type, target, action }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error?.message || "Failed to create rule");
+        return;
+      }
+      setOpen(false);
+      setName("");
+      setPattern("");
+      onCreated();
+    } catch {
+      setError("Failed to connect to gateway");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium transition-colors"
+      >
+        Add Custom Rule
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg font-semibold">Add Custom Rule</h3>
+        <button type="button" onClick={() => setOpen(false)} className="text-zinc-400 hover:text-zinc-200">Cancel</button>
+      </div>
+
+      {error && <div className="bg-red-900/30 border border-red-800 rounded px-3 py-2 text-sm text-red-300">{error}</div>}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+            placeholder="e.g. Block profanity"
+          />
+        </div>
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Type</label>
+          <select value={type} onChange={(e) => setType(e.target.value)} className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500">
+            <option value="regex">Custom Regex</option>
+            <option value="pii">PII Detection</option>
+            <option value="content">Content Policy</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm text-zinc-400 mb-1">Regex Pattern</label>
+        <input
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          required
+          className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm font-mono focus:outline-none focus:border-blue-500"
+          placeholder="e.g. \\b(badword1|badword2)\\b"
+        />
+        <p className="text-xs text-zinc-500 mt-1">JavaScript-compatible regex. Tested against message content.</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Apply To</label>
+          <select value={target} onChange={(e) => setTarget(e.target.value)} className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500">
+            <option value="both">Input + Output</option>
+            <option value="input">Input only</option>
+            <option value="output">Output only</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm text-zinc-400 mb-1">Action</label>
+          <select value={action} onChange={(e) => setAction(e.target.value)} className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500">
+            <option value="block">Block request</option>
+            <option value="redact">Redact matches</option>
+            <option value="flag">Flag (log only)</option>
+          </select>
+        </div>
+      </div>
+
+      <button type="submit" disabled={submitting} className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-lg text-sm font-medium transition-colors">
+        {submitting ? "Creating..." : "Create Rule"}
+      </button>
+    </form>
+  );
+}
+
+export default function GuardrailsPage() {
+  const [rules, setRules] = useState<GuardrailRule[]>([]);
+  const [logs, setLogs] = useState<GuardrailLog[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function fetchData() {
+    try {
+      const [rulesRes, logsRes] = await Promise.all([
+        gatewayFetchRaw("/v1/admin/guardrails"),
+        gatewayFetchRaw("/v1/admin/guardrails/logs"),
+      ]);
+      const rulesData = await rulesRes.json();
+      const logsData = await logsRes.json();
+      setRules(rulesData.rules || []);
+      setLogs(logsData.logs || []);
+    } catch (err) {
+      console.error("Failed to fetch guardrails:", err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleRule(id: string, enabled: boolean) {
+    await gatewayFetchRaw(`/v1/admin/guardrails/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ enabled }),
+    });
+    fetchData();
+  }
+
+  async function deleteRule(id: string) {
+    if (!confirm("Delete this rule?")) return;
+    await gatewayFetchRaw(`/v1/admin/guardrails/${id}`, { method: "DELETE" });
+    fetchData();
+  }
+
+  useEffect(() => { fetchData(); }, []);
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-zinc-400">Loading guardrails...</p>
+      </div>
+    );
+  }
+
+  const builtInRules = rules.filter((r) => r.builtIn);
+  const customRules = rules.filter((r) => !r.builtIn);
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      <div className="flex justify-between items-center">
+        <div>
+          <h1 className="text-2xl font-bold">Guardrails</h1>
+          <p className="text-sm text-zinc-400 mt-1">Input/output filtering for PII detection, content policies, and custom patterns.</p>
+        </div>
+        <AddRuleForm onCreated={fetchData} />
+      </div>
+
+      {/* Built-in Rules */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Built-in Rules</h2>
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-zinc-800 text-zinc-400 text-left">
+                <th className="px-4 py-3">Rule</th>
+                <th className="px-4 py-3">Type</th>
+                <th className="px-4 py-3">Target</th>
+                <th className="px-4 py-3">Action</th>
+                <th className="px-4 py-3 text-right">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {builtInRules.map((rule) => (
+                <tr key={rule.id} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
+                  <td className="px-4 py-3">
+                    <p className="font-medium">{rule.name}</p>
+                    {rule.pattern && <p className="text-xs text-zinc-500 font-mono mt-0.5 truncate max-w-xs">{rule.pattern}</p>}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-zinc-400">{TYPE_LABELS[rule.type] || rule.type}</td>
+                  <td className="px-4 py-3 text-xs text-zinc-400 capitalize">{rule.target}</td>
+                  <td className="px-4 py-3">
+                    <span className={`text-xs px-2 py-0.5 rounded border ${ACTION_COLORS[rule.action]}`}>
+                      {rule.action}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => toggleRule(rule.id, !rule.enabled)}
+                      className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
+                        rule.enabled
+                          ? "bg-emerald-900/40 text-emerald-300 hover:bg-emerald-900/60"
+                          : "bg-zinc-800 text-zinc-500 hover:bg-zinc-700"
+                      }`}
+                    >
+                      {rule.enabled ? "Enabled" : "Disabled"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {builtInRules.length === 0 && (
+                <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">No built-in rules loaded yet. They will appear on first request.</td></tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* Custom Rules */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Custom Rules</h2>
+        {customRules.length === 0 ? (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-8 text-center">
+            <p className="text-zinc-400">No custom rules yet. Add one to start filtering content.</p>
+          </div>
+        ) : (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-zinc-400 text-left">
+                  <th className="px-4 py-3">Rule</th>
+                  <th className="px-4 py-3">Target</th>
+                  <th className="px-4 py-3">Action</th>
+                  <th className="px-4 py-3 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {customRules.map((rule) => (
+                  <tr key={rule.id} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
+                    <td className="px-4 py-3">
+                      <p className="font-medium">{rule.name}</p>
+                      <p className="text-xs text-zinc-500 font-mono mt-0.5">{rule.pattern}</p>
+                    </td>
+                    <td className="px-4 py-3 text-xs text-zinc-400 capitalize">{rule.target}</td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-2 py-0.5 rounded border ${ACTION_COLORS[rule.action]}`}>{rule.action}</span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="flex gap-2 justify-end">
+                        <button
+                          onClick={() => toggleRule(rule.id, !rule.enabled)}
+                          className="text-xs text-zinc-400 hover:text-zinc-200"
+                        >
+                          {rule.enabled ? "Disable" : "Enable"}
+                        </button>
+                        <button
+                          onClick={() => deleteRule(rule.id)}
+                          className="text-xs text-red-400 hover:text-red-300"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Recent Violations */}
+      <section>
+        <h2 className="text-lg font-semibold mb-3">Recent Violations</h2>
+        {logs.length === 0 ? (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-8 text-center">
+            <p className="text-zinc-400">No violations recorded yet.</p>
+          </div>
+        ) : (
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-800 text-zinc-400 text-left">
+                  <th className="px-4 py-3">Rule</th>
+                  <th className="px-4 py-3">Target</th>
+                  <th className="px-4 py-3">Action</th>
+                  <th className="px-4 py-3">Matched</th>
+                  <th className="px-4 py-3 text-right">Time</th>
+                </tr>
+              </thead>
+              <tbody>
+                {logs.map((log) => (
+                  <tr key={log.id} className="border-b border-zinc-800/50">
+                    <td className="px-4 py-3 font-medium">{log.ruleName}</td>
+                    <td className="px-4 py-3 text-xs text-zinc-400 capitalize">{log.target}</td>
+                    <td className="px-4 py-3">
+                      <span className={`text-xs px-2 py-0.5 rounded border ${ACTION_COLORS[log.action]}`}>{log.action}</span>
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-zinc-400 max-w-xs truncate">{log.matchedContent || "—"}</td>
+                    <td className="px-4 py-3 text-right text-xs text-zinc-500">
+                      {new Date(log.createdAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-nav.tsx
+++ b/apps/web/src/components/dashboard-nav.tsx
@@ -11,6 +11,7 @@ const links = [
   { href: "/dashboard/routing", label: "Routing" },
   { href: "/dashboard/quality", label: "Quality" },
   { href: "/dashboard/ab-tests", label: "A/B Tests" },
+  { href: "/dashboard/guardrails", label: "Guardrails" },
   { href: "/dashboard/tokens", label: "Tokens" },
   { href: "/dashboard/api-keys", label: "API Keys" },
 ];

--- a/packages/db/drizzle/0008_burly_captain_midlands.sql
+++ b/packages/db/drizzle/0008_burly_captain_midlands.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `guardrail_logs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`request_id` text,
+	`tenant_id` text,
+	`rule_id` text,
+	`rule_name` text NOT NULL,
+	`target` text NOT NULL,
+	`action` text NOT NULL,
+	`matched_content` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`rule_id`) REFERENCES `guardrail_rules`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `guardrail_rules` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`name` text NOT NULL,
+	`type` text NOT NULL,
+	`target` text DEFAULT 'both' NOT NULL,
+	`action` text DEFAULT 'block' NOT NULL,
+	`pattern` text,
+	`enabled` integer DEFAULT true NOT NULL,
+	`built_in` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0008_snapshot.json
+++ b/packages/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1122 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cc101daa-b986-4ca4-89df-d2b6d0a7c646",
+  "prevId": "42e99bc5-2ac4-4175-bc7c-5aee98e5de36",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776260177850,
       "tag": "0007_burly_the_hand",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1776263135747,
+      "tag": "0008_burly_captain_midlands",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -160,6 +160,35 @@ export const feedback = sqliteTable("feedback", {
     .$defaultFn(() => new Date()),
 });
 
+export const guardrailRules = sqliteTable("guardrail_rules", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  name: text("name").notNull(),
+  type: text("type", { enum: ["pii", "content", "regex", "token_limit"] }).notNull(),
+  target: text("target", { enum: ["input", "output", "both"] }).notNull().default("both"),
+  action: text("action", { enum: ["block", "redact", "flag"] }).notNull().default("block"),
+  pattern: text("pattern"), // regex pattern or JSON config
+  enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+  builtIn: integer("built_in", { mode: "boolean" }).notNull().default(false),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const guardrailLogs = sqliteTable("guardrail_logs", {
+  id: text("id").primaryKey(),
+  requestId: text("request_id"),
+  tenantId: text("tenant_id"),
+  ruleId: text("rule_id").references(() => guardrailRules.id),
+  ruleName: text("rule_name").notNull(),
+  target: text("target", { enum: ["input", "output"] }).notNull(),
+  action: text("action", { enum: ["block", "redact", "flag"] }).notNull(),
+  matchedContent: text("matched_content"), // truncated snippet of what was matched
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const costLogs = sqliteTable("cost_logs", {
   id: text("id").primaryKey(),
   requestId: text("request_id").references(() => requests.id),

--- a/packages/gateway/src/guardrails/engine.ts
+++ b/packages/gateway/src/guardrails/engine.ts
@@ -1,0 +1,160 @@
+import type { Db } from "@provara/db";
+import { guardrailRules, guardrailLogs } from "@provara/db";
+import { eq, and } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { BUILTIN_RULES } from "./patterns.js";
+
+export interface GuardrailRule {
+  id: string;
+  name: string;
+  type: string;
+  target: "input" | "output" | "both";
+  action: "block" | "redact" | "flag";
+  pattern: string | null;
+  enabled: boolean;
+  builtIn: boolean;
+}
+
+export interface GuardrailResult {
+  passed: boolean;
+  action: "block" | "redact" | "flag" | "pass";
+  content: string; // original or redacted content
+  violations: {
+    ruleId: string;
+    ruleName: string;
+    action: string;
+    matchedSnippet: string;
+  }[];
+}
+
+// Initialize built-in rules if they don't exist
+export async function ensureBuiltInRules(db: Db, tenantId: string | null) {
+  for (const rule of BUILTIN_RULES) {
+    const existing = await db
+      .select()
+      .from(guardrailRules)
+      .where(
+        and(
+          eq(guardrailRules.name, rule.name),
+          eq(guardrailRules.builtIn, true),
+          tenantId ? eq(guardrailRules.tenantId, tenantId) : undefined
+        )
+      )
+      .get();
+
+    if (!existing) {
+      await db.insert(guardrailRules).values({
+        id: nanoid(),
+        tenantId,
+        name: rule.name,
+        type: rule.type,
+        target: rule.target,
+        action: rule.action,
+        pattern: rule.pattern,
+        enabled: false, // Disabled by default — user opts in
+        builtIn: true,
+      }).run();
+    }
+  }
+}
+
+// Load active rules for a tenant
+export async function loadRules(db: Db, tenantId: string | null): Promise<GuardrailRule[]> {
+  const rows = await db
+    .select()
+    .from(guardrailRules)
+    .where(
+      and(
+        eq(guardrailRules.enabled, true),
+        tenantId ? eq(guardrailRules.tenantId, tenantId) : undefined
+      )
+    )
+    .all();
+
+  return rows as GuardrailRule[];
+}
+
+// Check content against rules
+export function checkContent(
+  content: string,
+  rules: GuardrailRule[],
+  target: "input" | "output"
+): GuardrailResult {
+  const violations: GuardrailResult["violations"] = [];
+  let processedContent = content;
+  let shouldBlock = false;
+
+  for (const rule of rules) {
+    // Skip rules that don't apply to this target
+    if (rule.target !== "both" && rule.target !== target) continue;
+    if (!rule.pattern) continue;
+
+    try {
+      const regex = new RegExp(rule.pattern, "gi");
+      const matches = content.match(regex);
+
+      if (matches && matches.length > 0) {
+        const snippet = matches[0].slice(0, 50);
+
+        violations.push({
+          ruleId: rule.id,
+          ruleName: rule.name,
+          action: rule.action,
+          matchedSnippet: snippet,
+        });
+
+        if (rule.action === "block") {
+          shouldBlock = true;
+        } else if (rule.action === "redact") {
+          processedContent = processedContent.replace(regex, "[REDACTED]");
+        }
+        // "flag" action: just log, don't modify content
+      }
+    } catch {
+      // Invalid regex — skip this rule
+    }
+  }
+
+  if (shouldBlock) {
+    return {
+      passed: false,
+      action: "block",
+      content,
+      violations,
+    };
+  }
+
+  if (violations.length > 0) {
+    const hasRedact = violations.some((v) => v.action === "redact");
+    return {
+      passed: true,
+      action: hasRedact ? "redact" : "flag",
+      content: processedContent,
+      violations,
+    };
+  }
+
+  return { passed: true, action: "pass", content, violations: [] };
+}
+
+// Log guardrail violations
+export async function logViolations(
+  db: Db,
+  requestId: string | null,
+  tenantId: string | null,
+  target: "input" | "output",
+  violations: GuardrailResult["violations"]
+) {
+  for (const v of violations) {
+    await db.insert(guardrailLogs).values({
+      id: nanoid(),
+      requestId,
+      tenantId,
+      ruleId: v.ruleId,
+      ruleName: v.ruleName,
+      target,
+      action: v.action as "block" | "redact" | "flag",
+      matchedContent: v.matchedSnippet,
+    }).run();
+  }
+}

--- a/packages/gateway/src/guardrails/patterns.ts
+++ b/packages/gateway/src/guardrails/patterns.ts
@@ -1,0 +1,52 @@
+// Built-in PII detection patterns
+export const BUILTIN_RULES = [
+  {
+    name: "SSN (US Social Security Number)",
+    type: "pii" as const,
+    pattern: "\\b\\d{3}-\\d{2}-\\d{4}\\b",
+    target: "both" as const,
+    action: "redact" as const,
+  },
+  {
+    name: "Credit Card Number",
+    type: "pii" as const,
+    pattern: "\\b(?:\\d{4}[- ]?){3}\\d{4}\\b",
+    target: "both" as const,
+    action: "redact" as const,
+  },
+  {
+    name: "Email Address",
+    type: "pii" as const,
+    pattern: "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b",
+    target: "both" as const,
+    action: "flag" as const,
+  },
+  {
+    name: "Phone Number (US)",
+    type: "pii" as const,
+    pattern: "\\b(?:\\+?1[- ]?)?\\(?\\d{3}\\)?[- ]?\\d{3}[- ]?\\d{4}\\b",
+    target: "both" as const,
+    action: "flag" as const,
+  },
+  {
+    name: "IP Address",
+    type: "pii" as const,
+    pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b",
+    target: "both" as const,
+    action: "flag" as const,
+  },
+  {
+    name: "AWS Access Key",
+    type: "content" as const,
+    pattern: "\\bAKIA[0-9A-Z]{16}\\b",
+    target: "input" as const,
+    action: "block" as const,
+  },
+  {
+    name: "Generic API Key/Secret",
+    type: "content" as const,
+    pattern: "(?i)(?:api[_-]?key|api[_-]?secret|access[_-]?token|secret[_-]?key)\\s*[:=]\\s*['\"]?[A-Za-z0-9_\\-]{20,}",
+    target: "input" as const,
+    action: "block" as const,
+  },
+];

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -18,6 +18,9 @@ import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import { createTeamRoutes } from "./routes/team.js";
 import { createModelRoutes } from "./routes/models.js";
+import { createGuardrailRoutes } from "./routes/guardrails.js";
+import { loadRules, checkContent, logViolations } from "./guardrails/engine.js";
+import { getTenantId } from "./auth/tenant.js";
 import { createJudge } from "./routing/judge.js";
 import { getCached, putCache, cacheStats } from "./cache/index.js";
 import { getMode } from "./config.js";
@@ -88,6 +91,9 @@ export async function createRouter(ctx: RouterContext) {
   // Mount model stats routes (public — no admin auth needed)
   app.route("/v1/models", createModelRoutes({ db: ctx.db, registry: ctx.registry }));
 
+  // Mount guardrail management routes (admin)
+  app.route("/v1/admin/guardrails", createGuardrailRoutes(ctx.db));
+
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", async (c) => {
     await ctx.registry.reload();
@@ -100,6 +106,27 @@ export async function createRouter(ctx: RouterContext) {
     const body = await c.req.json<CompletionRequest & { provider?: string; cache?: boolean }>();
     const { provider: providerName, routing_hint, cache: cacheParam, ...rest } = body;
     const request = rest as CompletionRequest;
+
+    // Input guardrails — check all message content before routing
+    const tenantIdForGuardrails = getTenantId(c.req.raw);
+    const guardrailRulesList = await loadRules(ctx.db, tenantIdForGuardrails);
+    if (guardrailRulesList.length > 0) {
+      const inputText = request.messages.map((m) => m.content).join("\n");
+      const inputCheck = checkContent(inputText, guardrailRulesList, "input");
+
+      if (inputCheck.violations.length > 0) {
+        await logViolations(ctx.db, null, tenantIdForGuardrails, "input", inputCheck.violations);
+      }
+
+      if (!inputCheck.passed) {
+        return c.json({
+          error: {
+            message: `Request blocked by guardrail: ${inputCheck.violations.map((v) => v.ruleName).join(", ")}`,
+            type: "guardrail_error",
+          },
+        }, 400);
+      }
+    }
 
     // Determine if caching is eligible
     const noCache = c.req.header("x-provara-no-cache") === "true" || cacheParam === false;
@@ -390,6 +417,24 @@ export async function createRouter(ctx: RouterContext) {
       responseContent: response.content,
     }).catch(() => {});
 
+    // Output guardrails — check response content before returning
+    let responseContent = response.content;
+    if (guardrailRulesList.length > 0) {
+      const outputCheck = checkContent(responseContent, guardrailRulesList, "output");
+      if (outputCheck.violations.length > 0) {
+        await logViolations(ctx.db, requestId, tenantIdForGuardrails, "output", outputCheck.violations);
+      }
+      if (!outputCheck.passed) {
+        return c.json({
+          error: {
+            message: `Response blocked by guardrail: ${outputCheck.violations.map((v) => v.ruleName).join(", ")}`,
+            type: "guardrail_error",
+          },
+        }, 400);
+      }
+      responseContent = outputCheck.content; // May be redacted
+    }
+
     // Return OpenAI-compatible response format
     return c.json({
       id: `chatcmpl-${response.id}`,
@@ -399,7 +444,7 @@ export async function createRouter(ctx: RouterContext) {
       choices: [
         {
           index: 0,
-          message: { role: "assistant", content: response.content },
+          message: { role: "assistant", content: responseContent },
           finish_reason: "stop",
         },
       ],

--- a/packages/gateway/src/routes/guardrails.ts
+++ b/packages/gateway/src/routes/guardrails.ts
@@ -1,0 +1,127 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { guardrailRules, guardrailLogs } from "@provara/db";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantId } from "../auth/tenant.js";
+import { ensureBuiltInRules } from "../guardrails/engine.js";
+
+export function createGuardrailRoutes(db: Db) {
+  const app = new Hono();
+
+  // List all rules (ensures built-in rules exist)
+  app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    await ensureBuiltInRules(db, tenantId);
+
+    const rules = await db
+      .select()
+      .from(guardrailRules)
+      .where(tenantId ? eq(guardrailRules.tenantId, tenantId) : undefined)
+      .all();
+
+    return c.json({ rules });
+  });
+
+  // Create a custom rule
+  app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{
+      name: string;
+      type: "pii" | "content" | "regex" | "token_limit";
+      target?: "input" | "output" | "both";
+      action?: "block" | "redact" | "flag";
+      pattern: string;
+    }>();
+
+    if (!body.name || !body.pattern) {
+      return c.json({ error: { message: "name and pattern are required", type: "validation_error" } }, 400);
+    }
+
+    // Validate regex
+    try {
+      new RegExp(body.pattern);
+    } catch {
+      return c.json({ error: { message: "Invalid regex pattern", type: "validation_error" } }, 400);
+    }
+
+    const id = nanoid();
+    await db.insert(guardrailRules).values({
+      id,
+      tenantId,
+      name: body.name,
+      type: body.type || "regex",
+      target: body.target || "both",
+      action: body.action || "block",
+      pattern: body.pattern,
+      enabled: true,
+      builtIn: false,
+    }).run();
+
+    const rule = await db.select().from(guardrailRules).where(eq(guardrailRules.id, id)).get();
+    return c.json({ rule }, 201);
+  });
+
+  // Toggle a rule on/off
+  app.patch("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+    const body = await c.req.json<{ enabled?: boolean; action?: string }>();
+
+    const rule = await db.select().from(guardrailRules).where(
+      tenantId ? and(eq(guardrailRules.id, id), eq(guardrailRules.tenantId, tenantId)) : eq(guardrailRules.id, id)
+    ).get();
+
+    if (!rule) {
+      return c.json({ error: { message: "Rule not found", type: "not_found" } }, 404);
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (body.enabled !== undefined) updates.enabled = body.enabled;
+    if (body.action) updates.action = body.action;
+
+    await db.update(guardrailRules).set(updates).where(eq(guardrailRules.id, id)).run();
+
+    const updated = await db.select().from(guardrailRules).where(eq(guardrailRules.id, id)).get();
+    return c.json({ rule: updated });
+  });
+
+  // Delete a custom rule (can't delete built-in)
+  app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+
+    const rule = await db.select().from(guardrailRules).where(
+      tenantId ? and(eq(guardrailRules.id, id), eq(guardrailRules.tenantId, tenantId)) : eq(guardrailRules.id, id)
+    ).get();
+
+    if (!rule) {
+      return c.json({ error: { message: "Rule not found", type: "not_found" } }, 404);
+    }
+
+    if (rule.builtIn) {
+      return c.json({ error: { message: "Cannot delete built-in rules. Disable them instead.", type: "validation_error" } }, 400);
+    }
+
+    await db.delete(guardrailRules).where(eq(guardrailRules.id, id)).run();
+    return c.json({ deleted: true });
+  });
+
+  // View recent guardrail logs
+  app.get("/logs", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const limit = Math.min(parseInt(c.req.query("limit") || "50"), 200);
+
+    const logs = await db
+      .select()
+      .from(guardrailLogs)
+      .where(tenantId ? eq(guardrailLogs.tenantId, tenantId) : undefined)
+      .orderBy(desc(guardrailLogs.createdAt))
+      .limit(limit)
+      .all();
+
+    return c.json({ logs });
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

Input/output guardrails for the gateway with dashboard management.

- **Built-in rules:** SSN, credit card, email, phone, IP, AWS keys, generic API secrets
- **Custom rules:** User-defined regex patterns with configurable target and action
- **Three actions:** Block (return error), Redact (replace with [REDACTED]), Flag (log only)
- **Violation logging:** All matches recorded with timestamps and matched snippets
- **Dashboard page:** Toggle built-in rules, add custom rules, view violation log

Rules are tenant-scoped and disabled by default — users opt in to each rule.

## Test plan

- [ ] Visit /dashboard/guardrails — built-in rules appear
- [ ] Enable "SSN" rule — send a message containing "123-45-6789" — blocked
- [ ] Set SSN action to "redact" — content returns with [REDACTED]
- [ ] Set SSN action to "flag" — content passes, violation logged
- [ ] Add custom regex rule — matches trigger the configured action
- [ ] Delete custom rule — built-in rules can only be disabled, not deleted
- [ ] Violation log shows matched content snippets

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)