### PR TITLE
fix(#45): analytics timeseries epoch math and playground chat width

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -285,7 +285,8 @@ export default function PlaygroundPage() {
         </div>
 
         {/* Messages */}
-        <div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-6 space-y-6">
+        <div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-6">
+          <div className="max-w-4xl mx-auto space-y-6">
           {messages.length === 0 && !streamingContent && (
             <div className="flex items-center justify-center h-full">
               <div className="text-center max-w-md">
@@ -350,6 +351,7 @@ export default function PlaygroundPage() {
           )}
 
           <div ref={messagesEndRef} />
+          </div>
         </div>
 
         {/* Input */}

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -323,22 +323,17 @@ export function createAnalyticsRoutes(db: Db) {
 
     const rows = await db
       .select({
-        bucket: sql<string>`strftime(${fmt}, datetime(${requests.createdAt} / 1000, 'unixepoch'))`,
+        bucket: sql<string>`strftime(${fmt}, datetime(${requests.createdAt}, 'unixepoch'))`,
         requestCount: sql<number>`count(*)`,
         avgLatency: sql<number>`avg(${requests.latencyMs})`,
-        p50Latency: sql<number>`percentile(50, ${requests.latencyMs})`,
-        p95Latency: sql<number>`percentile(95, ${requests.latencyMs})`,
-        p99Latency: sql<number>`percentile(99, ${requests.latencyMs})`,
+        minLatency: sql<number>`min(${requests.latencyMs})`,
+        maxLatency: sql<number>`max(${requests.latencyMs})`,
       })
       .from(requests)
       .where(and(...conditions))
       .groupBy(sql`1`)
       .orderBy(sql`1`)
-      .all()
-      .then((rows) => rows.filter((r) => {
-        if (provider && model) return true; // filtered below via cost query
-        return true;
-      }));
+      .all();
 
     // Cost time-series (separate table)
     const costConditions = [gte(costLogs.createdAt, since)];
@@ -346,7 +341,7 @@ export function createAnalyticsRoutes(db: Db) {
 
     const costRows = await db
       .select({
-        bucket: sql<string>`strftime(${fmt}, datetime(${costLogs.createdAt} / 1000, 'unixepoch'))`,
+        bucket: sql<string>`strftime(${fmt}, datetime(${costLogs.createdAt}, 'unixepoch'))`,
         totalCost: sql<number>`sum(${costLogs.cost})`,
       })
       .from(costLogs)
@@ -357,15 +352,20 @@ export function createAnalyticsRoutes(db: Db) {
 
     const costMap = new Map(costRows.map((r) => [r.bucket, r.totalCost]));
 
-    const series = rows.map((r) => ({
-      bucket: r.bucket,
-      requestCount: r.requestCount,
-      avgLatency: Math.round(r.avgLatency || 0),
-      p50Latency: Math.round(r.p50Latency || r.avgLatency || 0),
-      p95Latency: Math.round(r.p95Latency || r.avgLatency || 0),
-      p99Latency: Math.round(r.p99Latency || r.avgLatency || 0),
-      totalCost: costMap.get(r.bucket) || 0,
-    }));
+    // Approximate percentiles: p50 ≈ avg, p95 ≈ avg + 0.8*(max-avg), p99 ≈ max
+    const series = rows.map((r) => {
+      const avg = r.avgLatency || 0;
+      const max = r.maxLatency || avg;
+      return {
+        bucket: r.bucket,
+        requestCount: r.requestCount,
+        avgLatency: Math.round(avg),
+        p50Latency: Math.round(avg),
+        p95Latency: Math.round(avg + 0.8 * (max - avg)),
+        p99Latency: Math.round(max),
+        totalCost: costMap.get(r.bucket) || 0,
+      };
+    });
 
     return c.json({ series, range });
   });
@@ -382,7 +382,7 @@ export function createAnalyticsRoutes(db: Db) {
 
     const rows = await db
       .select({
-        bucket: sql<string>`strftime(${fmt}, datetime(${costLogs.createdAt} / 1000, 'unixepoch'))`,
+        bucket: sql<string>`strftime(${fmt}, datetime(${costLogs.createdAt}, 'unixepoch'))`,
         provider: costLogs.provider,
         totalCost: sql<number>`sum(${costLogs.cost})`,
         requestCount: sql<number>`count(*)`,


### PR DESCRIPTION
## Summary

Fixes two dashboard issues: empty analytics charts and misaligned playground chat.

### Analytics timeseries (gateway)

**Root cause:** `created_at` is stored as epoch **seconds** (Drizzle `{ mode: "timestamp" }`), but the `strftime` queries divided by 1000 as if it were milliseconds. This produced dates in January 1970, so all 94 requests bucketed to a single point outside any visible time range.

**Second issue:** `percentile(50, ...)` / `percentile(95, ...)` / `percentile(99, ...)` are not available in SQLite/Turso. The entire `/v1/analytics/timeseries` endpoint was failing.

**Fix:**
- Removed `/ 1000` from all `datetime(created_at / 1000, 'unixepoch')` → `datetime(created_at, 'unixepoch')`
- Replaced `percentile()` with min/max/avg approximation (p50 ≈ avg, p95 ≈ avg + 80% spread, p99 ≈ max)

### Playground chat width (web)

Messages area had no max-width, spanning the full container. Input bar used `max-w-4xl mx-auto`. Added matching constraint to the messages wrapper.

Closes #45

---

**Authored-by:** Claude/opus-4-6 (Claude Code)
