### PR TITLE
fix(#61): heatmap outlines + restore confidence gradient

### DIFF
--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -37,10 +37,10 @@ export function cellKey(taskType: string, complexity: string, provider: string, 
   return `${taskType}:${complexity}:${provider}:${model}`;
 }
 
-function scoreColor(score: number, alpha = 1): string {
+function scoreColor(score: number): string {
   const clamped = Math.max(1, Math.min(5, score));
   const hue = ((clamped - 1) / 4) * 120;
-  return `hsla(${hue}, 55%, 42%, ${alpha})`;
+  return `hsl(${hue}, 55%, 42%)`;
 }
 
 function Strip({
@@ -59,8 +59,8 @@ function Strip({
   rowIndex: number;
 }) {
   const isBelowThreshold = score.sampleCount < minSamples;
-  const confidenceAlpha = 0.35 + 0.65 * (score.sampleCount / Math.max(maxSamplesInCell, 1));
-  const fillColor = scoreColor(score.qualityScore, confidenceAlpha);
+  const confidenceOpacity = 0.35 + 0.65 * (score.sampleCount / Math.max(maxSamplesInCell, 1));
+  const fillColor = scoreColor(score.qualityScore);
   const animationStyle = pulsing ? { animation: "adaptive-tick 900ms ease-out" } : {};
   const tooltipPositionClass = rowIndex === 0 ? "top-full mt-1" : "bottom-full mb-1";
 
@@ -68,19 +68,23 @@ function Strip({
     <div
       className="relative group rounded-sm"
       style={{
-        backgroundColor: fillColor,
         borderStyle: isBelowThreshold ? "dashed" : "solid",
-        borderColor: "rgba(0,0,0,0.35)",
+        borderColor: "rgba(255,255,255,0.6)",
         borderWidth: "1px",
         ...animationStyle,
       }}
     >
+      <div
+        aria-hidden
+        className="absolute inset-0 rounded-sm pointer-events-none"
+        style={{ backgroundColor: fillColor, opacity: confidenceOpacity }}
+      />
       <div className="flex items-center justify-between px-2 py-1 text-[10px] text-zinc-50 font-mono relative z-10">
         <span className="truncate pr-1">{score.model}</span>
         <span className="opacity-90 shrink-0">{score.qualityScore.toFixed(2)}</span>
       </div>
       {sparkline && sparkline.length >= 2 && (
-        <div className="absolute inset-0 pointer-events-none opacity-55">
+        <div className="absolute inset-0 pointer-events-none opacity-55 z-[5]">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={sparkline} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
               <YAxis domain={[1, 5]} hide />


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 61
branch: issue/61-heatmap-outline-and-opacity
status: resolved
updated_at: 2026-04-16T21:15:30Z
review_status: awaiting-review
-->

## Summary

Two UAT follow-ups to #59/T1's tooltip-opacity fix: strip outlines were invisible (black on near-black), and the confidence gradient on the bars themselves was too subtle to read after the HSLA-alpha swap. Both addressed by restructuring the strip so fill has its own layer with real opacity, and lightening the border color.

Closes #61

## Review Status

- **Current state:** awaiting review
- **Needs re-review since:** no

## Changes Made

- `3512cf0` fix(#61): restore heatmap confidence gradient + visible outlines

**Diff:** +11/-7 on `apps/web/src/components/adaptive-heatmap.tsx`.

## Fix details

| # | Symptom | Root cause | Fix |
|---|---------|-----------|-----|
| T1 | Dashed vs. solid outlines indistinguishable | `borderColor: rgba(0,0,0,0.35)` — black on near-black parent | `rgba(255,255,255,0.6)` |
| T2 | Confidence gradient on bars invisible | #59/T1 moved opacity into HSLA fill alpha; too subtle against dark parent | Split fill into its own `absolute inset-0` layer with real `opacity` prop; tooltip remains a sibling so stays at 1.0 |

`scoreColor` reverted to plain HSL; no longer takes an alpha parameter.

## Testing

- [x] `npx tsc --noEmit` — clean.
- [ ] **Visual verification in a browser: not run.** Manual checks:
  1. Dashed outlines on below-threshold strips are clearly dashed (not just "a slightly different edge").
  2. Low-confidence strips look visibly dimmer than high-confidence strips in the same cell.
  3. Tooltip content on a low-confidence strip is still crisp at full opacity.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
