### PR TITLE
feat(#63): promote 10px text floor to 12px

### DIFF
--- a/apps/web/src/app/dashboard/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/alerts/page.tsx
@@ -284,7 +284,7 @@ export default function AlertsPage() {
                   </div>
                   <div className="flex items-center gap-4">
                     {rule.webhookUrl && (
-                      <span className="text-[10px] px-2 py-0.5 rounded bg-zinc-800 text-zinc-400 border border-zinc-700">webhook</span>
+                      <span className="text-xs px-2 py-0.5 rounded bg-zinc-800 text-zinc-400 border border-zinc-700">webhook</span>
                     )}
                     <span className="text-xs text-zinc-500">
                       Last fired: {formatTimestamp(rule.lastTriggeredAt)}

--- a/apps/web/src/app/dashboard/analytics/page.tsx
+++ b/apps/web/src/app/dashboard/analytics/page.tsx
@@ -206,8 +206,8 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <AreaChart data={timeseries.map((t) => ({ ...t, bucket: formatBucket(t.bucket) }))}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                  <XAxis dataKey="bucket" tick={{ fontSize: 10, fill: "#71717a" }} />
-                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} />
+                  <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: "#71717a" }} />
+                  <YAxis tick={{ fontSize: 11, fill: "#71717a" }} />
                   <Tooltip content={<ChartTooltip />} />
                   <Area type="monotone" dataKey="requestCount" name="Requests" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.15} />
                 </AreaChart>
