### PR TITLE
fix(#53): pass routing_hint through to routing engine

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -176,7 +176,7 @@ export async function createRouter(ctx: RouterContext) {
       messages: request.messages,
       provider: providerName,
       model: request.model !== "" ? request.model : undefined,
-      routingHint: routing_hint?.task_type,
+      routingHint: routing_hint,
       routingProfile: (tokenInfo?.routingProfile as RoutingProfile) || undefined,
       routingWeights: tokenInfo?.routingWeights || undefined,
     });


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 53
branch: issue/53-fix-routing-hint
status: resolved
updated_at: 2026-04-16T20:29:30Z
review_status: approved
last_reviewed_by: human (repo owner)
last_reviewed_at: 2026-04-16T20:29:30Z
reviewed_commit: ed5a206
review_source: working session authorization
-->

## Summary

One-line fix: `routing_hint?.task_type` → `routing_hint`. The hint is already typed as a `TaskType` string; the `?.task_type` dereference always produced `undefined`, silently dropping the API parameter.

Closes #53

## Review Status

- **Current state:** approved (human authorization — same-session override per `closure-and-review.md §3`)
- **Last reviewed by:** human (repo owner)
- **Reviewed commit:** `ed5a206`
- **Needs re-review since:** no

## Changes Made

- `ed5a206` fix(#53/T1): pass routing_hint through to routing engine

## Testing

- [x] `npx tsc -p packages/gateway/tsconfig.json --noEmit` — clean (this was the only error on master before the fix).
- [ ] Runtime smoke test with `"routing_hint": "coding"` — not run in this session; left for the repo owner to verify on next deploy or local run.

## Notes

Discovered during #49 while typechecking the live-feedback-learning changes. Stashed the work, confirmed the error lived on master without my changes, then filed this as a scoped follow-up rather than bundling it into #49.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
