### PR TITLE
fix(#42): filter non-chat models from OpenAI discovery

### DIFF
--- a/packages/gateway/src/providers/openai.ts
+++ b/packages/gateway/src/providers/openai.ts
@@ -16,9 +16,14 @@ export function createOpenAIProvider(apiKey?: string): Provider {
         const response = await client.models.list();
         const chatModels: string[] = [];
         for await (const model of response) {
-          // Only include chat-capable models, skip embeddings/tts/whisper/dall-e
-          if (model.id.startsWith("gpt-") || model.id.startsWith("o1") || model.id.startsWith("o3") || model.id.startsWith("o4")) {
-            chatModels.push(model.id);
+          // Only include chat completion-capable models
+          const id = model.id;
+          const isChat = id.startsWith("gpt-") || id.startsWith("o1") || id.startsWith("o3") || id.startsWith("o4");
+          const isNonChat = /-(tts|realtime|audio|transcribe|diarize|image|search)/.test(id)
+            || id.includes("instruct")
+            || id.startsWith("gpt-image");
+          if (isChat && !isNonChat) {
+            chatModels.push(id);
           }
         }
         if (chatModels.length > 0) {


### PR DESCRIPTION
## Summary

Tightens the OpenAI model discovery filter to exclude non-chat models that would fail if selected by the router.

The `listModels()` call returns all OpenAI model types. The gateway only supports `POST /v1/chat/completions`, so models for other modalities need to be excluded.

**Filtered out** (regex: `-(tts|realtime|audio|transcribe|diarize|image|search)`, `instruct`, `gpt-image-*`):
- TTS: `gpt-4o-mini-tts`, `gpt-audio-*`
- Realtime: `gpt-4o-realtime-*`, `gpt-realtime-*`
- Transcribe: `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`
- Image: `gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`
- Search: `gpt-4o-search-preview`, `gpt-5-search-api`
- Instruct: `gpt-3.5-turbo-instruct`

**Kept**: 62 chat-capable models (gpt-3.5-turbo through gpt-5.4-pro, codex variants, o1/o3/o4 reasoning)

---

**Authored-by:** Claude/opus-4-6 (Claude Code)