@@ -219,8 +219,8 @@ export default function AnalyticsPage() {
               <ResponsiveContainer width="100%" height={240}>
                 <BarChart data={costPivot.map((c) => ({ ...c, bucket: formatBucket(String(c.bucket)) }))}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                  <XAxis dataKey="bucket" tick={{ fontSize: 10, fill: "#71717a" }} />
-                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickFormatter={(v) => `$${v}`} />
+                  <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: "#71717a" }} />
+                  <YAxis tick={{ fontSize: 11, fill: "#71717a" }} tickFormatter={(v) => `$${v}`} />
                   <Tooltip content={<ChartTooltip />} cursor={false} />
                   <Legend wrapperStyle={{ fontSize: 11 }} />
                   {providers.map((p) => (
@@ -237,8 +237,8 @@ export default function AnalyticsPage() {
             <ResponsiveContainer width="100%" height={280}>
               <LineChart data={timeseries.map((t) => ({ ...t, bucket: formatBucket(t.bucket) }))}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                <XAxis dataKey="bucket" tick={{ fontSize: 10, fill: "#71717a" }} />
-                <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickFormatter={(v) => `${v}ms`} />
+                <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: "#71717a" }} />
+                <YAxis tick={{ fontSize: 11, fill: "#71717a" }} tickFormatter={(v) => `${v}ms`} />
                 <Tooltip content={<ChartTooltip />} />
                 <Legend wrapperStyle={{ fontSize: 11 }} />
                 <Line type="monotone" dataKey="p50Latency" name="p50" stroke="#34d399" strokeWidth={2} dot={false} />
@@ -272,7 +272,7 @@ export default function AnalyticsPage() {
                       <tr key={`${m.provider}/${m.model}`} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
                         <td className="px-6 py-3">
                           <div className="flex items-center gap-2">
-                            <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${BADGE_COLORS[m.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"}`}>
+                            <span className={`px-1.5 py-0.5 rounded text-xs font-medium border ${BADGE_COLORS[m.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"}`}>
                               {m.provider}
                             </span>
                             <span className="font-mono text-xs text-zinc-300">{m.model}</span>

--- a/apps/web/src/app/dashboard/logs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/logs/[id]/page.tsx
@@ -242,7 +242,7 @@ export default function RequestDetailPage() {
           <div>
             <p className="text-xs text-zinc-500 mb-1">Provider / Model</p>
             <div className="flex items-center gap-2">
-              <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${PROVIDER_COLORS[request.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"}`}>
+              <span className={`px-1.5 py-0.5 rounded text-xs font-medium border ${PROVIDER_COLORS[request.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"}`}>
                 {request.provider}
               </span>
               <span className="text-sm font-mono text-zinc-300">{request.model}</span>
@@ -329,7 +329,7 @@ export default function RequestDetailPage() {
                 : "bg-zinc-900 border-zinc-800"
             }`}
           >
-            <p className={`text-[10px] font-semibold uppercase tracking-widest mb-2 ${
+            <p className={`text-xs font-semibold uppercase tracking-widest mb-2 ${
               msg.role === "user" ? "text-blue-400" : msg.role === "assistant" ? "text-emerald-400" : "text-zinc-500"
             }`}>
               {msg.role}
@@ -346,7 +346,7 @@ export default function RequestDetailPage() {
         <div className="space-y-3">
           <h2 className="text-sm font-semibold text-zinc-400">Response</h2>
           <div className="bg-zinc-900 border border-emerald-900/30 rounded-lg p-4">
-            <p className="text-[10px] font-semibold uppercase tracking-widest mb-2 text-emerald-400">
+            <p className="text-xs font-semibold uppercase tracking-widest mb-2 text-emerald-400">
               assistant
             </p>
             <pre className="text-sm text-zinc-300 whitespace-pre-wrap font-sans leading-relaxed">
@@ -473,7 +473,7 @@ export default function RequestDetailPage() {
                     Diff
                   </button>
                 </div>
-                <div className="flex gap-4 text-[10px] text-zinc-500">
+                <div className="flex gap-4 text-xs text-zinc-500">
                   <span>Original: {request.latencyMs}ms, {request.inputTokens}/{request.outputTokens} tok, {formatCost(request.cost)}</span>
                   <span>Replay: {replayResult.latencyMs}ms, {replayResult.inputTokens}/{replayResult.outputTokens} tok</span>
                 </div>
@@ -511,7 +511,7 @@ export default function RequestDetailPage() {
                       replay={replayResult.content}
                     />
                   </div>
-                  <div className="flex gap-4 mt-2 text-[10px] text-zinc-600">
+                  <div className="flex gap-4 mt-2 text-xs text-zinc-600">
                     <span className="flex items-center gap-1">
                       <span className="inline-block w-3 h-2 rounded-sm bg-red-900/40 border border-red-800/30" />
                       Removed from original

--- a/apps/web/src/app/dashboard/logs/page.tsx
+++ b/apps/web/src/app/dashboard/logs/page.tsx
@@ -209,7 +209,7 @@ export default function LogsPage() {
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
                       <span
-                        className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+                        className={`px-1.5 py-0.5 rounded text-xs font-medium border ${
                           PROVIDER_COLORS[r.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"
                         }`}
                       >
@@ -221,12 +221,12 @@ export default function LogsPage() {
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-1.5">
                       {r.taskType && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 border border-zinc-700">
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 border border-zinc-700">
                           {r.taskType}
                         </span>
                       )}
                       {r.complexity && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-500 border border-zinc-700/50">
+                        <span className="text-xs px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-500 border border-zinc-700/50">
                           {r.complexity}
                         </span>
                       )}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -141,7 +141,7 @@ export default function Dashboard() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
       <div className="flex items-center gap-3">
         <h1 className="text-2xl font-bold">Dashboard</h1>
-        <span className="flex items-center gap-1.5 text-[10px] text-zinc-600">
+        <span className="flex items-center gap-1.5 text-xs text-zinc-600">
           <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
           Live
         </span>

--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -305,7 +305,7 @@ export default function PlaygroundPage() {
               <>{showDivider && (
                 <div className="flex items-center gap-3 py-2">
                   <div className="flex-1 h-px bg-zinc-800" />
-                  <span className="text-[10px] text-zinc-600 uppercase tracking-widest">New topic</span>
+                  <span className="text-xs text-zinc-600 uppercase tracking-widest">New topic</span>
                   <div className="flex-1 h-px bg-zinc-800" />
                 </div>
               )}
@@ -320,7 +320,7 @@ export default function PlaygroundPage() {
                   }`}
                 >
                   {msg.model && !isGuardrail && (
-                    <p className="text-[10px] text-zinc-500 mb-1.5 font-mono">{msg.model}</p>
+                    <p className="text-xs text-zinc-500 mb-1.5 font-mono">{msg.model}</p>
                   )}
                   <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
                 </div>

--- a/apps/web/src/app/dashboard/prompts/page.tsx
+++ b/apps/web/src/app/dashboard/prompts/page.tsx
@@ -204,7 +204,7 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
             {template.description && <p className="text-xs text-zinc-500 mt-0.5">{template.description}</p>}
           </div>
           <div className="flex items-center gap-3">
-            <code className="text-[10px] text-zinc-600 bg-zinc-800 px-2 py-1 rounded font-mono">
+            <code className="text-xs text-zinc-600 bg-zinc-800 px-2 py-1 rounded font-mono">
               /v1/admin/prompts/resolve/{template.name}
             </code>
             <button onClick={handleDelete} className="px-3 py-1 bg-red-900/50 hover:bg-red-800/50 text-red-300 rounded text-xs">Delete</button>
@@ -229,7 +229,7 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-semibold">v{v.version}</span>
                       {isPublished && (
-                        <span className="text-[10px] px-2 py-0.5 rounded bg-emerald-900/50 text-emerald-300 border border-emerald-800/50">Published</span>
+                        <span className="text-xs px-2 py-0.5 rounded bg-emerald-900/50 text-emerald-300 border border-emerald-800/50">Published</span>
                       )}
                       {v.note && <span className="text-xs text-zinc-500">— {v.note}</span>}
                     </div>
@@ -250,7 +250,7 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
                   <div className="space-y-2">
                     {messages.map((msg, i) => (
                       <div key={i} className="bg-zinc-800/50 rounded p-3">
-                        <p className={`text-[10px] font-semibold uppercase tracking-widest mb-1 ${
+                        <p className={`text-xs font-semibold uppercase tracking-widest mb-1 ${
                           msg.role === "user" ? "text-blue-400" : msg.role === "assistant" ? "text-emerald-400" : "text-zinc-500"
                         }`}>{msg.role}</p>
                         <pre className="text-xs text-zinc-300 whitespace-pre-wrap font-sans">{msg.content}</pre>
@@ -260,9 +260,9 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
 
                   {variables.length > 0 && (
                     <div className="flex items-center gap-2">
-                      <span className="text-[10px] text-zinc-600">Variables:</span>
+                      <span className="text-xs text-zinc-600">Variables:</span>
                       {variables.map((v) => (
-                        <span key={v} className="text-[10px] px-1.5 py-0.5 rounded bg-blue-900/30 text-blue-300 border border-blue-800/50 font-mono">{`{{${v}}}`}</span>
+                        <span key={v} className="text-xs px-1.5 py-0.5 rounded bg-blue-900/30 text-blue-300 border border-blue-800/50 font-mono">{`{{${v}}}`}</span>
                       ))}
                     </div>
                   )}
@@ -331,12 +331,12 @@ export default function PromptsPage() {
             >
               <div className="flex items-center justify-between">
                 <h3 className="font-semibold text-sm">{t.name}</h3>
-                <span className="text-[10px] text-zinc-600 bg-zinc-800 px-2 py-0.5 rounded">
+                <span className="text-xs text-zinc-600 bg-zinc-800 px-2 py-0.5 rounded">
                   v{t.latestVersion} ({t.versionCount} ver{t.versionCount !== 1 ? "s" : ""})
                 </span>
               </div>
               {t.description && <p className="text-xs text-zinc-500">{t.description}</p>}
-              <div className="flex items-center justify-between text-[10px] text-zinc-600">
+              <div className="flex items-center justify-between text-xs text-zinc-600">
                 <span>Created {formatDate(t.createdAt)}</span>
                 <span>Updated {formatDate(t.updatedAt)}</span>
               </div>

--- a/apps/web/src/app/dashboard/quality/page.tsx
+++ b/apps/web/src/app/dashboard/quality/page.tsx
@@ -232,8 +232,8 @@ export default function QualityPage() {
           <ResponsiveContainer width="100%" height={240}>
             <LineChart data={trend.map((t) => ({ ...t, bucket: formatBucket(t.bucket) }))}>
               <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-              <XAxis dataKey="bucket" tick={{ fontSize: 10, fill: "#71717a" }} />
-              <YAxis domain={[0, 5]} tick={{ fontSize: 10, fill: "#71717a" }} />
+              <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: "#71717a" }} />
+              <YAxis domain={[0, 5]} tick={{ fontSize: 11, fill: "#71717a" }} />
               <Tooltip content={<ChartTooltip />} />
               <Legend wrapperStyle={{ fontSize: 11 }} />
               <Line type="monotone" dataKey="avgScore" name="Avg Score" stroke="#34d399" strokeWidth={2} dot={false} />
@@ -277,7 +277,7 @@ export default function QualityPage() {
                 onChange={(e) => setJudgeConfigState({ ...judgeConfig, sampleRate: parseInt(e.target.value) / 100 })}
                 className="w-full accent-blue-500"
               />
-              <div className="flex justify-between text-[10px] text-zinc-600 mt-1">
+              <div className="flex justify-between text-xs text-zinc-600 mt-1">
                 <span>0%</span>
                 <span>50%</span>
                 <span>100%</span>

--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -79,7 +79,7 @@ function Strip({
         className="absolute inset-0 rounded-sm pointer-events-none"
         style={{ backgroundColor: fillColor, opacity: confidenceOpacity }}
       />
-      <div className="flex items-center justify-between px-2 py-1 text-[10px] text-zinc-50 font-mono relative z-10">
+      <div className="flex items-center justify-between px-2 py-1 text-xs text-zinc-50 font-mono relative z-10">
         <span className="truncate pr-1">{score.model}</span>
         <span className="opacity-90 shrink-0">{score.qualityScore.toFixed(2)}</span>
       </div>
@@ -101,7 +101,7 @@ function Strip({
         </div>
       )}
 
-      <div className={`invisible group-hover:visible absolute ${tooltipPositionClass} left-0 z-20 bg-zinc-950 border border-zinc-700 rounded p-2 text-[10px] whitespace-nowrap shadow-xl pointer-events-none`}>
+      <div className={`invisible group-hover:visible absolute ${tooltipPositionClass} left-0 z-20 bg-zinc-950 border border-zinc-700 rounded p-2 text-xs whitespace-nowrap shadow-xl pointer-events-none`}>
         <div className="text-zinc-200 font-medium mb-1 font-mono">{score.provider}/{score.model}</div>
         <div className="text-zinc-400 space-y-0.5">
           <div>
@@ -160,7 +160,7 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
                   className="border-b border-l border-zinc-800 p-1 min-h-[64px]"
                 >
                   {scores.length === 0 ? (
-                    <div className="h-full flex items-center justify-center text-[10px] text-zinc-600">
+                    <div className="h-full flex items-center justify-center text-xs text-zinc-600">
                       No data
                     </div>
                   ) : (
@@ -187,7 +187,7 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
           </React.Fragment>
         ))}
       </div>
-      <div className="border-t border-zinc-800 bg-zinc-950/40 px-4 py-2 flex items-center justify-between text-[10px] text-zinc-500">
+      <div className="border-t border-zinc-800 bg-zinc-950/40 px-4 py-2 flex items-center justify-between text-xs text-zinc-500">
         <div className="flex items-center gap-3">
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-3 h-3 rounded-sm" style={{ background: scoreColor(1.5) }} />

--- a/apps/web/src/components/dashboard-nav.tsx
+++ b/apps/web/src/components/dashboard-nav.tsx
@@ -176,7 +176,7 @@ export function DashboardNav() {
       <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-6">
         {navGroups.map((group) => (
           <div key={group.label}>
-            <p className="px-2 mb-2 text-[10px] font-semibold uppercase tracking-widest text-zinc-600">
+            <p className="px-2 mb-2 text-xs font-semibold uppercase tracking-widest text-zinc-600">
               {group.label}
             </p>
             <div className="space-y-0.5">


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 63
branch: issue/63-text-floor
status: resolved
updated_at: 2026-04-16T21:27:00Z
review_status: awaiting-review
-->

## Summary

Promotes the dashboard's text floor from 10px to 12px. `text-[10px]` → `text-xs` across 10 files; recharts `fontSize: 10` → `fontSize: 11` on chart ticks. Everything else left alone.

Closes #63

## Review Status

- **Current state:** awaiting review
- **Needs re-review since:** no

## Changes Made

- `276ae2c` feat(#63/T1): promote 10px text floor to 12px across the dashboard

**Diff:** +34/-34 across 10 files (pure symmetric replacement).

## Files touched

| File | Changes |
|------|---------|
| `apps/web/src/components/adaptive-heatmap.tsx` | 4 × `text-[10px]` → `text-xs` |
| `apps/web/src/components/dashboard-nav.tsx` | 1 |
| `apps/web/src/app/dashboard/page.tsx` | 1 |
| `apps/web/src/app/dashboard/logs/page.tsx` | 3 |
| `apps/web/src/app/dashboard/logs/[id]/page.tsx` | 5 |
| `apps/web/src/app/dashboard/playground/page.tsx` | 2 |
| `apps/web/src/app/dashboard/prompts/page.tsx` | 7 |
| `apps/web/src/app/dashboard/alerts/page.tsx` | 1 |
| `apps/web/src/app/dashboard/quality/page.tsx` | 1 × `text-[10px]` + 2 × `fontSize: 10` → `fontSize: 11` |
| `apps/web/src/app/dashboard/analytics/page.tsx` | 1 × `text-[10px]` + 6 × `fontSize: 10` → `fontSize: 11` |

## Testing

- [x] `npx tsc --noEmit` — clean.
- [x] Post-sweep grep: zero remaining `text-[10px]` and zero remaining `fontSize: 10` in chart tick props.
- [ ] **Visual verification: not run.** Most likely spots to check for layout regressions:
  1. Heatmap strips — the model-name + score label is the tightest fit; cell min-height may want a small bump if text now wraps.
  2. Analytics chart tick labels — 11px is a modest bump and should be fine, but worth confirming nothing overlaps.
  3. Dashboard nav — one occurrence; low risk.

## Out of scope

- Promoting `text-xs` (12px) → `text-sm` (14px). Requires real UAT before committing.
- Line-height tuning, table row density, cell min-heights.
- The single `text-[11px]` on the tokens-page code snippet.

---
Authored-by: claude/opus-4.7 (claude-code)
Last-code-by: claude/opus-4.7 (claude-code)
*Captain's log - PR timeline by [shiplog](https://github.com/devallibus/shiplog)*
