### PR TITLE
feat(#49): wire live feedback learning into adaptive router

### DIFF
--- a/packages/db/drizzle/0012_giant_magma.sql
+++ b/packages/db/drizzle/0012_giant_magma.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `model_scores` (
+	`task_type` text NOT NULL,
+	`complexity` text NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`quality_score` real NOT NULL,
+	`sample_count` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`task_type`, `complexity`, `provider`, `model`)
+);

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1511 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c06550d8-3685-45f8-9076-71a8c7accb7e",
+  "prevId": "82873b30-2097-4b9a-8e9a-09af7b5db4f3",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1776269160795,
       "tag": "0011_oval_molly_hayes",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1776370620420,
+      "tag": "0012_giant_magma",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, uniqueIndex } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, uniqueIndex, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
@@ -247,6 +247,20 @@ export const promptVersions = sqliteTable("prompt_versions", {
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+export const modelScores = sqliteTable("model_scores", {
+  taskType: text("task_type").notNull(),
+  complexity: text("complexity").notNull(),
+  provider: text("provider").notNull(),
+  model: text("model").notNull(),
+  qualityScore: real("quality_score").notNull(),
+  sampleCount: integer("sample_count").notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  primaryKey({ columns: [table.taskType, table.complexity, table.provider, table.model] }),
+]);
 
 export const costLogs = sqliteTable("cost_logs", {
   id: text("id").primaryKey(),

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -35,7 +35,7 @@ interface RouterContext {
 export async function createRouter(ctx: RouterContext) {
   const app = new Hono();
   const routingEngine = await createRoutingEngine({ registry: ctx.registry, db: ctx.db });
-  const judge = createJudge(ctx.registry, ctx.db);
+  const judge = createJudge(ctx.registry, ctx.db, routingEngine.adaptive);
 
   // Enable CORS for web dashboard and browser-based API clients
   app.use("/*", cors({
@@ -82,7 +82,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/api-keys", createApiKeyRoutes(ctx.db));
 
   // Mount feedback routes
-  app.route("/v1/feedback", createFeedbackRoutes(ctx.db));
+  app.route("/v1/feedback", createFeedbackRoutes(ctx.db, routingEngine.adaptive));
 
   // Mount token management routes (owner only)
   app.route("/v1/admin/tokens", createTokenRoutes(ctx.db));
@@ -319,6 +319,16 @@ export async function createRouter(ctx: RouterContext) {
                   })
                   .run();
 
+                if (routingResult.taskType && routingResult.complexity) {
+                  routingEngine.adaptive.updateLatency(
+                    routingResult.taskType,
+                    routingResult.complexity,
+                    usedProvider,
+                    usedModel,
+                    latencyMs
+                  );
+                }
+
                 logCost(ctx.db, {
                   requestId,
                   provider: usedProvider,
@@ -344,6 +354,10 @@ export async function createRouter(ctx: RouterContext) {
                   tenantId,
                   messages: request.messages,
                   responseContent: fullContent,
+                  taskType: routingResult.taskType,
+                  complexity: routingResult.complexity,
+                  provider: usedProvider,
+                  model: usedModel,
                 }).catch(() => {});
               } catch (err) {
                 controller.error(err);
@@ -437,6 +451,16 @@ export async function createRouter(ctx: RouterContext) {
       })
       .run();
 
+    if (routingResult.taskType && routingResult.complexity) {
+      routingEngine.adaptive.updateLatency(
+        routingResult.taskType,
+        routingResult.complexity,
+        usedProvider,
+        usedModel,
+        latencyMs
+      );
+    }
+
     await logCost(ctx.db, {
       requestId,
       provider: usedProvider,
@@ -457,6 +481,10 @@ export async function createRouter(ctx: RouterContext) {
       tenantId,
       messages: request.messages,
       responseContent: response.content,
+      taskType: routingResult.taskType,
+      complexity: routingResult.complexity,
+      provider: usedProvider,
+      model: usedModel,
     }).catch(() => {});
 
     // Output guardrails — check response content before returning

--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -6,8 +6,9 @@ import { nanoid } from "nanoid";
 import { getTokenInfo } from "../auth/middleware.js";
 import { getTenantId } from "../auth/tenant.js";
 import { getJudgeConfig, setJudgeConfig } from "../routing/judge.js";
+import type { AdaptiveRouter } from "../routing/adaptive.js";
 
-export function createFeedbackRoutes(db: Db) {
+export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
   const app = new Hono();
 
   // Submit feedback for a request
@@ -55,6 +56,17 @@ export function createFeedbackRoutes(db: Db) {
         source: "user",
       })
       .run();
+
+    if (request.taskType && request.complexity) {
+      await adaptive.updateScore(
+        request.taskType,
+        request.complexity,
+        request.provider,
+        request.model,
+        body.score,
+        "user"
+      );
+    }
 
     return c.json({ id, requestId: body.requestId, score: body.score }, 201);
   });

--- a/packages/gateway/src/routing/adaptive.ts
+++ b/packages/gateway/src/routing/adaptive.ts
@@ -1,13 +1,29 @@
+// Single-instance constraint: the EMA score map is in-process memory. Multiple gateway
+// replicas would each hold a drifting copy; updateScore writes from replica-1 would not
+// reach replica-2 until the next restart. The model_scores table is the durable source
+// of truth so a single process recovers cleanly on boot, but horizontal scaling needs
+// a sync mechanism (pub/sub or periodic reload). Tracked in issue #50.
 import type { Db } from "@provara/db";
-import { feedback, requests } from "@provara/db";
+import { feedback, modelScores, requests } from "@provara/db";
 import { eq, sql } from "drizzle-orm";
 import type { TaskType, Complexity } from "../classifier/types.js";
 import type { RouteTarget } from "./types.js";
 import { getPricing } from "../cost/index.js";
 
-// EMA decay factor: 0.1 = slow adaptation, 0.3 = moderate, 0.5 = fast
+// EMA decay factor: 0.1 = slow adaptation, 0.3 = moderate, 0.5 = fast.
+// Used for latency EMA and as the global override for quality EMA when per-source vars are unset.
 const EMA_ALPHA = parseFloat(process.env.PROVARA_EMA_ALPHA || "0.2");
 const MIN_SAMPLES = parseInt(process.env.PROVARA_MIN_SAMPLES || "5");
+
+export type FeedbackSource = "user" | "judge";
+
+function getQualityAlpha(source: FeedbackSource): number {
+  const envVar = source === "user" ? "PROVARA_EMA_ALPHA_USER" : "PROVARA_EMA_ALPHA_JUDGE";
+  const specific = process.env[envVar];
+  if (specific !== undefined) return parseFloat(specific);
+  if (process.env.PROVARA_EMA_ALPHA !== undefined) return parseFloat(process.env.PROVARA_EMA_ALPHA);
+  return source === "user" ? 0.4 : 0.2;
+}
 
 export type RoutingProfile = "cost" | "balanced" | "quality" | "custom";
 
@@ -71,10 +87,46 @@ function computeRouteScore(
   return weights.quality * normalizedQuality + weights.cost * normalizedCost + weights.latency * normalizedLatency;
 }
 
+export type AdaptiveRouter = Awaited<ReturnType<typeof createAdaptiveRouter>>;
+
 export async function createAdaptiveRouter(db: Db) {
-  // Load initial scores from existing feedback data
+  // Load initial scores. Precedence:
+  //  1. model_scores table — authoritative live EMA persisted across restarts.
+  //  2. feedback aggregation — seed for cells that have feedback history but no
+  //     model_scores row yet (first boot after the table was added, or cells that
+  //     predate live learning). Once updateScore fires for a cell, it becomes
+  //     authoritative and the seed path no longer applies to it.
   async function loadScoresFromDb(): Promise<void> {
-    const rows = await db
+    const persisted = await db
+      .select({
+        taskType: modelScores.taskType,
+        complexity: modelScores.complexity,
+        provider: modelScores.provider,
+        model: modelScores.model,
+        qualityScore: modelScores.qualityScore,
+        sampleCount: modelScores.sampleCount,
+      })
+      .from(modelScores)
+      .all();
+
+    for (const row of persisted) {
+      const ck = cellKey(row.taskType, row.complexity);
+      const mk = modelKey(row.provider, row.model);
+
+      if (!emaScores.has(ck)) emaScores.set(ck, new Map());
+      const cellScores = emaScores.get(ck)!;
+
+      cellScores.set(mk, {
+        provider: row.provider,
+        model: row.model,
+        qualityScore: row.qualityScore,
+        sampleCount: row.sampleCount,
+        costPer1M: getModelCost(row.model),
+        avgLatencyMs: 0, // populated from requests below
+      });
+    }
+
+    const feedbackRows = await db
       .select({
         provider: requests.provider,
         model: requests.model,
@@ -88,7 +140,7 @@ export async function createAdaptiveRouter(db: Db) {
       .groupBy(requests.provider, requests.model, requests.taskType, requests.complexity)
       .all();
 
-    for (const row of rows) {
+    for (const row of feedbackRows) {
       if (!row.taskType || !row.complexity) continue;
       const ck = cellKey(row.taskType, row.complexity);
       const mk = modelKey(row.provider, row.model);
@@ -96,13 +148,16 @@ export async function createAdaptiveRouter(db: Db) {
       if (!emaScores.has(ck)) emaScores.set(ck, new Map());
       const cellScores = emaScores.get(ck)!;
 
+      // Skip cells that already have a persisted EMA — that takes precedence.
+      if (cellScores.has(mk)) continue;
+
       cellScores.set(mk, {
         provider: row.provider,
         model: row.model,
         qualityScore: row.avgScore,
         sampleCount: row.count,
         costPer1M: getModelCost(row.model),
-        avgLatencyMs: 0, // Will be populated by updateLatency calls
+        avgLatencyMs: 0,
       });
     }
 
@@ -133,34 +188,54 @@ export async function createAdaptiveRouter(db: Db) {
     }
   }
 
-  // Update EMA score when new feedback arrives
-  function updateScore(
+  // Update EMA score when new feedback arrives and persist to model_scores.
+  // `source` picks the alpha: user feedback moves the needle harder than the judge.
+  async function updateScore(
     taskType: string,
     complexity: string,
     provider: string,
     model: string,
-    newScore: number
-  ): void {
+    newScore: number,
+    source: FeedbackSource
+  ): Promise<void> {
+    const alpha = getQualityAlpha(source);
     const ck = cellKey(taskType, complexity);
     const mk = modelKey(provider, model);
 
     if (!emaScores.has(ck)) emaScores.set(ck, new Map());
     const cellScores = emaScores.get(ck)!;
 
+    let qualityScore: number;
+    let sampleCount: number;
+
     const existing = cellScores.get(mk);
     if (existing) {
-      existing.qualityScore = EMA_ALPHA * newScore + (1 - EMA_ALPHA) * existing.qualityScore;
+      existing.qualityScore = alpha * newScore + (1 - alpha) * existing.qualityScore;
       existing.sampleCount++;
+      qualityScore = existing.qualityScore;
+      sampleCount = existing.sampleCount;
     } else {
+      qualityScore = newScore;
+      sampleCount = 1;
       cellScores.set(mk, {
         provider,
         model,
-        qualityScore: newScore,
-        sampleCount: 1,
+        qualityScore,
+        sampleCount,
         costPer1M: getModelCost(model),
         avgLatencyMs: 0,
       });
     }
+
+    const updatedAt = new Date();
+    await db
+      .insert(modelScores)
+      .values({ taskType, complexity, provider, model, qualityScore, sampleCount, updatedAt })
+      .onConflictDoUpdate({
+        target: [modelScores.taskType, modelScores.complexity, modelScores.provider, modelScores.model],
+        set: { qualityScore, sampleCount, updatedAt },
+      })
+      .run();
   }
 
   // Update latency EMA after each request

--- a/packages/gateway/src/routing/judge.ts
+++ b/packages/gateway/src/routing/judge.ts
@@ -4,6 +4,7 @@ import type { Db } from "@provara/db";
 import { feedback } from "@provara/db";
 import { nanoid } from "nanoid";
 import { getPricing } from "../cost/index.js";
+import type { AdaptiveRouter } from "./adaptive.js";
 
 let judgeSampleRate = parseFloat(process.env.PROVARA_JUDGE_SAMPLE_RATE || "0.1");
 let judgeEnabled = true;
@@ -85,9 +86,13 @@ export interface JudgeContext {
   tenantId: string | null;
   messages: ChatMessage[];
   responseContent: string;
+  taskType: string | null;
+  complexity: string | null;
+  provider: string;
+  model: string;
 }
 
-export function createJudge(registry: ProviderRegistry, db: Db) {
+export function createJudge(registry: ProviderRegistry, db: Db, adaptive: AdaptiveRouter) {
   async function maybeJudge(ctx: JudgeContext): Promise<void> {
     if (!shouldJudge()) return;
 
@@ -131,6 +136,17 @@ export function createJudge(registry: ProviderRegistry, db: Db) {
           source: "judge",
         })
         .run();
+
+      if (ctx.taskType && ctx.complexity) {
+        await adaptive.updateScore(
+          ctx.taskType,
+          ctx.complexity,
+          ctx.provider,
+          ctx.model,
+          result.average,
+          "judge"
+        );
+      }
     } catch {
       // Judge failure is silent — don't affect the main request
     }


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 49
branch: issue/49-live-feedback-learning
status: resolved
updated_at: 2026-04-16T20:26:30Z
review_status: approved
last_reviewed_by: human (repo owner)
last_reviewed_at: 2026-04-16T20:26:00Z
reviewed_commit: 1bfa2147d1a7cd27c88403b8f009abe1ee09254e
review_source: https://github.com/syndicalt/provara/pull/52#issuecomment-4263182601
-->

## Summary

Wires the previously dormant `updateScore` / `updateLatency` functions into the gateway's event flow and persists the adaptive router's quality EMA to a new `model_scores` table so learning survives process restarts. User and judge feedback use separate alpha values (0.4 vs 0.2) so volume imbalance doesn't let the judge drown out sparser user signal.

Closes #49

## Review Status

- **Current state:** approved
- **Last reviewed by:** human (repo owner) — merge explicitly authorized in working session
- **Last reviewed at:** 2026-04-16T20:26:00Z
- **Reviewed commit:** `1bfa214`
- **Source artifact:** https://github.com/syndicalt/provara/pull/52#issuecomment-4263182601
- **Needs re-review since:** no

Cross-model agent review unavailable in this session. Author self-review posted as audit trail only; the gate-satisfying signal is the human authorization from the repo owner per `closure-and-review.md §3` ("human review always counts as independent").

## Journey Timeline

### Initial Plan
Per issue #49: `updateScore` and `updateLatency` existed in `packages/gateway/src/routing/adaptive.ts` but were never called, and `loadScoresFromDb` recomputed a flat `avg(feedback.score)` on every boot. The adaptive router was "static learning on restart" rather than "live learning." This PR wires the events and adds durable EMA persistence.

### What We Discovered
- The routing engine already exposes `adaptive` via its return object, so no DI refactor was needed to thread the router handle into feedback/judge/router call sites — they just take one extra positional arg.
- The judge didn't previously know `taskType / complexity / provider / model` — it only had `requestId`, `messages`, and `responseContent`. Options were to either query `requests` inside the judge or to pass the cell through `JudgeContext`. Chose the latter: the caller in `router.ts` already has these values from `routingResult`, so it's a free pass-through with no extra DB hit.
- Pre-existing tsc error at `packages/gateway/src/router.ts:179` (`routing_hint?.task_type` — `routing_hint` is a `TaskType` string, not an object). Lives on master, unrelated to this branch, verified by stash-diff. Will be addressed in a separate follow-up.

### Implementation Issues
- None material. The pre-existing tsc error above was noticed but explicitly deferred — fixing it here would muddy the scope of this PR.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| EMA persistence strategy | Persisted EMA in a new table (Q1 option B) | Railway restarts would otherwise flatten weeks of signal to a raw avg on every deploy, undercutting the "self-updating" claim |
| User vs judge signal | Per-source alpha (Q2 option B) | Judge samples automatically on 10% of requests and dominates by volume. Per-source alpha gives users more weight per event without a second-EMA schema |
| Latency persistence | In-memory only, rebuild from `requests.latencyMs` on boot (Q3 option A) | Raw latency already lives in `requests`; a second write-through per request adds cost with no durability win |
| Multi-instance sync | Documented as single-instance constraint; deferred to #50 (Q4 option A) | Premature for current solo-replica Railway deploy; the right design depends on whether we'll use Redis for other things too |

### Changes Made

**Commits:**
- `5226934` feat(#49/T1): add model_scores table for persisted EMA
- `8d1931d` feat(#49/T2): source-aware quality EMA with write-through persistence
- `1bfa214` feat(#49): wire feedback, judge, and latency into adaptive router (T3-T5)

## Testing

- [x] T1: `npm run db:generate -w packages/db` produced migration `0012_giant_magma.sql`; `npm run db:migrate` applied cleanly on a fresh DB, all 13 migrations registered in `__drizzle_migrations`.
- [x] T2: Behavioral test — called `updateScore` with scores 5 / 5 / 1 (user source, α=0.4) against a fresh DB; `model_scores` row ended at `qualityScore: 3.4, sampleCount: 3`. Restarted the router and confirmed the same values loaded back (not flattened to a raw average of 3.67).
- [x] T3–T5: Typecheck clean across gateway and db packages aside from the pre-existing `router.ts:179` error.
- [ ] End-to-end test against a live request path: not run. The wiring is straightforward (one `updateScore` call after each feedback insert, one `updateLatency` call after each requests insert) and verified by typecheck and T2's round-trip test of the core path, but no HTTP-level smoke test was executed.

**Verification summary:** Core EMA round-trip verified behaviorally; call-site wiring verified by type-check only. No existing tests cover the adaptive router, so no regressions to run.

## Stacked PRs / Related

- Follow-up: #50 — Multi-instance EMA synchronization
- Follow-up: #51 — Time-based decay for stale routing cells

## Knowledge for Future Reference

- The in-memory `emaScores` map in `adaptive.ts` is the hot read path; `model_scores` is the durable write-through target. The map is canonical *within a process*; the DB table is canonical *across restarts*. Don't read from `model_scores` at route time — that's what `loadScoresFromDb` (boot) and `updateScore` (write) are for.
- `loadScoresFromDb` has two sources: `model_scores` (authoritative) and `avg(feedback.score)` (seed for cells that predate the live-learning table). Once a cell receives any `updateScore` call, it has a `model_scores` row and the seed path never applies to it again.
- User feedback and judge feedback land in the same `feedback` table with a `source` column. The EMA alpha, not the storage, distinguishes them — so if you ever want to inspect the raw signal by source, the data is intact.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
Updated-by: claude/opus-4.7 (claude-code)
Edit-kind: amendment
Edit-note: Refresh review snapshot after human authorization.
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
