### PR TITLE
fix(#75): include (provider, model) in cache key

### DIFF
--- a/packages/gateway/src/cache/index.ts
+++ b/packages/gateway/src/cache/index.ts
@@ -11,8 +11,8 @@ const MAX_ENTRIES = 1000;
 
 const cache = new Map<string, CacheEntry>();
 
-function hashKey(messages: ChatMessage[]): string {
-  const raw = messages.map((m) => `${m.role}:${m.content}`).join("|");
+function hashKey(messages: ChatMessage[], provider: string, model: string): string {
+  const raw = `${provider}::${model}::` + messages.map((m) => `${m.role}:${m.content}`).join("|");
   let hash = 0;
   for (let i = 0; i < raw.length; i++) {
     hash = ((hash << 5) - hash + raw.charCodeAt(i)) | 0;
@@ -20,8 +20,12 @@ function hashKey(messages: ChatMessage[]): string {
   return hash.toString(36);
 }
 
-export function getCached(messages: ChatMessage[]): CompletionResponse | null {
-  const key = hashKey(messages);
+export function getCached(
+  messages: ChatMessage[],
+  provider: string,
+  model: string
+): CompletionResponse | null {
+  const key = hashKey(messages, provider, model);
   const entry = cache.get(key);
   if (!entry) return null;
   if (Date.now() > entry.expiresAt) {
@@ -33,10 +37,12 @@ export function getCached(messages: ChatMessage[]): CompletionResponse | null {
 
 export function putCache(
   messages: ChatMessage[],
+  provider: string,
+  model: string,
   response: CompletionResponse,
   ttlMs: number = DEFAULT_TTL_MS
 ): void {
-  const key = hashKey(messages);
+  const key = hashKey(messages, provider, model);
 
   // Evict oldest entries if full
   if (cache.size >= MAX_ENTRIES) {

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -186,7 +186,7 @@ export async function createRouter(ctx: RouterContext) {
     // Check cache before calling any provider
     const skipCache = !isCacheable || routingResult.routedBy === "ab-test";
     if (!skipCache) {
-      const cached = getCached(request.messages);
+      const cached = getCached(request.messages, routingResult.provider, routingResult.model);
       if (cached) {
         return c.json({
           id: `chatcmpl-${cached.id}`,
@@ -341,7 +341,7 @@ export async function createRouter(ctx: RouterContext) {
                 }).catch(() => {});
 
                 if (!skipCache) {
-                  putCache(request.messages, {
+                  putCache(request.messages, usedProvider, usedModel, {
                     id: requestId,
                     provider: usedProvider,
                     model: usedModel,
@@ -476,7 +476,7 @@ export async function createRouter(ctx: RouterContext) {
 
     // Cache the response for future identical requests
     if (!skipCache) {
-      putCache(request.messages, response);
+      putCache(request.messages, usedProvider, usedModel, response);
     }
 
     // Fire-and-forget: LLM-as-judge quality scoring on a sample of responses


### PR DESCRIPTION
## Summary

`cache/index.ts:hashKey()` hashed only the `messages` array, so cross-model cache collisions were silently corrupting multi-model workflows. A cached response from `openai/gpt-4.1-nano` would be returned for a subsequent `anthropic/claude-sonnet-4-6` request with the same prompt, with stale `_provara.provider` metadata and no new `requests` row (cache hits skip DB insert).

## Changes

- `packages/gateway/src/cache/index.ts` — `hashKey(messages, provider, model)`; `getCached` and `putCache` accept and pass through the pair.
- `packages/gateway/src/router.ts` — `getCached` call passes `routingResult.provider/model` (lookup intent); both `putCache` calls pass `usedProvider/usedModel` (actual served pair).

## Test plan

- [x] `tsc --noEmit` clean on gateway
- [ ] Deploy, send same prompt across 3 different models, confirm each lands as a distinct `requests` row (not 1 + 2 cache hits)
- [ ] Repeat same prompt+model → second hit returns from cache (latency ≈ 0ms, `_provara.cached=true`)

Closes #75

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
