### PR TITLE
feat(#69): judge observability + playground feedback buttons

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -12,6 +12,8 @@ interface Message {
   role: "system" | "user" | "assistant";
   content: string;
   model?: string;
+  requestId?: string;
+  feedback?: "up" | "down";
 }
 
 interface ProvaraMetadata {
@@ -142,6 +144,7 @@ export default function PlaygroundPage() {
 
       // Read model info from response headers
       const headerModel = res.headers.get("X-Provara-Model") || "";
+      const requestId = res.headers.get("X-Provara-Request-Id") || undefined;
 
       // Check for guardrail violations
       const guardrailHeader = res.headers.get("X-Provara-Guardrail");
@@ -192,7 +195,7 @@ export default function PlaygroundPage() {
         }
       }
 
-      const finalMessages = [...newMessages, { role: "assistant" as const, content: fullContent, model: headerModel || responseModel || undefined }];
+      const finalMessages = [...newMessages, { role: "assistant" as const, content: fullContent, model: headerModel || responseModel || undefined, requestId }];
       setMessages(finalMessages);
       setStreamingContent("");
       // Persist completed messages so they survive navigation
@@ -224,6 +227,28 @@ export default function PlaygroundPage() {
     setLastMeta(null);
     setTopicStartIndex(0);
     sessionStorage.removeItem("pg:messages");
+  }
+
+  async function handleFeedback(messageIndex: number, verdict: "up" | "down") {
+    const msg = messages[messageIndex];
+    if (!msg?.requestId || msg.feedback) return;
+    const score = verdict === "up" ? 5 : 1;
+    try {
+      const hdrs: Record<string, string> = { "Content-Type": "application/json", ...adminHeaders() };
+      if (apiToken) hdrs["Authorization"] = `Bearer ${apiToken}`;
+      const res = await fetch(gatewayUrl("/v1/feedback"), {
+        method: "POST",
+        credentials: "include",
+        headers: hdrs,
+        body: JSON.stringify({ requestId: msg.requestId, score }),
+      });
+      if (!res.ok) return;
+      const updated = messages.map((m, i) => (i === messageIndex ? { ...m, feedback: verdict } : m));
+      setMessages(updated);
+      sessionStorage.setItem("pg:messages", JSON.stringify(updated));
+    } catch {
+      // Swallow — UI stays unmarked, user can retry
+    }
   }
 
   function handleModelChange(value: string) {
@@ -309,7 +334,7 @@ export default function PlaygroundPage() {
                   <div className="flex-1 h-px bg-zinc-800" />
                 </div>
               )}
-              <div key={i} className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
+              <div key={i} className={`flex flex-col ${msg.role === "user" ? "items-end" : "items-start"}`}>
                 <div
                   className={`max-w-2xl rounded-xl px-4 py-3 ${
                     isGuardrail
@@ -324,6 +349,38 @@ export default function PlaygroundPage() {
                   )}
                   <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
                 </div>
+                {msg.role === "assistant" && !isGuardrail && msg.requestId && (
+                  <div className="flex gap-1 mt-1.5 ml-1">
+                    <button
+                      onClick={() => handleFeedback(i, "up")}
+                      disabled={!!msg.feedback}
+                      title={msg.feedback === "up" ? "Thanks — feedback recorded" : "Good response"}
+                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${
+                        msg.feedback === "up"
+                          ? "bg-emerald-900/40 border-emerald-700 text-emerald-300"
+                          : msg.feedback
+                          ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
+                          : "border-zinc-700 text-zinc-400 hover:text-emerald-300 hover:border-emerald-700"
+                      }`}
+                    >
+                      👍
+                    </button>
+                    <button
+                      onClick={() => handleFeedback(i, "down")}
+                      disabled={!!msg.feedback}
+                      title={msg.feedback === "down" ? "Thanks — feedback recorded" : "Poor response"}
+                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${
+                        msg.feedback === "down"
+                          ? "bg-rose-900/40 border-rose-700 text-rose-300"
+                          : msg.feedback
+                          ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
+                          : "border-zinc-700 text-zinc-400 hover:text-rose-300 hover:border-rose-700"
+                      }`}
+                    >
+                      👎
+                    </button>
+                  </div>
+                )}
               </div>
               </>
             );

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -43,7 +43,7 @@ export async function createRouter(ctx: RouterContext) {
     credentials: true,
     allowHeaders: ["Content-Type", "Authorization", "X-Admin-Key", "X-Stainless-OS", "X-Stainless-Arch", "X-Stainless-Lang", "X-Stainless-Runtime", "X-Stainless-Runtime-Version", "X-Stainless-Package-Version", "X-Stainless-Retry-Count"],
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
+    exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-Provara-Request-Id", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
   }));
 
   // Mount OAuth routes (public, only in multi_tenant mode)
@@ -261,7 +261,7 @@ export async function createRouter(ctx: RouterContext) {
           usedProvider = attempt.provider;
           usedModel = attempt.model;
           if (attempt !== attempts[0]) usedFallback = true;
-          const responseId = nanoid();
+          const requestId = nanoid();
           const start = performance.now();
 
           const sseStream = new ReadableStream({
@@ -274,7 +274,7 @@ export async function createRouter(ctx: RouterContext) {
                 fullContent += chunk.content;
                 if (chunk.usage) usage = chunk.usage;
                 const sseData = JSON.stringify({
-                  id: `chatcmpl-${responseId}`,
+                  id: `chatcmpl-${requestId}`,
                   object: "chat.completion.chunk",
                   created: Math.floor(Date.now() / 1000),
                   model: usedModel,
@@ -301,7 +301,6 @@ export async function createRouter(ctx: RouterContext) {
 
                 // Log after stream completes
                 const latencyMs = Math.round(performance.now() - start);
-                const requestId = nanoid();
                 await ctx.db
                   .insert(requests)
                   .values({
@@ -343,7 +342,7 @@ export async function createRouter(ctx: RouterContext) {
 
                 if (!skipCache) {
                   putCache(request.messages, {
-                    id: responseId,
+                    id: requestId,
                     provider: usedProvider,
                     model: usedModel,
                     content: fullContent,
@@ -374,6 +373,7 @@ export async function createRouter(ctx: RouterContext) {
             "Connection": "keep-alive",
             "X-Provara-Model": usedModel,
             "X-Provara-Provider": usedProvider,
+            "X-Provara-Request-Id": requestId,
           };
           if (guardrailViolations.size > 0) {
             streamHeaders["X-Provara-Guardrail"] = JSON.stringify([...guardrailViolations]);
@@ -510,6 +510,7 @@ export async function createRouter(ctx: RouterContext) {
     }
 
     // Return OpenAI-compatible response format
+    c.header("X-Provara-Request-Id", requestId);
     return c.json({
       id: `chatcmpl-${response.id}`,
       object: "chat.completion",

--- a/packages/gateway/src/routing/judge.ts
+++ b/packages/gateway/src/routing/judge.ts
@@ -159,7 +159,13 @@ export function createJudge(registry: ProviderRegistry, db: Db, adaptive: Adapti
       });
 
       const result = parseJudgeResponse(response.content);
-      if (!result) return;
+      if (!result) {
+        console.warn(
+          `[judge] parse failed — ${target.provider}/${target.model} returned unparseable response:`,
+          response.content.slice(0, 200)
+        );
+        return;
+      }
 
       // Store as feedback with source "judge"
       await db.insert(feedback)
@@ -183,8 +189,11 @@ export function createJudge(registry: ProviderRegistry, db: Db, adaptive: Adapti
           "judge"
         );
       }
-    } catch {
-      // Judge failure is silent — don't affect the main request
+    } catch (err) {
+      console.warn(
+        `[judge] ${target.provider}/${target.model} scoring failed:`,
+        err instanceof Error ? err.message : err
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- Judge was failing ~90% of the time invisibly (2 successful scorings out of ~18 expected at 20% sample rate). Root cause now observable: `console.warn` surfaces the attempted model + error (or truncated unparseable body for JSON parse failures).
- Playground never produced user-scored samples. Now carries the DB `requestId` via `X-Provara-Request-Id` response header (streaming + non-streaming), and renders 👍/👎 buttons under each assistant message that POST to `/v1/feedback`.

## Changes

- `packages/gateway/src/routing/judge.ts` — replace bare `catch {}` with `console.warn` including `(provider/model, err.message)`; also log parse failures with a 200-char preview of the unparseable body.
- `packages/gateway/src/router.ts`
  - Streaming path: reuse `requestId` as both the SSE chunk `id` (was a separate `responseId` nanoid) and the cache key; add `X-Provara-Request-Id` to stream response headers.
  - Non-streaming path: `c.header("X-Provara-Request-Id", requestId)` before the JSON response.
  - CORS `exposeHeaders`: add `X-Provara-Request-Id`.
- `apps/web/src/app/dashboard/playground/page.tsx`
  - `Message` type gains `requestId?` and `feedback?: "up" | "down"`.
  - Read `X-Provara-Request-Id` from fetch response headers; store on the assistant message.
  - New `handleFeedback(i, verdict)` posts `{ requestId, score: verdict === "up" ? 5 : 1 }` to `/v1/feedback`, then marks the message locally so buttons lock.
  - 👍/👎 buttons render under assistant messages (not guardrail-triggered ones), with hover/active/disabled styling.

## Test plan

- [x] `tsc --noEmit` clean on `packages/gateway` + `apps/web`
- [ ] Deploy to Railway, exercise playground, check Railway logs for `[judge]` warnings on failure — confirms observability works
- [ ] Click 👍 on an assistant message → verify new `feedback` row with `source='user'` and `score=5`
- [ ] Click 👎 → verify `score=1`
- [ ] Reload playground page → verify previous feedback buttons stay locked (sessionStorage persistence)
- [ ] After several feedback submissions, verify `model_scores.sample_count` increments

Closes #69

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
