### PR TITLE
feat(#42): dynamic model discovery via provider API queries

### DIFF
--- a/apps/web/src/app/dashboard/providers/page.tsx
+++ b/apps/web/src/app/dashboard/providers/page.tsx
@@ -261,6 +261,30 @@ export default function ProvidersPage() {
   const [builtinProviders, setBuiltinProviders] = useState<BuiltinProvider[]>([]);
   const [customProvidersList, setCustomProvidersList] = useState<CustomProvider[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshResult, setRefreshResult] = useState<string | null>(null);
+
+  async function handleRefreshModels() {
+    setRefreshing(true);
+    setRefreshResult(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/providers/refresh-models`, { method: "POST" });
+      if (res.ok) {
+        const data = await res.json();
+        const discovered = (data.results || []).filter((r: { discovered: boolean }) => r.discovered);
+        const totalModels = discovered.reduce((sum: number, r: { models: string[] }) => sum + r.models.length, 0);
+        setRefreshResult(`Discovered ${totalModels} models from ${discovered.length} providers`);
+        await fetchData();
+      } else {
+        setRefreshResult("Failed to refresh models");
+      }
+    } catch {
+      setRefreshResult("Failed to connect to gateway");
+    } finally {
+      setRefreshing(false);
+      setTimeout(() => setRefreshResult(null), 5000);
+    }
+  }
 
   async function fetchData() {
     try {
@@ -295,8 +319,23 @@ export default function ProvidersPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Providers</h1>
-        <AddProviderForm onCreated={fetchData} />
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleRefreshModels}
+            disabled={refreshing}
+            className="px-4 py-2 bg-zinc-800 hover:bg-zinc-700 disabled:opacity-50 border border-zinc-700 rounded-lg text-sm font-medium transition-colors"
+          >
+            {refreshing ? "Refreshing..." : "Refresh Models"}
+          </button>
+          <AddProviderForm onCreated={fetchData} />
+        </div>
       </div>
+
+      {refreshResult && (
+        <div className="bg-zinc-900 border border-zinc-700 rounded-lg px-4 py-2 text-sm text-zinc-300">
+          {refreshResult}
+        </div>
+      )}
 
       {/* Active Providers (built-in) */}
       <section>

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -23,6 +23,19 @@ const registry = await createProviderRegistry({
 });
 const app = await createRouter({ registry, db });
 
+// Discover available models from each provider's API at startup
+registry.refreshModels().then((results) => {
+  const discovered = results.filter((r) => r.discovered);
+  if (discovered.length > 0) {
+    console.log(`Discovered models from ${discovered.length} provider(s):`);
+    for (const r of discovered) {
+      console.log(`  ${r.provider}: ${r.models.length} models`);
+    }
+  }
+}).catch((err) => {
+  console.warn("Model discovery failed (using defaults):", err instanceof Error ? err.message : err);
+});
+
 console.log(`Provara gateway running on http://localhost:${port}`);
 console.log(`Providers: ${registry.list().map((p) => p.name).join(", ")}`);
 

--- a/packages/gateway/src/providers/anthropic.ts
+++ b/packages/gateway/src/providers/anthropic.ts
@@ -7,9 +7,25 @@ export function createAnthropicProvider(apiKey?: string): Provider {
     apiKey: apiKey || process.env.ANTHROPIC_API_KEY,
   });
 
-  return {
+  const provider: Provider = {
     name: "anthropic",
     models: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+
+    async listModels(): Promise<string[]> {
+      try {
+        const response = await client.models.list({ limit: 100 });
+        const chatModels: string[] = [];
+        for (const model of response.data) {
+          chatModels.push(model.id);
+        }
+        if (chatModels.length > 0) {
+          provider.models = chatModels;
+        }
+        return provider.models;
+      } catch {
+        return provider.models;
+      }
+    },
 
     async complete(request: CompletionRequest): Promise<CompletionResponse> {
       const start = performance.now();
@@ -74,4 +90,6 @@ export function createAnthropicProvider(apiKey?: string): Provider {
       };
     },
   };
+
+  return provider;
 }

--- a/packages/gateway/src/providers/google.ts
+++ b/packages/gateway/src/providers/google.ts
@@ -2,12 +2,38 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import type { Provider, CompletionRequest, CompletionResponse, StreamChunk } from "./types.js";
 import { nanoid } from "nanoid";
 
-export function createGoogleProvider(apiKey?: string): Provider {
-  const genAI = new GoogleGenerativeAI(apiKey || process.env.GOOGLE_API_KEY || "");
+const GOOGLE_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
 
-  return {
+export function createGoogleProvider(apiKey?: string): Provider {
+  const key = apiKey || process.env.GOOGLE_API_KEY || "";
+  const genAI = new GoogleGenerativeAI(key);
+
+  const provider: Provider = {
     name: "google",
     models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+
+    async listModels(): Promise<string[]> {
+      try {
+        // Google's JS SDK doesn't expose listModels, so use the REST API directly
+        const res = await fetch(`${GOOGLE_API_BASE}/models?key=${key}&pageSize=100`);
+        if (!res.ok) return provider.models;
+        const data = await res.json() as { models?: { name: string; supportedGenerationMethods?: string[] }[] };
+        const chatModels: string[] = [];
+        for (const m of data.models || []) {
+          // Only include models that support generateContent (chat)
+          if (m.supportedGenerationMethods?.includes("generateContent")) {
+            // Model name is "models/gemini-2.5-pro" — strip the prefix
+            chatModels.push(m.name.replace("models/", ""));
+          }
+        }
+        if (chatModels.length > 0) {
+          provider.models = chatModels;
+        }
+        return provider.models;
+      } catch {
+        return provider.models;
+      }
+    },
 
     async complete(request: CompletionRequest): Promise<CompletionResponse> {
       const start = performance.now();
@@ -77,4 +103,6 @@ export function createGoogleProvider(apiKey?: string): Provider {
       };
     },
   };
+
+  return provider;
 }

--- a/packages/gateway/src/providers/index.ts
+++ b/packages/gateway/src/providers/index.ts
@@ -11,11 +11,18 @@ import { createOpenAICompatibleProvider, type OpenAICompatibleConfig } from "./o
 export type { Provider, CompletionRequest, CompletionResponse, ChatMessage, StreamChunk } from "./types.js";
 export { createOpenAICompatibleProvider, type OpenAICompatibleConfig } from "./openai-compatible.js";
 
+export interface RefreshModelsResult {
+  provider: string;
+  models: string[];
+  discovered: boolean;
+}
+
 export interface ProviderRegistry {
   get(name: string): Provider | undefined;
   getForModel(model: string): Provider | undefined;
   list(): Provider[];
   reload(): void | Promise<void>;
+  refreshModels(): Promise<RefreshModelsResult[]>;
   addCustom(config: OpenAICompatibleConfig): void;
   removeCustom(name: string): void;
 }
@@ -77,6 +84,21 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
 
     reload() {
       load();
+    },
+
+    async refreshModels(): Promise<RefreshModelsResult[]> {
+      const results: RefreshModelsResult[] = [];
+      await Promise.allSettled(
+        providers.map(async (p) => {
+          if (p.listModels) {
+            const models = await p.listModels();
+            results.push({ provider: p.name, models, discovered: true });
+          } else {
+            results.push({ provider: p.name, models: p.models, discovered: false });
+          }
+        })
+      );
+      return results;
     },
 
     addCustom(customConfig: OpenAICompatibleConfig) {

--- a/packages/gateway/src/providers/openai-compatible.ts
+++ b/packages/gateway/src/providers/openai-compatible.ts
@@ -15,9 +15,25 @@ export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): 
     baseURL: config.baseURL,
   });
 
-  return {
+  const provider: Provider = {
     name: config.name,
     models: [...config.models],
+
+    async listModels(): Promise<string[]> {
+      try {
+        const response = await client.models.list();
+        const discovered: string[] = [];
+        for await (const model of response) {
+          discovered.push(model.id);
+        }
+        if (discovered.length > 0) {
+          provider.models = discovered;
+        }
+        return provider.models;
+      } catch {
+        return provider.models;
+      }
+    },
 
     async complete(request: CompletionRequest): Promise<CompletionResponse> {
       const start = performance.now();
@@ -74,6 +90,8 @@ export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): 
       }
     },
   };
+
+  return provider;
 }
 
 // Validate that a provider is OpenAI-compatible by testing the /models endpoint

--- a/packages/gateway/src/providers/openai.ts
+++ b/packages/gateway/src/providers/openai.ts
@@ -7,9 +7,28 @@ export function createOpenAIProvider(apiKey?: string): Provider {
     apiKey: apiKey || process.env.OPENAI_API_KEY,
   });
 
