### PR TITLE
docs(#55): document adaptive routing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Intelligent multi-provider LLM gateway with adaptive routing, A/B testing, and c
 ## Features
 
 - **Intelligent Routing** — Classifies queries by task type (coding, creative, summarization, Q&A, general) and complexity (simple, medium, complex), then routes to the optimal model
-- **Adaptive Quality Scoring** — Learns from feedback (user ratings + LLM-as-judge) to auto-optimize which model handles each task type
+- **Adaptive Quality Scoring** — Every user rating and LLM-judge score updates a live quality EMA per routing cell (task × complexity × model), persisted across restarts. Winning models earn more traffic automatically — no retraining step, no manual model selection to keep current as providers ship new versions
 - **A/B Testing** — Split traffic between models with weighted variants, scoped to routing cells
 - **8+ Providers** — OpenAI, Anthropic, Google, Mistral, xAI, Z.ai, Ollama, plus any OpenAI-compatible provider
 - **Dynamic Model Discovery** — Automatically detects available models from each provider's API at startup, with on-demand refresh
@@ -130,8 +130,56 @@ Each request logs which routing method was used in `_provara.routing.routedBy`:
 - `"explicit"` — user specified provider/model
 - `"routing-hint"` — user provided a task type hint
 - `"ab-test"` — matched an active A/B test
-- `"adaptive"` — quality-based adaptive routing
+- `"adaptive"` — live quality-based routing (see [Adaptive Routing](#adaptive-routing))
 - `"classification"` — classifier picked the route
+
+## Adaptive Routing
+
+Provara's adaptive router learns from live traffic. Every user rating submitted to `/v1/feedback` and every score produced by the built-in LLM judge flows into a per-cell quality EMA. Over time, the router leans harder on the models that actually perform well on the traffic you're sending — without a retraining step and without you having to manually swap model names when providers ship new versions.
+
+### The feedback loop
+
+Two signal sources land in the same `feedback` table:
+
+- **User ratings** (`source: "user"`) — explicit 1–5 scores submitted via `POST /v1/feedback` or the dashboard's Quality view.
+- **LLM-as-judge** (`source: "judge"`) — the gateway automatically samples a configurable fraction of responses (default ~10%, tunable via `/v1/feedback/judge/config`) and asks a cheap model to score relevance, accuracy, and coherence. The average lands as a `feedback` row with `source: "judge"`.
+
+Both sources feed the same learning loop but with different weights — see [Live learning](#live-learning) below.
+
+A **routing cell** is the `(taskType, complexity)` tuple the classifier assigns to each request — e.g. `coding/medium` or `creative/simple`. The router tracks a running quality score per `(cell, provider, model)` independently: GPT-4o on `coding/complex` has its own score, separate from GPT-4o on `qa/simple`. This matters because a model that wins on one cell can lose on another, and a blended global score would hide that.
+
+### Live learning
+
+Every feedback event nudges the relevant score by an exponential moving average. User ratings move the EMA harder than judge scores, so:
+
+- A single user rating meaningfully shifts the result.
+- Judge scores accumulate into a stable baseline without any one sample swinging the decision.
+- A flood of automated judge traffic can't drown out sparser but higher-signal user feedback.
+
+Scores persist to a `model_scores` table on every update, so a Railway redeploy or local restart resumes with the exact running EMA — not a flat re-average of historical feedback. Weeks of signal don't get lost to a restart.
+
+### When adaptive routing kicks in
+
+Adaptive routing is sample-gated. A `(cell, provider, model)` combination needs at least a few feedback events before the router will pick it on quality grounds. Below that threshold, traffic falls through to cost-ranked fallback (cheapest viable provider first) or to an active A/B test if one scopes to the cell.
+
+Routing priority for each request:
+
+1. **Explicit user override** — the caller specified `provider` + `model` in the request body.
+2. **Active A/B test on the cell** — weighted random variant selection.
+3. **Adaptive** — the cell has enough signal; pick the highest-scoring model under the active routing profile.
+4. **Cost fallback** — no adaptive data yet; route to the cheapest provider that can handle the classification.
+
+Adaptive coexists cleanly with A/B tests: while a test is active, the test wins (so you get controlled comparison data); once it completes, the scores it generated continue shaping the adaptive decision for that cell.
+
+### Tuning the trade-off
+
+The adaptive winner isn't chosen on quality alone. Each candidate is scored against three dimensions — quality, cost, latency — weighted by a **routing profile**:
+
+- `cost` — cheapest wins unless quality is catastrophically bad (20/70/10).
+- `balanced` (default) — equal weight on quality and cost, a touch on latency (40/40/20).
+- `quality` — highest EMA wins unless cost or latency are egregious (70/15/15).
+
+Profiles can be set per API token (via `/v1/admin/tokens`) so a production workload and a throwaway experiment can share the same adaptive scores but route differently.
 
 ## A/B Testing Guide
 
@@ -213,7 +261,7 @@ curl -X POST http://localhost:4000/v1/feedback \
   }'
 ```
 
-Scores feed into the adaptive routing engine — after enough feedback, Provara will auto-route to the better model even without an A/B test.
+Scores also feed the live adaptive router — see [Adaptive Routing](#adaptive-routing) for how the feedback loop works and when it starts influencing traffic.
 
 ### 5. Complete the test
 


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 55
branch: issue/55-readme-adaptive-routing
status: resolved
updated_at: 2026-04-16T20:38:30Z
review_status: awaiting-review
-->

## Summary

Expands the README's adaptive routing coverage from one thin feature bullet to a real conceptual section. Now that #49 shipped live feedback learning, a first-time reader can actually see how the loop works — sources, routing cells, EMA weighting, restart persistence, and when adaptive kicks in vs. falls through.

Closes #55

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Changes Made

- `89c62b4` docs(#55/T1): document adaptive routing in README

**Diff:** +51/-3 lines on `README.md`. Four edits:
1. Rewrote the "Adaptive Quality Scoring" feature bullet with concrete language (live EMA, restart persistence, why it doesn't need retraining).
2. New `## Adaptive Routing` section between "How Routing Works" and "A/B Testing Guide" with four subsections: feedback loop, live learning, when it kicks in, tuning the trade-off.
3. Tightened the `"adaptive"` entry in the `routedBy` list to cross-link the new section.
4. Replaced the hand-wave at the bottom of A/B Testing step 4 with a direct link to the new section.

## Out of scope (deferred)

- Env-var tuning table (`PROVARA_EMA_ALPHA_USER`, `PROVARA_EMA_ALPHA_JUDGE`, `PROVARA_MIN_SAMPLES`). Current `.env.example` and README env tables document only "needs setting to run" vars, not tuning knobs. Stays out; fits a future Tuning doc if one is written.
- Diagram asset changes (`public/routing.png` left alone to avoid drift).

## Testing

- [x] GitHub markdown render: verified the new anchor links (`#adaptive-routing`, `#live-learning`) resolve correctly in the PR's own rendering.
- [x] No drift with shipped behavior: all claims in the new section describe what #49 and pre-existing code actually do (EMA formula, `model_scores` persistence, sample gate, profile weights 20/70/10 · 40/40/20 · 70/15/15 match `PROFILE_WEIGHTS` in `adaptive.ts`).

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
