### PR TITLE
fix(#36): widen CORS for browser-based API clients

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -37,10 +37,12 @@ export async function createRouter(ctx: RouterContext) {
   const routingEngine = await createRoutingEngine({ registry: ctx.registry, db: ctx.db });
   const judge = createJudge(ctx.registry, ctx.db);
 
-  // Enable CORS for web dashboard (credentials needed for session cookies)
+  // Enable CORS for web dashboard and browser-based API clients
   app.use("/*", cors({
-    origin: process.env.DASHBOARD_URL || "http://localhost:3000",
+    origin: (origin) => origin || "*",
     credentials: true,
+    allowHeaders: ["Content-Type", "Authorization", "X-Admin-Key"],
+    allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
   }));
 


### PR DESCRIPTION
## Summary

- Reflects the requesting `Origin` header instead of restricting CORS to a single `DASHBOARD_URL`, so any browser-based client (web demos, Pathlight collector, SPAs) can reach the gateway
- Adds `allowHeaders` for `Content-Type`, `Authorization`, and `X-Admin-Key` so preflight `OPTIONS` requests succeed
- Adds explicit `allowMethods` covering all route verbs

Closes #36

## Test plan

- [ ] `curl -I -X OPTIONS -H "Origin: https://example.com" http://localhost:4000/v1/chat/completions` returns `Access-Control-Allow-Origin: https://example.com` and `Access-Control-Allow-Headers` including `Authorization`
- [ ] Dashboard still works with session cookies (credentials mode preserved)
- [ ] Browser-based API client can call `/v1/chat/completions` with a Bearer token from a different origin

---

**Last-code-by:** Claude/Opus-4.6 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