-  return {
+  const provider: Provider = {
     name: "openai",
     models: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "o3", "o4-mini"],
+
+    async listModels(): Promise<string[]> {
+      try {
+        const response = await client.models.list();
+        const chatModels: string[] = [];
+        for await (const model of response) {
+          // Only include chat-capable models, skip embeddings/tts/whisper/dall-e
+          if (model.id.startsWith("gpt-") || model.id.startsWith("o1") || model.id.startsWith("o3") || model.id.startsWith("o4")) {
+            chatModels.push(model.id);
+          }
+        }
+        if (chatModels.length > 0) {
+          provider.models = chatModels;
+        }
+        return provider.models;
+      } catch {
+        return provider.models;
+      }
+    },
 
     async complete(request: CompletionRequest): Promise<CompletionResponse> {
       const start = performance.now();
@@ -64,4 +83,6 @@ export function createOpenAIProvider(apiKey?: string): Provider {
       }
     },
   };
+
+  return provider;
 }

--- a/packages/gateway/src/providers/types.ts
+++ b/packages/gateway/src/providers/types.ts
@@ -38,4 +38,6 @@ export interface Provider {
   models: string[];
   complete(request: CompletionRequest): Promise<CompletionResponse>;
   stream(request: CompletionRequest): AsyncIterable<StreamChunk>;
+  /** Query the provider API for available models. Updates `models` in-place and returns the list. */
+  listModels?(): Promise<string[]>;
 }

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -112,6 +112,12 @@ export async function createRouter(ctx: RouterContext) {
     return c.json({ reloaded: true, providers });
   });
 
