### PR TITLE
feat(#57): adaptive routing visualizations — heatmap, sparklines, pipeline pulse

### DIFF
--- a/apps/web/src/app/dashboard/quality/page.tsx
+++ b/apps/web/src/app/dashboard/quality/page.tsx
@@ -6,6 +6,8 @@ import {
 } from "recharts";
 import { formatNumber } from "../../../lib/format";
 import { DataTable, type Column } from "../../../components/data-table";
+import { AdaptiveHeatmap, type AdaptiveCell } from "../../../components/adaptive-heatmap";
+import { useAdaptiveScoreBuffer } from "../../../hooks/use-adaptive-score-buffer";
 import { gatewayClientFetch, gatewayFetchRaw } from "../../../lib/gateway-client";
 
 interface QualityByModel {
@@ -15,20 +17,6 @@ interface QualityByModel {
   count: number;
   userCount: number;
   judgeCount: number;
-}
-
-interface AdaptiveScore {
-  provider: string;
-  model: string;
-  qualityScore: number;
-  sampleCount: number;
-  costPer1M: number;
-}
-
-interface AdaptiveCell {
-  taskType: string;
-  complexity: string;
-  scores: AdaptiveScore[];
 }
 
 interface FeedbackEntry {
@@ -58,8 +46,6 @@ interface JudgeConfig {
   enabled: boolean;
 }
 
-const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general"];
-const COMPLEXITIES = ["simple", "medium", "complex"];
 const RANGES = [
   { value: "24h", label: "24h" },
   { value: "7d", label: "7d" },
@@ -98,60 +84,6 @@ function ChartTooltip({ active, payload, label }: { active?: boolean; payload?: 
           <span className="text-zinc-200 font-medium">{typeof entry.value === "number" ? entry.value.toFixed(2) : entry.value}</span>
         </div>
       ))}
-    </div>
-  );
-}
-
-function AdaptiveMatrix({ cells }: { cells: AdaptiveCell[] }) {
-  const matrix: Record<string, Record<string, AdaptiveScore | null>> = {};
-  for (const tt of TASK_TYPES) {
-    matrix[tt] = {};
-    for (const cx of COMPLEXITIES) {
-      const cell = cells.find((c) => c.taskType === tt && c.complexity === cx);
-      if (cell && cell.scores.length > 0) {
-        const best = [...cell.scores].sort((a, b) => b.qualityScore - a.qualityScore)[0];
-        matrix[tt][cx] = best;
-      } else {
-        matrix[tt][cx] = null;
-      }
-    }
-  }
-
-  return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-zinc-800 text-zinc-400 text-left">
-            <th className="px-4 py-3">Task Type</th>
-            {COMPLEXITIES.map((c) => (
-              <th key={c} className="px-4 py-3 text-center capitalize">{c}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {TASK_TYPES.map((tt) => (
-            <tr key={tt} className="border-b border-zinc-800/50">
-              <td className="px-4 py-3 capitalize font-medium">{tt}</td>
-              {COMPLEXITIES.map((cx) => {
-                const score = matrix[tt][cx];
-                return (
-                  <td key={cx} className="px-4 py-3 text-center">
-                    {score ? (
-                      <div>
-                        <p className="font-mono text-xs">{score.model}</p>
-                        <ScoreBar score={score.qualityScore} />
-                        <p className="text-xs text-zinc-500 mt-1">{score.sampleCount} samples</p>
-                      </div>
-                    ) : (
-                      <span className="text-zinc-600">No data</span>
-                    )}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }
@@ -196,6 +128,7 @@ export default function QualityPage() {
   const [judgeConfig, setJudgeConfigState] = useState<JudgeConfig | null>(null);
   const [savingConfig, setSavingConfig] = useState(false);
   const [loading, setLoading] = useState(true);
+  const { getSparkline, pulsedKeys } = useAdaptiveScoreBuffer(adaptiveCells);
 
   const fetchTrend = useCallback(async () => {
     try {
@@ -234,6 +167,22 @@ export default function QualityPage() {
   useEffect(() => {
     fetchTrend();
   }, [fetchTrend]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function pollAdaptive() {
+      try {
+        const res = await gatewayFetchRaw("/v1/analytics/adaptive/scores");
+        const data = await res.json();
+        if (!cancelled) setAdaptiveCells(data.cells || []);
+      } catch {}
+    }
+    const id = setInterval(pollAdaptive, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
 
   async function handleSaveConfig() {
     if (!judgeConfig) return;
@@ -345,13 +294,13 @@ export default function QualityPage() {
         </section>
       )}
 
-      {/* Adaptive Routing Matrix */}
+      {/* Adaptive Routing Heatmap */}
       <section>
-        <h2 className="text-lg font-semibold mb-4">Adaptive Routing Matrix</h2>
+        <h2 className="text-lg font-semibold mb-4">Adaptive Routing</h2>
         <p className="text-sm text-zinc-400 mb-3">
-          Best model per cell based on EMA quality scores from feedback. The router uses these scores to auto-select models.
+          Live quality EMA per routing cell. Each strip is a candidate model — color shows score, opacity shows sample confidence, dashed outlines mark models still below the adaptive-routing threshold.
         </p>
-        <AdaptiveMatrix cells={adaptiveCells} />
+        <AdaptiveHeatmap cells={adaptiveCells} pulsedKeys={pulsedKeys} getSparkline={getSparkline} />
       </section>
 
       {/* Quality by Model */}

--- a/apps/web/src/app/dashboard/routing/page.tsx
+++ b/apps/web/src/app/dashboard/routing/page.tsx
@@ -6,6 +6,8 @@ import { DataTable, type Column } from "../../../components/data-table";
 import { Badge } from "../../../components/badge";
 import { gatewayFetchRaw } from "../../../lib/gateway-client";
 import { PipelineVisualization } from "../../../components/pipeline-viz";
+import type { AdaptiveCell } from "../../../components/adaptive-heatmap";
+import { useAdaptiveScoreBuffer } from "../../../hooks/use-adaptive-score-buffer";
 
 interface RoutingStat {
   taskType: string | null;
@@ -115,7 +117,9 @@ const routingStatsColumns: Column<RoutingStat>[] = [
 export default function RoutingPage() {
   const [stats, setStats] = useState<RoutingStat[]>([]);
   const [distribution, setDistribution] = useState<Distribution | null>(null);
+  const [adaptiveCells, setAdaptiveCells] = useState<AdaptiveCell[]>([]);
   const [loading, setLoading] = useState(true);
+  const { pulseTick, recentUpdateCount } = useAdaptiveScoreBuffer(adaptiveCells);
 
   useEffect(() => {
     async function fetchData() {
@@ -137,6 +141,23 @@ export default function RoutingPage() {
     fetchData();
   }, []);
 
+  useEffect(() => {
+    let cancelled = false;
+    async function pollAdaptive() {
+      try {
+        const res = await gatewayFetchRaw("/v1/analytics/adaptive/scores");
+        const data = await res.json();
+        if (!cancelled) setAdaptiveCells(data.cells || []);
+      } catch {}
+    }
+    pollAdaptive();
+    const id = setInterval(pollAdaptive, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
   if (loading) {
     return (
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -151,8 +172,21 @@ export default function RoutingPage() {
 
       {/* Pipeline Visualization */}
       <section>
-        <h2 className="text-lg font-semibold mb-4">Routing Pipeline</h2>
-        <PipelineVisualization />
+        <div className="flex items-baseline justify-between mb-4">
+          <h2 className="text-lg font-semibold">Routing Pipeline</h2>
+          <div className="flex items-center gap-2 text-xs text-zinc-400">
+            <span
+              className={`inline-block w-2 h-2 rounded-full ${
+                recentUpdateCount > 0 ? "bg-emerald-400" : "bg-zinc-600"
+              }`}
+            />
+            <span>
+              <span className="font-mono text-zinc-200">{recentUpdateCount}</span>{" "}
+              learning {recentUpdateCount === 1 ? "update" : "updates"} in last 60s
+            </span>
+          </div>
+        </div>
+        <PipelineVisualization adaptivePulseTick={pulseTick} />
       </section>
 
       {/* Distribution Charts */}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -18,3 +18,8 @@ button, [role="button"], a, select, summary, label[for] {
 .scrollbar-thin::-webkit-scrollbar-thumb:hover {
   background: #52525b;
 }
+
+@keyframes adaptive-tick {
+  0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.75); }
+  100% { box-shadow: 0 0 0 8px rgba(52, 211, 153, 0); }
+}

--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import React from "react";
+import { LineChart, Line, ResponsiveContainer, YAxis } from "recharts";
+
+export interface AdaptiveScore {
+  provider: string;
+  model: string;
+  qualityScore: number;
+  sampleCount: number;
+  costPer1M: number;
+  avgLatencyMs?: number;
+}
+
+export interface AdaptiveCell {
+  taskType: string;
+  complexity: string;
+  scores: AdaptiveScore[];
+}
+
+export interface SparklinePoint {
+  timestamp: number;
+  qualityScore: number;
+}
+
+interface Props {
+  cells: AdaptiveCell[];
+  minSamples?: number;
+  pulsedKeys?: Set<string>;
+  getSparkline?: (key: string) => SparklinePoint[];
+}
+
+const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general"] as const;
+const COMPLEXITIES = ["simple", "medium", "complex"] as const;
+
+export function cellKey(taskType: string, complexity: string, provider: string, model: string): string {
+  return `${taskType}:${complexity}:${provider}:${model}`;
+}
+
+function scoreColor(score: number): string {
+  const clamped = Math.max(1, Math.min(5, score));
+  const hue = ((clamped - 1) / 4) * 120;
+  return `hsl(${hue}, 55%, 42%)`;
+}
+
+function Strip({
+  score,
+  maxSamplesInCell,
+  minSamples,
+  pulsing,
+  sparkline,
+}: {
+  score: AdaptiveScore;
+  maxSamplesInCell: number;
+  minSamples: number;
+  pulsing: boolean;
+  sparkline: SparklinePoint[] | undefined;
+}) {
+  const isBelowThreshold = score.sampleCount < minSamples;
+  const opacity = 0.35 + 0.65 * (score.sampleCount / Math.max(maxSamplesInCell, 1));
+  const fillColor = scoreColor(score.qualityScore);
+  const animationStyle = pulsing ? { animation: "adaptive-tick 900ms ease-out" } : {};
+
+  return (
+    <div
+      className="relative group rounded-sm"
+      style={{
+        backgroundColor: fillColor,
+        opacity,
+        borderStyle: isBelowThreshold ? "dashed" : "solid",
+        borderColor: "rgba(0,0,0,0.35)",
+        borderWidth: "1px",
+        ...animationStyle,
+      }}
+    >
+      <div className="flex items-center justify-between px-2 py-1 text-[10px] text-zinc-50 font-mono relative z-10">
+        <span className="truncate pr-1">{score.model}</span>
+        <span className="opacity-90 shrink-0">{score.qualityScore.toFixed(2)}</span>
+      </div>
+      {sparkline && sparkline.length >= 2 && (
+        <div className="absolute inset-0 pointer-events-none opacity-55">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={sparkline} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
+              <YAxis domain={[1, 5]} hide />
+              <Line
+                type="stepAfter"
+                dataKey="qualityScore"
+                stroke="rgba(255,255,255,0.9)"
+                strokeWidth={1.25}
+                dot={false}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      <div className="invisible group-hover:visible absolute bottom-full left-0 z-20 mb-1 bg-zinc-950 border border-zinc-700 rounded p-2 text-[10px] whitespace-nowrap shadow-xl pointer-events-none">
+        <div className="text-zinc-200 font-medium mb-1 font-mono">{score.provider}/{score.model}</div>
+        <div className="text-zinc-400 space-y-0.5">
+          <div>
+            Quality: <span className="text-zinc-200">{score.qualityScore.toFixed(2)}</span>
+          </div>
+          <div>
+            Samples: <span className="text-zinc-200">{score.sampleCount}</span>
+            {isBelowThreshold && <span className="text-amber-400 ml-1">(below threshold)</span>}
+          </div>
+          {score.avgLatencyMs !== undefined && score.avgLatencyMs > 0 && (
+            <div>
+              Avg latency: <span className="text-zinc-200">{score.avgLatencyMs.toFixed(0)}ms</span>
+            </div>
+          )}
+          <div>
+            Cost/1M: <span className="text-zinc-200">${score.costPer1M.toFixed(2)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparkline }: Props) {
+  const cellMap = new Map<string, AdaptiveCell>();
+  for (const c of cells) {
+    cellMap.set(`${c.taskType}:${c.complexity}`, c);
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+      <div className="grid grid-cols-[auto_repeat(3,minmax(0,1fr))]">
+        <div className="border-b border-zinc-800 bg-zinc-950/50" />
+        {COMPLEXITIES.map((cx) => (
+          <div
+            key={cx}
+            className="border-b border-l border-zinc-800 bg-zinc-950/50 px-4 py-2 text-xs font-medium text-zinc-400 capitalize text-center"
+          >
+            {cx}
+          </div>
+        ))}
+
+        {TASK_TYPES.map((tt) => (
+          <React.Fragment key={tt}>
+            <div className="border-b border-zinc-800 px-4 py-3 text-xs font-medium text-zinc-300 capitalize flex items-center">
+              {tt}
+            </div>
+            {COMPLEXITIES.map((cx) => {
+              const cell = cellMap.get(`${tt}:${cx}`);
+              const scores = [...(cell?.scores ?? [])].sort((a, b) => b.qualityScore - a.qualityScore);
+              const maxSamples = scores.reduce((m, s) => Math.max(m, s.sampleCount), 0);
+
+              return (
+                <div
+                  key={`${tt}-${cx}`}
+                  className="border-b border-l border-zinc-800 p-1 min-h-[64px]"
+                >
+                  {scores.length === 0 ? (
+                    <div className="h-full flex items-center justify-center text-[10px] text-zinc-600">
+                      No data
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-0.5">
+                      {scores.map((s) => {
+                        const key = cellKey(tt, cx, s.provider, s.model);
+                        return (
+                          <Strip
+                            key={key}
+                            score={s}
+                            maxSamplesInCell={maxSamples}
+                            minSamples={minSamples}
+                            pulsing={pulsedKeys?.has(key) ?? false}
+                            sparkline={getSparkline?.(key)}
+                          />
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="border-t border-zinc-800 bg-zinc-950/40 px-4 py-2 flex items-center justify-between text-[10px] text-zinc-500">
+        <div className="flex items-center gap-3">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm" style={{ background: scoreColor(1.5) }} />
+            <span>Low</span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm" style={{ background: scoreColor(3) }} />
+            <span>Mid</span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm" style={{ background: scoreColor(4.8) }} />
+            <span>High</span>
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-4 h-3 rounded-sm border border-dashed border-zinc-500" />
+            <span>Below {minSamples} samples</span>
+          </span>
+          <span>Opacity = confidence</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/pipeline-viz.tsx
+++ b/apps/web/src/components/pipeline-viz.tsx
@@ -1,11 +1,10 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ReactFlow,
   Background,
   Controls,
-  MiniMap,
   useNodesState,
   type Node,
   type Edge,
@@ -53,13 +52,30 @@ function PipelineNode({ data }: NodeProps) {
     active: boolean;
     color: string;
     detail?: string;
+    pulseTick?: number;
   };
+
+  const [pulsing, setPulsing] = useState(false);
+  const prevTick = useRef<number | undefined>(d.pulseTick);
+
+  useEffect(() => {
+    if (d.pulseTick === undefined) return;
+    if (prevTick.current === d.pulseTick) return;
+    prevTick.current = d.pulseTick;
+    setPulsing(true);
+    const id = setTimeout(() => setPulsing(false), 900);
+    return () => clearTimeout(id);
+  }, [d.pulseTick]);
 
   const borderColor = d.active ? d.color : "border-zinc-700";
   const bgColor = d.active ? `${d.color.replace("border-", "bg-")}/10` : "bg-zinc-900";
+  const animationStyle = pulsing ? { animation: "adaptive-tick 900ms ease-out" } : undefined;
 
   return (
-    <div className={`px-4 py-3 rounded-xl border-2 ${borderColor} ${bgColor} min-w-[160px] shadow-lg`}>
+    <div
+      className={`px-4 py-3 rounded-xl border-2 ${borderColor} ${bgColor} min-w-[160px] shadow-lg`}
+      style={animationStyle}
+    >
       <Handle type="target" position={Position.Left} className="!bg-zinc-600 !border-zinc-500 !w-2 !h-2" />
       <div className="flex items-center gap-2 mb-1">
         <span className="text-lg">{d.icon}</span>
@@ -91,7 +107,7 @@ function PipelineNode({ data }: NodeProps) {
 
 const nodeTypes = { pipeline: PipelineNode };
 
-function buildNodes(data: PipelineData | null): Node[] {
+function buildNodes(data: PipelineData | null, adaptivePulseTick = 0): Node[] {
   const s = data?.stages;
   return [
     {
@@ -149,6 +165,7 @@ function buildNodes(data: PipelineData | null): Node[] {
         active: s?.adaptive.active ?? false,
         color: "border-emerald-500",
         detail: s?.adaptive.feedbackCount ? `${s.adaptive.feedbackCount} feedback` : undefined,
+        pulseTick: adaptivePulseTick,
       },
     },
     {
@@ -192,16 +209,25 @@ const edges: Edge[] = [
   { id: "e-fb-prv", source: "fallback", target: "provider", animated: true, style: { stroke: "#f59e0b", strokeWidth: 1.5 } },
 ];
 
-export function PipelineVisualization() {
-  const [nodes, setNodes, onNodesChange] = useNodesState(buildNodes(null));
+interface PipelineVisualizationProps {
+  adaptivePulseTick?: number;
+}
+
+export function PipelineVisualization({ adaptivePulseTick = 0 }: PipelineVisualizationProps = {}) {
+  const [nodes, setNodes, onNodesChange] = useNodesState(buildNodes(null, adaptivePulseTick));
+  const [data, setData] = useState<PipelineData | null>(null);
 
   useEffect(() => {
     gatewayClientFetch<PipelineData>("/v1/analytics/pipeline")
       .then((d) => {
-        setNodes(buildNodes(d));
+        setData(d);
       })
       .catch((err) => console.error("Failed to fetch pipeline data:", err));
-  }, [setNodes]);
+  }, []);
+
+  useEffect(() => {
+    setNodes(buildNodes(data, adaptivePulseTick));
+  }, [data, adaptivePulseTick, setNodes]);
 
   return (
     <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden" style={{ height: 400 }}>

--- a/apps/web/src/hooks/use-adaptive-score-buffer.ts
+++ b/apps/web/src/hooks/use-adaptive-score-buffer.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { AdaptiveCell, SparklinePoint } from "../components/adaptive-heatmap";
+
+const BUFFER_CAPACITY = 30;
+const PULSE_WINDOW_MS = 60_000;
+const PULSE_CLEAR_MS = 1_200;
+
+interface UseAdaptiveScoreBufferResult {
+  getSparkline: (key: string) => SparklinePoint[];
+  pulsedKeys: Set<string>;
+  recentUpdateCount: number;
+  pulseTick: number;
+}
+
+function bufferKey(taskType: string, complexity: string, provider: string, model: string): string {
+  return `${taskType}:${complexity}:${provider}:${model}`;
+}
+
+export function useAdaptiveScoreBuffer(cells: AdaptiveCell[]): UseAdaptiveScoreBufferResult {
+  const [buffers, setBuffers] = useState<Map<string, SparklinePoint[]>>(() => new Map());
+  const [pulsedKeys, setPulsedKeys] = useState<Set<string>>(() => new Set());
+  const [recentUpdateCount, setRecentUpdateCount] = useState(0);
+  const [pulseTick, setPulseTick] = useState(0);
+  const prevSampleCounts = useRef<Map<string, number>>(new Map());
+  const updateLog = useRef<Array<{ key: string; timestamp: number }>>([]);
+
+  useEffect(() => {
+    const now = Date.now();
+    let buffersChanged = false;
+    const nextBuffers = new Map(buffers);
+    const nextPulsed = new Set<string>();
+    const nextPrev = new Map(prevSampleCounts.current);
+
+    for (const cell of cells) {
+      for (const score of cell.scores) {
+        const key = bufferKey(cell.taskType, cell.complexity, score.provider, score.model);
+        const prevCount = prevSampleCounts.current.get(key);
+        const firstSeen = prevCount === undefined;
+        const sampleIncreased = !firstSeen && score.sampleCount > prevCount;
+
+        if (firstSeen || sampleIncreased) {
+          const existing = nextBuffers.get(key) ?? [];
+          const next = existing.concat({ timestamp: now, qualityScore: score.qualityScore });
+          if (next.length > BUFFER_CAPACITY) next.shift();
+          nextBuffers.set(key, next);
+          buffersChanged = true;
+        }
+
+        if (sampleIncreased) {
+          nextPulsed.add(key);
+          updateLog.current.push({ key, timestamp: now });
+        }
+
+        nextPrev.set(key, score.sampleCount);
+      }
+    }
+
+    prevSampleCounts.current = nextPrev;
+    if (buffersChanged) setBuffers(nextBuffers);
+    if (nextPulsed.size > 0) {
+      setPulsedKeys(nextPulsed);
+      setPulseTick((n) => n + 1);
+    }
+
+    updateLog.current = updateLog.current.filter((e) => now - e.timestamp <= PULSE_WINDOW_MS);
+    setRecentUpdateCount(updateLog.current.length);
+  }, [cells]);
+
+  useEffect(() => {
+    if (pulsedKeys.size === 0) return;
+    const id = setTimeout(() => setPulsedKeys(new Set()), PULSE_CLEAR_MS);
+    return () => clearTimeout(id);
+  }, [pulsedKeys]);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const now = Date.now();
+      updateLog.current = updateLog.current.filter((e) => now - e.timestamp <= PULSE_WINDOW_MS);
+      setRecentUpdateCount(updateLog.current.length);
+    }, 5_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return {
+    getSparkline: (key: string) => buffers.get(key) ?? [],
+    pulsedKeys,
+    recentUpdateCount,
+    pulseTick,
+  };
+}


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 57
branch: issue/57-adaptive-viz
status: resolved
updated_at: 2026-04-16T20:56:03Z
review_status: awaiting-review
-->

## Summary

Three adaptive-routing visualizations that make the live learning loop legible at a glance on the Quality and Routing pages. The existing `AdaptiveMatrix` (one winning model per cell as text) is replaced by a live heatmap grid with per-model strips, sparklines inside each strip, and a pulse on every feedback-driven score update. The Routing page's React Flow pipeline gets a matching tick on its Adaptive node plus a "N updates in last 60s" counter next to the canvas.

Closes #57

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Changes Made

**Commits:**
- `dbdb815` feat(#57): adaptive routing heatmap with live sparklines (T1, T2)
- `b082ed7` feat(#57/T3): pipeline adaptive-node pulse and 60s update counter

**New files:**
- `apps/web/src/components/adaptive-heatmap.tsx` — heatmap grid, strips, tooltip, sparkline slot, legend.
- `apps/web/src/hooks/use-adaptive-score-buffer.ts` — 30-sample rolling buffer keyed by `(cell, provider, model)`; exposes `getSparkline`, `pulsedKeys`, `pulseTick`, `recentUpdateCount`.

**Modified:**
- `apps/web/src/app/dashboard/quality/page.tsx` — swapped `AdaptiveMatrix` → `AdaptiveHeatmap`, added 10s polling of `/v1/analytics/adaptive/scores`, wired the buffer hook.
- `apps/web/src/app/dashboard/routing/page.tsx` — added adaptive polling, shared hook, passed `pulseTick` into the pipeline, added the counter in the section header.
- `apps/web/src/components/pipeline-viz.tsx` — `PipelineNode` now watches `data.pulseTick` and flashes the `adaptive-tick` keyframe; `PipelineVisualization` accepts an `adaptivePulseTick` prop and threads it through the Adaptive node's data.
- `apps/web/src/app/globals.css` — added `@keyframes adaptive-tick` (a one-shot emerald-400 box-shadow ripple, ~900ms).

## Journey Timeline

### Initial Plan
Per issue #57: make the live learning shipped in #49 *visible*. The Quality page had an `AdaptiveMatrix` widget showing one winning model per cell as a bar — no indication of candidates, confidence, or real-time behavior.

### What We Discovered
- The existing `AdaptiveMatrix` and the `/v1/analytics/adaptive/scores` endpoint already returned the nested `{cells: [{taskType, complexity, scores: ModelScore[]}]}` shape we needed — no backend changes.
- Each page needed its own poll loop because `AdaptiveMatrix`'s original fetch only ran once on mount. Kept the hook pluggable so both Quality and Routing share one buffer implementation with one poll stream per page.
- CSS animation re-triggering via React state transitions is brittle. Solved with a `pulseTick` counter from the hook (increments on every new pulse observation) and a ref-gated `useEffect` in `PipelineNode` that flips `pulsing` true for 900ms on each tick bump. Heatmap strips use the same trick — apply the inline `animation` style only while the key is in `pulsedKeys`, with a 1.2s timeout in the hook that clears the set to force a clean next-pulse transition.

### Implementation Issues
- **Visual verification is pending.** See Testing below. This is a genuine gap, not a claim of completeness.

### Key Decisions Made

| Decision | Choice | Why |
|----------|--------|-----|
| Option 2 depth (sparklines persistence) | Client-side rolling buffer, ephemeral across refresh | User picked light path; persisted history deferred to a potential follow-up |
| Strip layout inside each cell | Vertical stack of strips, sorted by qualityScore desc | Winning model always on top; readable at small cell sizes |
| Color scheme | HSL red→yellow→green on `(qualityScore - 1) / 4 * 120°` | Smooth gradient that scales to any score distribution; matches the existing emerald/yellow/red palette used in `ScoreBar` |
| Below-threshold styling | Dashed outline on strips with `sampleCount < 5` | Reader sees exactly which cells the router isn't using adaptively yet |
| Poll cadence | 10s on each page | Matches the main dashboard pattern per project memory; not so fast that empty deployments burn DB reads |
| Pulse animation mechanism | `@keyframes adaptive-tick` + `pulseTick` counter, not Tailwind `animate-pulse` | One-shot ripple, not continuous; avoids fighting Tailwind's default pulse timing |

## Testing

- [x] `npx tsc --noEmit` in `apps/web/` — clean, zero errors across all touched files.
- [x] Logical round-trip review: hook behavior hand-traced against the `updateScore` event shape from #49 (sampleCount monotonically increases per feedback; hook detects the delta and pulses + buffers).
- [ ] **Visual verification in a browser: NOT RUN.** Dev server requires the full provider stack to be configured and real feedback events to drive the live behavior. The visual-design choices (strip sizes, sparkline legibility against colored fills, pulse timing against the React Flow node border, counter placement) are educated guesses and the first honest review will almost certainly find one or two "move this / change that" items. Flagging this explicitly rather than claiming completeness.

**Recommended manual test path once someone runs `npx turbo dev`:**
1. Open `/dashboard/quality` — confirm the grid renders with one strip per model per cell, color/opacity/dashed-outline states all distinct.
2. Hover a strip — tooltip shows provider/model + quality/samples/latency/cost.
3. In another terminal, hit `POST /v1/feedback` a few times for an existing request — within 10s, the matching strip should briefly pulse and its sparkline should grow a new point.
4. Open `/dashboard/routing` — confirm the Adaptive node pulses on the same feedback events and the counter increments.

## Stacked PRs / Related

- Parent feature: #49 (live feedback learning)
- Considered deferral: persisted `model_score_history` table for refresh-surviving sparklines — natural follow-up if ephemeral proves limiting.

## Knowledge for Future Reference

- `useAdaptiveScoreBuffer` is a general primitive for any adaptive-router visualization. It watches score updates, not raw feedback events, and only writes a new buffer point when `sampleCount` actually bumps — so polling while idle doesn't inflate the sparkline with flat samples.
- The `@keyframes adaptive-tick` is defined once in `globals.css` and reused by both the heatmap strips and the pipeline node. If you want a different "beat" for each, fork the keyframe.
- Each page owns its own poll loop for `/v1/analytics/adaptive/scores`. If we ever add a third consumer, extract the polling into a context provider to avoid N poll streams per page session.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
