### PR TITLE
fix(#38): derive token tenant from session instead of user input

### DIFF
--- a/apps/web/src/app/dashboard/tokens/page.tsx
+++ b/apps/web/src/app/dashboard/tokens/page.tsx
@@ -35,7 +35,6 @@ interface TenantUsage {
 function CreateTokenForm({ onCreated }: { onCreated: () => void }) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
-  const [tenant, setTenant] = useState("");
   const [rateLimit, setRateLimit] = useState("");
   const [spendLimit, setSpendLimit] = useState("");
   const [spendPeriod, setSpendPeriod] = useState("monthly");
@@ -53,7 +52,6 @@ function CreateTokenForm({ onCreated }: { onCreated: () => void }) {
         method: "POST",
         body: JSON.stringify({
           name,
-          tenant,
           rateLimit: rateLimit ? parseInt(rateLimit) : undefined,
           spendLimit: spendLimit ? parseFloat(spendLimit) : undefined,
           spendPeriod,
@@ -90,7 +88,6 @@ function CreateTokenForm({ onCreated }: { onCreated: () => void }) {
   function handleDone() {
     setCreatedToken(null);
     setName("");
-    setTenant("");
     setRateLimit("");
     setSpendLimit("");
     setOpen(false);
@@ -165,27 +162,15 @@ function CreateTokenForm({ onCreated }: { onCreated: () => void }) {
         </button>
       </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm text-zinc-400 mb-1">Name</label>
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
-            placeholder="e.g. Production App"
-          />
-        </div>
-        <div>
-          <label className="block text-sm text-zinc-400 mb-1">Tenant</label>
-          <input
-            value={tenant}
-            onChange={(e) => setTenant(e.target.value)}
-            required
-            className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
-            placeholder="e.g. my-app"
-          />
-        </div>
+      <div>
+        <label className="block text-sm text-zinc-400 mb-1">Name</label>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
+          placeholder="e.g. Production App"
+        />
       </div>
 
       <div className="grid grid-cols-2 gap-4">

--- a/packages/gateway/src/routes/tokens.ts
+++ b/packages/gateway/src/routes/tokens.ts
@@ -5,6 +5,7 @@ import { eq, and, gte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { generateToken, hashToken, maskToken } from "../auth/tokens.js";
 import { getTenantId } from "../auth/tenant.js";
+import { getAuthUser } from "../auth/admin.js";
 
 export function createTokenRoutes(db: Db) {
   const app = new Hono();
@@ -100,7 +101,6 @@ export function createTokenRoutes(db: Db) {
   app.post("/", async (c) => {
     const body = await c.req.json<{
       name: string;
-      tenant: string;
       rateLimit?: number;
       spendLimit?: number;
       spendPeriod?: "monthly" | "weekly" | "daily";
@@ -109,12 +109,16 @@ export function createTokenRoutes(db: Db) {
       expiresAt?: string;
     }>();
 
-    if (!body.name || !body.tenant) {
+    if (!body.name) {
       return c.json(
-        { error: { message: "name and tenant are required", type: "validation_error" } },
+        { error: { message: "name is required", type: "validation_error" } },
         400
       );
     }
+
+    // Use the authenticated user's tenant ID, fall back to body.tenant for self_hosted mode
+    const authUser = getAuthUser(c.req.raw);
+    const tenant = authUser?.tenantId || getTenantId(c.req.raw) || "default";
 
     const plainToken = generateToken();
     const hashed = hashToken(plainToken);
@@ -124,7 +128,7 @@ export function createTokenRoutes(db: Db) {
       .values({
         id,
         name: body.name,
-        tenant: body.tenant,
+        tenant,
         hashedToken: hashed,
         tokenPrefix: plainToken.slice(0, 9),
         rateLimit: body.rateLimit || null,
@@ -142,7 +146,7 @@ export function createTokenRoutes(db: Db) {
         token: {
           id,
           name: body.name,
-          tenant: body.tenant,
+          tenant,
           tokenPrefix: plainToken.slice(0, 9),
           rateLimit: body.rateLimit || null,
           spendLimit: body.spendLimit || null,


### PR DESCRIPTION
## Summary

Fixes a bug where dashboard analytics (logs, overview, cost tables) showed no data despite requests being logged to the database.

- **Root cause:** Token creation accepted a freeform "Tenant" field. The value entered didn't match the user's actual `tenantId` (auto-generated nanoid at OAuth signup). All analytics queries filter by session tenant, so the data was invisible.
- **Fix:** Derive `tenant` from `getAuthUser().tenantId` on the backend; remove the Tenant input from the frontend form.

## Changes

| File | Change |
|------|--------|
| `packages/gateway/src/routes/tokens.ts` | Import `getAuthUser`, derive tenant from session instead of `body.tenant` |
| `apps/web/src/app/dashboard/tokens/page.tsx` | Remove Tenant input field and state |

## Test plan

- [ ] Create a new API token from the dashboard — no Tenant field should appear
- [ ] Send a request using the new token
- [ ] Verify the request appears on the dashboard and logs pages
- [ ] Verify self-hosted mode (no session) falls back to `getTenantId()` or `"default"`

Closes #38

---

*Authored-by: Claude/Opus-4.6 (Claude Code)*