+  // Refresh models by querying each provider's API
+  app.post("/v1/providers/refresh-models", async (c) => {
+    const results = await ctx.registry.refreshModels();
+    return c.json({ results });
+  });
+
   // OpenAI-compatible chat completions endpoint
   app.post("/v1/chat/completions", async (c) => {
     const body = await c.req.json<CompletionRequest & { provider?: string; cache?: boolean }>();


### PR DESCRIPTION
## Summary

Adds dynamic model discovery so Provara automatically picks up new models from provider APIs without code changes.

### Changes

**Gateway (`packages/gateway`)**:
- Added optional `listModels()` method to the `Provider` interface
- Implemented for all built-in providers:
  - **OpenAI**: `client.models.list()`, filtered to chat models (gpt-*, o1/o3/o4)
  - **Anthropic**: `client.models.list({ limit: 100 })`
  - **Google**: REST call to generativelanguage API, filtered to `generateContent`-capable models
  - **OpenAI-compatible** (Mistral, xAI, Z.ai, Ollama): `client.models.list()` via their baseURL
- Added `refreshModels()` to `ProviderRegistry` — calls `listModels()` on all providers in parallel
- New endpoint: `POST /v1/providers/refresh-models` — triggers refresh and returns results
- Startup: `refreshModels()` runs non-blocking after server starts (falls back to hardcoded defaults on failure)

**Dashboard (`apps/web`)**:
- "Refresh Models" button on the Providers page — calls the new endpoint and shows a result toast

### Behavior

- On startup, provider APIs are queried for available models. Static lists are used as fallback if discovery fails.
- `listModels()` updates the provider's `models` array in-place — the routing engine and `getForModel()` immediately see new models.
- Discovered models not in `MODEL_PRICING` get `cost: 0`. Pricing can be added separately.
- Each `listModels()` call is wrapped in try/catch — one provider failing doesn't affect others.

Closes #42

---

**Authored-by:** Claude/opus-4-6 (Claude Code)
