### PR TITLE
feat(#71): pin judge to a specific model

### DIFF
--- a/apps/web/src/app/dashboard/quality/page.tsx
+++ b/apps/web/src/app/dashboard/quality/page.tsx
@@ -44,6 +44,13 @@ interface TrendPoint {
 interface JudgeConfig {
   sampleRate: number;
   enabled: boolean;
+  provider: string | null;
+  model: string | null;
+}
+
+interface ProviderInfo {
+  name: string;
+  models: string[];
 }
 
 const RANGES = [
@@ -126,6 +133,7 @@ export default function QualityPage() {
   const [trend, setTrend] = useState<TrendPoint[]>([]);
   const [trendRange, setTrendRange] = useState("7d");
   const [judgeConfig, setJudgeConfigState] = useState<JudgeConfig | null>(null);
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [savingConfig, setSavingConfig] = useState(false);
   const [loading, setLoading] = useState(true);
   const { getSparkline, pulsedKeys } = useAdaptiveScoreBuffer(adaptiveCells);
@@ -141,20 +149,23 @@ export default function QualityPage() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const [modelRes, adaptiveRes, feedbackRes, configRes] = await Promise.all([
+        const [modelRes, adaptiveRes, feedbackRes, configRes, providersRes] = await Promise.all([
           gatewayFetchRaw("/v1/feedback/quality/by-model"),
           gatewayFetchRaw("/v1/analytics/adaptive/scores"),
           gatewayFetchRaw("/v1/feedback?limit=20"),
           gatewayFetchRaw("/v1/feedback/judge/config"),
+          gatewayFetchRaw("/v1/providers"),
         ]);
         const modelData = await modelRes.json();
         const adaptiveData = await adaptiveRes.json();
         const feedbackData = await feedbackRes.json();
         const configData = await configRes.json();
+        const providersData = await providersRes.json();
         setByModel(modelData.quality || []);
         setAdaptiveCells(adaptiveData.cells || []);
         setRecentFeedback(feedbackData.feedback || []);
         setJudgeConfigState(configData);
+        setProviders(providersData.providers || []);
       } catch (err) {
         console.error("Failed to fetch quality data:", err);
       } finally {
@@ -249,7 +260,7 @@ export default function QualityPage() {
         <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6">
           <h2 className="text-sm font-semibold text-zinc-300 mb-4">LLM Judge Configuration</h2>
           <p className="text-xs text-zinc-500 mb-4">
-            The judge automatically scores a sample of responses using the cheapest available model.
+            The judge automatically scores a sample of responses. Pin a specific model below, or let it pick the cheapest available.
           </p>
           <div className="flex items-end gap-6">
             <div>
@@ -282,6 +293,31 @@ export default function QualityPage() {
                 <span>50%</span>
                 <span>100%</span>
               </div>
+            </div>
+            <div className="flex-1 max-w-xs">
+              <label className="block text-xs text-zinc-400 mb-1">Judge Model</label>
+              <select
+                value={judgeConfig.provider && judgeConfig.model ? `${judgeConfig.provider}:${judgeConfig.model}` : ""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (!v) {
+                    setJudgeConfigState({ ...judgeConfig, provider: null, model: null });
+                  } else {
+                    const [provider, ...rest] = v.split(":");
+                    setJudgeConfigState({ ...judgeConfig, provider, model: rest.join(":") });
+                  }
+                }}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded text-xs px-2 py-1.5 text-zinc-200"
+              >
+                <option value="">Auto (cheapest)</option>
+                {providers.flatMap((p) =>
+                  p.models.map((m) => (
+                    <option key={`${p.name}:${m}`} value={`${p.name}:${m}`}>
+                      {p.name} / {m}
+                    </option>
+                  ))
+                )}
+              </select>
             </div>
             <button
               onClick={handleSaveConfig}

--- a/packages/gateway/src/routing/judge.ts
+++ b/packages/gateway/src/routing/judge.ts
@@ -11,9 +11,16 @@ const JUDGE_CONFIG_KEY = "judge_config";
 
 let judgeSampleRate = parseFloat(process.env.PROVARA_JUDGE_SAMPLE_RATE || "0.1");
 let judgeEnabled = true;
+let judgeProvider: string | null = null;
+let judgeModel: string | null = null;
 
 export function getJudgeConfig() {
-  return { sampleRate: judgeSampleRate, enabled: judgeEnabled };
+  return {
+    sampleRate: judgeSampleRate,
+    enabled: judgeEnabled,
+    provider: judgeProvider,
+    model: judgeModel,
+  };
 }
 
 export async function hydrateJudgeConfig(db: Db) {
@@ -24,13 +31,20 @@ export async function hydrateJudgeConfig(db: Db) {
     .get();
   if (!row) return;
   try {
-    const parsed = JSON.parse(row.value) as { sampleRate?: number; enabled?: boolean };
+    const parsed = JSON.parse(row.value) as {
+      sampleRate?: number;
+      enabled?: boolean;
+      provider?: string | null;
+      model?: string | null;
+    };
     if (typeof parsed.sampleRate === "number") {
       judgeSampleRate = Math.max(0, Math.min(1, parsed.sampleRate));
     }
     if (typeof parsed.enabled === "boolean") {
       judgeEnabled = parsed.enabled;
     }
+    if (parsed.provider !== undefined) judgeProvider = parsed.provider || null;
+    if (parsed.model !== undefined) judgeModel = parsed.model || null;
   } catch {
     // Malformed row — leave defaults in place
   }
@@ -38,7 +52,12 @@ export async function hydrateJudgeConfig(db: Db) {
 
 export async function setJudgeConfig(
   db: Db,
-  config: { sampleRate?: number; enabled?: boolean }
+  config: {
+    sampleRate?: number;
+    enabled?: boolean;
+    provider?: string | null;
+    model?: string | null;
+  }
 ) {
   if (config.sampleRate !== undefined) {
     judgeSampleRate = Math.max(0, Math.min(1, config.sampleRate));
@@ -46,7 +65,15 @@ export async function setJudgeConfig(
   if (config.enabled !== undefined) {
     judgeEnabled = config.enabled;
   }
-  const value = JSON.stringify({ sampleRate: judgeSampleRate, enabled: judgeEnabled });
+  if (config.provider !== undefined) judgeProvider = config.provider || null;
+  if (config.model !== undefined) judgeModel = config.model || null;
+
+  const value = JSON.stringify({
+    sampleRate: judgeSampleRate,
+    enabled: judgeEnabled,
+    provider: judgeProvider,
+    model: judgeModel,
+  });
   const now = new Date();
   await db
     .insert(appConfig)
@@ -128,11 +155,24 @@ export interface JudgeContext {
   model: string;
 }
 
+function resolveJudgeTarget(registry: ProviderRegistry): { provider: string; model: string } | null {
+  if (judgeProvider && judgeModel) {
+    const pinned = registry.get(judgeProvider);
+    if (pinned && pinned.models.includes(judgeModel)) {
+      return { provider: judgeProvider, model: judgeModel };
+    }
+    console.warn(
+      `[judge] pinned model ${judgeProvider}/${judgeModel} not in registry; falling back to cheapest`
+    );
+  }
+  return findCheapestModel(registry);
+}
+
 export function createJudge(registry: ProviderRegistry, db: Db, adaptive: AdaptiveRouter) {
   async function maybeJudge(ctx: JudgeContext): Promise<void> {
     if (!shouldJudge()) return;
 
-    const target = findCheapestModel(registry);
+    const target = resolveJudgeTarget(registry);
     if (!target) return;
 
     const provider = registry.get(target.provider);


### PR DESCRIPTION
## Summary

Cheapest-model judging was causing two real problems on Railway: (1) `glm-4.7-flash` inflating every score to 4–5, giving adaptive routing no signal; (2) when that provider hits rate limits, every judge call silently fails until the limit clears. Now operators can pin the judge to a stable model via the Quality dashboard.

## Changes

- `packages/gateway/src/routing/judge.ts`
  - Added `judgeProvider`, `judgeModel` module-level state, threaded through `hydrateJudgeConfig` / `setJudgeConfig` / `getJudgeConfig`. Persisted via the existing `app_config` JSON blob — no schema migration needed.
  - New `resolveJudgeTarget(registry)` prefers the pin when valid, falls back to `findCheapestModel`. Emits `[judge] pinned model X/Y not in registry; falling back to cheapest` if the pin becomes stale.
- `apps/web/src/app/dashboard/quality/page.tsx`
  - `JudgeConfig` gains `provider: string | null; model: string | null`.
  - Fetches `/v1/providers` alongside the existing config payload.
  - New dropdown: "Auto (cheapest)" as default, each `provider/model` as an option. Saving posts the pin through the existing PUT endpoint.

## Test plan

- [x] `tsc --noEmit` clean on `packages/gateway` + `apps/web`
- [ ] Deploy, open Quality page, confirm dropdown lists registered providers/models
- [ ] Pick a pin (e.g. `openai/gpt-4.1-nano`), save, restart gateway, verify pin persists via `getJudgeConfig`
- [ ] Hit the playground, verify judge calls land on the pinned model (check Railway logs for provider attribution, or observe `feedback` rows with `source='judge'` appearing at the configured rate)
- [ ] Remove the pinned model from the registry (disable the provider via dashboard), send a request, verify the warn-and-fall-back message appears in logs

Closes #71

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
