### PR TITLE
fix(#59): UAT tooltip and bar-chart cursor polish

### DIFF
--- a/apps/web/src/app/dashboard/analytics/page.tsx
+++ b/apps/web/src/app/dashboard/analytics/page.tsx
@@ -221,7 +221,7 @@ export default function AnalyticsPage() {
                   <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
                   <XAxis dataKey="bucket" tick={{ fontSize: 10, fill: "#71717a" }} />
                   <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickFormatter={(v) => `$${v}`} />
-                  <Tooltip content={<ChartTooltip />} />
+                  <Tooltip content={<ChartTooltip />} cursor={false} />
                   <Legend wrapperStyle={{ fontSize: 11 }} />
                   {providers.map((p) => (
                     <Bar key={p} dataKey={p} name={p} stackId="cost" fill={getProviderColor(p)} />

--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -37,10 +37,10 @@ export function cellKey(taskType: string, complexity: string, provider: string, 
   return `${taskType}:${complexity}:${provider}:${model}`;
 }
 
-function scoreColor(score: number): string {
+function scoreColor(score: number, alpha = 1): string {
   const clamped = Math.max(1, Math.min(5, score));
   const hue = ((clamped - 1) / 4) * 120;
-  return `hsl(${hue}, 55%, 42%)`;
+  return `hsla(${hue}, 55%, 42%, ${alpha})`;
 }
 
 function Strip({
@@ -49,24 +49,26 @@ function Strip({
   minSamples,
   pulsing,
   sparkline,
+  rowIndex,
 }: {
   score: AdaptiveScore;
   maxSamplesInCell: number;
   minSamples: number;
   pulsing: boolean;
   sparkline: SparklinePoint[] | undefined;
+  rowIndex: number;
 }) {
   const isBelowThreshold = score.sampleCount < minSamples;
-  const opacity = 0.35 + 0.65 * (score.sampleCount / Math.max(maxSamplesInCell, 1));
-  const fillColor = scoreColor(score.qualityScore);
+  const confidenceAlpha = 0.35 + 0.65 * (score.sampleCount / Math.max(maxSamplesInCell, 1));
+  const fillColor = scoreColor(score.qualityScore, confidenceAlpha);
   const animationStyle = pulsing ? { animation: "adaptive-tick 900ms ease-out" } : {};
+  const tooltipPositionClass = rowIndex === 0 ? "top-full mt-1" : "bottom-full mb-1";
 
   return (
     <div
       className="relative group rounded-sm"
       style={{
         backgroundColor: fillColor,
-        opacity,
         borderStyle: isBelowThreshold ? "dashed" : "solid",
         borderColor: "rgba(0,0,0,0.35)",
         borderWidth: "1px",
@@ -95,7 +97,7 @@ function Strip({
         </div>
       )}
 
-      <div className="invisible group-hover:visible absolute bottom-full left-0 z-20 mb-1 bg-zinc-950 border border-zinc-700 rounded p-2 text-[10px] whitespace-nowrap shadow-xl pointer-events-none">
+      <div className={`invisible group-hover:visible absolute ${tooltipPositionClass} left-0 z-20 bg-zinc-950 border border-zinc-700 rounded p-2 text-[10px] whitespace-nowrap shadow-xl pointer-events-none`}>
         <div className="text-zinc-200 font-medium mb-1 font-mono">{score.provider}/{score.model}</div>
         <div className="text-zinc-400 space-y-0.5">
           <div>
@@ -138,7 +140,7 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
           </div>
         ))}
 
-        {TASK_TYPES.map((tt) => (
+        {TASK_TYPES.map((tt, rowIndex) => (
           <React.Fragment key={tt}>
             <div className="border-b border-zinc-800 px-4 py-3 text-xs font-medium text-zinc-300 capitalize flex items-center">
               {tt}
@@ -169,6 +171,7 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
                             minSamples={minSamples}
                             pulsing={pulsedKeys?.has(key) ?? false}
                             sparkline={getSparkline?.(key)}
+                            rowIndex={rowIndex}
                           />
                         );
                       })}


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 59
branch: issue/59-uat-fixes
status: resolved
updated_at: 2026-04-16T21:08:01Z
review_status: awaiting-review
-->

## Summary

Three UI polish fixes from UAT: two on the `AdaptiveHeatmap` shipped in #57, one pre-existing on the Analytics page's Cost Over Time bar chart.

Closes #59

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Reviewed commit:** n/a
- **Needs re-review since:** no

## Changes Made

- `18ef914` fix(#59): adaptive heatmap tooltip opacity and boundary clipping (T1, T2)
- `707b645` fix(#59/T3): disable BarChart cursor on Cost Over Time

**Diffs:** +11/-8 across two files.

## Root causes and fixes

| # | Symptom | Root cause | Fix |
|---|---------|-----------|-----|
| T1 | Tooltip text washed out on low-confidence strips | CSS `opacity` on the wrapper inherited to children including the tooltip | Move confidence dimming into the fill's HSLA alpha; wrapper stays at opacity 1 |
| T2 | Tooltip on top-row strips (coding) clipped by `overflow-hidden` | Tooltip anchored with `bottom-full` above strip; top row's "above" lands outside the grid | Pass `rowIndex` from grid to Strip; row 0 uses `top-full mt-1` (below), others keep `bottom-full mb-1` |
| T3 | White background flash behind bars on Cost Over Time hover | Recharts `<BarChart>` default cursor rectangle | `cursor={false}` on the chart's `<Tooltip>` |

## Testing

- [x] `npx tsc --noEmit` — clean.
- [ ] **Visual verification in a browser: not run in this session.** Each fix has a clear expected behavior described in the issue; recommended manual checks:
  1. Hover a sparse strip (e.g. one with `sampleCount < 5`) — tooltip body is fully readable.
  2. Hover any strip in the "coding" row — tooltip appears *below* and is fully visible.
  3. Hover a stacked bar on Cost Over Time — only the tooltip floats in; no light rectangle behind the bar.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
