### PR TITLE
feat(#80): sign-in UX polish

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -46,6 +46,49 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
+function OnboardingCard() {
+  return (
+    <section className="bg-gradient-to-br from-blue-950/40 via-zinc-900 to-zinc-900 border border-blue-900/40 rounded-xl p-8">
+      <h2 className="text-xl font-semibold mb-2">Welcome to Provara 👋</h2>
+      <p className="text-sm text-zinc-400 mb-6 max-w-2xl">
+        Your gateway is live. Send traffic through it and this dashboard will start showing routing decisions, costs, and quality scores per cell. Three steps to get going:
+      </p>
+      <ol className="space-y-4 max-w-2xl">
+        <li className="flex gap-3">
+          <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 border border-blue-500/40 text-blue-300 text-xs font-semibold flex items-center justify-center">1</span>
+          <div className="flex-1">
+            <p className="text-sm text-zinc-200 font-medium">Add an API key</p>
+            <p className="text-xs text-zinc-500 mb-2">Plug in OpenAI, Anthropic, Groq, DeepSeek, or any OpenAI-compatible provider. Keys are encrypted at rest.</p>
+            <a href="/dashboard/api-keys" className="inline-block text-xs px-3 py-1.5 bg-blue-600 hover:bg-blue-500 rounded-md transition-colors">Add key →</a>
+          </div>
+        </li>
+        <li className="flex gap-3">
+          <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 border border-blue-500/40 text-blue-300 text-xs font-semibold flex items-center justify-center">2</span>
+          <div className="flex-1">
+            <p className="text-sm text-zinc-200 font-medium">Point your SDK at the gateway</p>
+            <p className="text-xs text-zinc-500 mb-2">Works with any OpenAI-compatible client — just change the base URL and use your Provara token as the key.</p>
+            <pre className="bg-zinc-900/80 border border-zinc-800 rounded-md p-2 text-xs text-zinc-300 overflow-x-auto">
+              <code>baseURL: &quot;https://gateway.provara.xyz/v1&quot;</code>
+            </pre>
+          </div>
+        </li>
+        <li className="flex gap-3">
+          <span className="shrink-0 w-6 h-6 rounded-full bg-blue-600/20 border border-blue-500/40 text-blue-300 text-xs font-semibold flex items-center justify-center">3</span>
+          <div className="flex-1">
+            <p className="text-sm text-zinc-200 font-medium">Watch the pipeline learn</p>
+            <p className="text-xs text-zinc-500">Every request gets classified, routed, and optionally scored by the LLM judge. After a few dozen requests, the adaptive router starts picking the best model per cell on its own.</p>
+          </div>
+        </li>
+      </ol>
+      <div className="mt-6 pt-5 border-t border-zinc-800 flex flex-wrap gap-4 text-xs text-zinc-500">
+        <a href="/dashboard/playground" className="hover:text-zinc-300 transition-colors">Try the Playground →</a>
+        <a href="/dashboard/tokens" className="hover:text-zinc-300 transition-colors">Create an API token →</a>
+        <a href="https://github.com/syndicalt/provara" target="_blank" rel="noopener noreferrer" className="hover:text-zinc-300 transition-colors">Docs &amp; SDK examples →</a>
+      </div>
+    </section>
+  );
+}
+
 const costColumns: Column<CostByModel>[] = [
   { key: "provider", label: "Provider", sortable: true, filterable: true },
   { key: "model", label: "Model", sortable: true, filterable: true, render: (row) => <span className="font-mono text-xs">{row.model}</span> },
@@ -147,41 +190,47 @@ export default function Dashboard() {
         </span>
       </div>
 
-      {/* Overview Stats */}
-      <div className="grid grid-cols-4 gap-4">
-        <StatCard label="Total Requests" value={formatNumber(overview?.totalRequests || 0)} />
-        <StatCard label="Total Cost" value={formatCost(overview?.totalCost || 0)} />
-        <StatCard label="Avg Latency" value={formatLatency(overview?.avgLatency || 0)} />
-        <StatCard label="Active Providers" value={String(overview?.providerCount || 0)} />
-      </div>
+      {(overview?.totalRequests || 0) === 0 ? (
+        <OnboardingCard />
+      ) : (
+        <>
+          {/* Overview Stats */}
+          <div className="grid grid-cols-4 gap-4">
+            <StatCard label="Total Requests" value={formatNumber(overview?.totalRequests || 0)} />
+            <StatCard label="Total Cost" value={formatCost(overview?.totalCost || 0)} />
+            <StatCard label="Avg Latency" value={formatLatency(overview?.avgLatency || 0)} />
+            <StatCard label="Active Providers" value={String(overview?.providerCount || 0)} />
+          </div>
 
-      {/* Cost by Model */}
-      <section>
-        <h2 className="text-lg font-semibold mb-4">Cost by Model</h2>
-        <DataTable
-          columns={costColumns}
-          data={costsByModel}
-          pageSize={10}
-          emptyMessage="No data yet. Send some requests through the gateway."
-        />
-      </section>
+          {/* Cost by Model */}
+          <section>
+            <h2 className="text-lg font-semibold mb-4">Cost by Model</h2>
+            <DataTable
+              columns={costColumns}
+              data={costsByModel}
+              pageSize={10}
+              emptyMessage="No data yet. Send some requests through the gateway."
+            />
+          </section>
 
-      {/* Recent Requests */}
-      <section>
-        <h2 className="text-lg font-semibold mb-4">Recent Requests</h2>
-        <DataTable
-          columns={requestColumns}
-          data={recentRequests}
-          emptyMessage="No requests yet. Send some requests through the gateway."
-          serverPagination={{
-            total: totalRequests,
-            page: reqPage,
-            onPageChange: setReqPage,
-            pageSize: reqPageSize,
-            onPageSizeChange: (size) => { setReqPageSize(size); setReqPage(0); },
-          }}
-        />
-      </section>
+          {/* Recent Requests */}
+          <section>
+            <h2 className="text-lg font-semibold mb-4">Recent Requests</h2>
+            <DataTable
+              columns={requestColumns}
+              data={recentRequests}
+              emptyMessage="No requests yet. Send some requests through the gateway."
+              serverPagination={{
+                total: totalRequests,
+                page: reqPage,
+                onPageChange: setReqPage,
+                pageSize: reqPageSize,
+                onPageSizeChange: (size) => { setReqPageSize(size); setReqPage(0); },
+              }}
+            />
+          </section>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -8,17 +8,39 @@ import { useAuth } from "../../lib/auth-context";
 
 const GATEWAY = process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:4000";
 
+function errorMessage(code: string | null): string | null {
+  switch (code) {
+    case "expired":
+      return "Your session expired. Please sign in again.";
+    case "denied":
+      return "Sign-in was cancelled. You can try again whenever you're ready.";
+    case "oauth_failed":
+      return "Sign-in failed. Please try again — if this keeps happening, the OAuth provider may be down.";
+    case "invalid_state":
+      return "The sign-in link expired mid-flow. Please start again.";
+    case null:
+      return null;
+    default:
+      return "Something went wrong. Please try again.";
+  }
+}
+
 function LoginContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { user, loading } = useAuth();
   const error = searchParams.get("error");
+  const returnTo = searchParams.get("return") || "/dashboard";
+  const errorText = errorMessage(error);
+
+  // Append the return path onto the OAuth start URL so the callback can honor it.
+  const oauthReturn = returnTo === "/dashboard" ? "" : `?return=${encodeURIComponent(returnTo)}`;
 
   useEffect(() => {
     if (!loading && user) {
-      router.replace("/dashboard");
+      router.replace(returnTo);
     }
-  }, [user, loading, router]);
+  }, [user, loading, router, returnTo]);
 
   if (loading) {
     return (
@@ -34,19 +56,29 @@ function LoginContent() {
     <div className="min-h-[80vh] flex items-center justify-center">
       <div className="w-full max-w-sm space-y-6">
         <div className="text-center">
-          <h1 className="text-3xl font-bold">Welcome back</h1>
-          <p className="text-zinc-400 mt-2">Sign in to your Provara dashboard</p>
+          <h1 className="text-3xl font-bold">Sign in to Provara</h1>
+          <p className="text-zinc-400 mt-2">
+            Route across OpenAI, Anthropic, Groq, DeepSeek, and more — with adaptive quality scoring and built-in A/B testing.
+          </p>
         </div>
 
-        {error && (
-          <div className="bg-red-900/30 border border-red-800 rounded-lg px-4 py-3 text-sm text-red-300">
-            Authentication failed. Please try again.
+        {errorText && (
+          <div
+            className={`border rounded-lg px-4 py-3 text-sm ${
+              error === "denied"
+                ? "bg-zinc-900 border-zinc-700 text-zinc-300"
+                : error === "expired"
+                ? "bg-amber-900/30 border-amber-800 text-amber-200"
+                : "bg-red-900/30 border-red-800 text-red-300"
+            }`}
+          >
+            {errorText}
           </div>
         )}
 
         <div className="space-y-3">
           <a
-            href={`${GATEWAY}/auth/login/google`}
+            href={`${GATEWAY}/auth/login/google${oauthReturn}`}
             className="flex items-center justify-center gap-3 w-full px-4 py-3 bg-white text-zinc-900 rounded-lg font-medium hover:bg-zinc-100 transition-colors"
           >
             <svg className="w-5 h-5" viewBox="0 0 24 24">
@@ -59,7 +91,7 @@ function LoginContent() {
           </a>
 
           <a
-            href={`${GATEWAY}/auth/login/github`}
+            href={`${GATEWAY}/auth/login/github${oauthReturn}`}
             className="flex items-center justify-center gap-3 w-full px-4 py-3 bg-zinc-800 text-white rounded-lg font-medium hover:bg-zinc-700 transition-colors border border-zinc-700"
           >
             <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -69,9 +101,22 @@ function LoginContent() {
           </a>
         </div>
 
-        <p className="text-center text-xs text-zinc-500">
-          By signing in, you agree to our terms of service.
-        </p>
+        <div className="pt-2 text-center space-y-2">
+          <p className="text-xs text-zinc-500">
+            By signing in, you agree to our terms of service.
+          </p>
+          <p className="text-xs text-zinc-600">
+            Want to self-host instead?{" "}
+            <a
+              href="https://github.com/syndicalt/provara"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              Run it yourself →
+            </a>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -25,45 +25,68 @@ import {
 
 const DASHBOARD_URL = () => process.env.DASHBOARD_URL || "http://localhost:3000";
 const STATE_COOKIE = "provara_oauth_state";
+const RETURN_COOKIE = "provara_oauth_return";
+
+// Only allow redirecting to in-app paths (never external URLs)
+function sanitizeReturn(raw: string | undefined | null): string {
+  if (!raw) return "/dashboard";
+  if (!raw.startsWith("/") || raw.startsWith("//")) return "/dashboard";
+  return raw;
+}
 
 export function createAuthRoutes(db: Db) {
   const app = new Hono();
+
+  const cookieOpts = {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "Lax" as const,
+    path: "/",
+    maxAge: 600,
+  };
 
   // --- Login redirects ---
 
   app.get("/login/google", (c) => {
     const state = generateState();
-    setCookie(c, STATE_COOKIE, state, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "Lax",
-      path: "/",
-      maxAge: 600, // 10 minutes
-    });
+    const returnTo = sanitizeReturn(c.req.query("return"));
+    setCookie(c, STATE_COOKIE, state, cookieOpts);
+    setCookie(c, RETURN_COOKIE, returnTo, cookieOpts);
     return c.redirect(buildGoogleAuthUrl(state));
   });
 
   app.get("/login/github", (c) => {
     const state = generateState();
-    setCookie(c, STATE_COOKIE, state, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "Lax",
-      path: "/",
-      maxAge: 600,
-    });
+    const returnTo = sanitizeReturn(c.req.query("return"));
+    setCookie(c, STATE_COOKIE, state, cookieOpts);
+    setCookie(c, RETURN_COOKIE, returnTo, cookieOpts);
     return c.redirect(buildGitHubAuthUrl(state));
   });
 
   // --- Callbacks ---
 
+  function loginRedirect(errorCode: string): string {
+    return `${DASHBOARD_URL()}/login?error=${errorCode}`;
+  }
+
+  function successRedirect(c: Parameters<typeof getCookie>[0]): string {
+    const returnTo = sanitizeReturn(getCookie(c, RETURN_COOKIE));
+    return `${DASHBOARD_URL()}${returnTo}`;
+  }
+
   app.get("/callback/google", async (c) => {
+    // User clicked "cancel" on Google's consent screen
+    const providerError = c.req.query("error");
+    if (providerError === "access_denied") {
+      return c.redirect(loginRedirect("denied"));
+    }
+
     const code = c.req.query("code");
     const state = c.req.query("state");
     const storedState = getCookie(c, STATE_COOKIE);
 
     if (!code || !state || state !== storedState) {
-      return c.json({ error: { message: "Invalid OAuth state", type: "auth_error" } }, 400);
+      return c.redirect(loginRedirect("invalid_state"));
     }
 
     try {
@@ -72,20 +95,25 @@ export function createAuthRoutes(db: Db) {
       const user = await upsertUser(db, "google", profile);
       const sessionId = await createSession(db, user.id);
       setSessionCookie(c, sessionId);
-      return c.redirect(`${DASHBOARD_URL()}/dashboard`);
+      return c.redirect(successRedirect(c));
     } catch (err) {
       console.error("Google OAuth error:", err);
-      return c.redirect(`${DASHBOARD_URL()}/login?error=oauth_failed`);
+      return c.redirect(loginRedirect("oauth_failed"));
     }
   });
 
   app.get("/callback/github", async (c) => {
+    const providerError = c.req.query("error");
+    if (providerError === "access_denied") {
+      return c.redirect(loginRedirect("denied"));
+    }
+
     const code = c.req.query("code");
     const state = c.req.query("state");
     const storedState = getCookie(c, STATE_COOKIE);
 
     if (!code || !state || state !== storedState) {
-      return c.json({ error: { message: "Invalid OAuth state", type: "auth_error" } }, 400);
+      return c.redirect(loginRedirect("invalid_state"));
     }
 
     try {
@@ -94,10 +122,10 @@ export function createAuthRoutes(db: Db) {
       const user = await upsertUser(db, "github", profile);
       const sessionId = await createSession(db, user.id);
       setSessionCookie(c, sessionId);
-      return c.redirect(`${DASHBOARD_URL()}/dashboard`);
+      return c.redirect(successRedirect(c));
     } catch (err) {
       console.error("GitHub OAuth error:", err);
-      return c.redirect(`${DASHBOARD_URL()}/login?error=oauth_failed`);
+      return c.redirect(loginRedirect("oauth_failed"));
     }
   });
 


### PR DESCRIPTION
## Summary

Polishes the sign-in and first-run flows so new visitors land somewhere guided rather than staring at an empty dashboard or a generic "authentication failed" message.

## Changes

### Sign-in page (`apps/web/src/app/login/page.tsx`)
- Heading: "Welcome back" → "Sign in to Provara" (works for first-timers too).
- Tagline: generic filler → concrete value prop about multi-provider routing + adaptive scoring.
- Error messages branched by `?error=` code: `denied` (neutral tone), `expired` (amber), `oauth_failed` / `invalid_state` (red). Previously all errors were flattened to "Authentication failed."
- Added a "Want to self-host instead?" footer link to the GitHub repo — captures visitors who don't want managed.

### OAuth flow (`packages/gateway/src/routes/auth.ts`)
- `/login/google` and `/login/github` accept `?return=/some/path` and stash it in a short-lived `provara_oauth_return` cookie alongside the state cookie.
- Callbacks read the return cookie on success and redirect there. Paths are sanitized — only in-app paths (`/...`) are honored; anything else falls back to `/dashboard` to prevent open-redirect abuse.
- `access_denied` from the provider (user clicks "cancel" on the consent screen) now redirects to `/login?error=denied` instead of falling into the invalid-state branch.
- Invalid state now redirects to `/login?error=invalid_state` instead of returning a raw JSON 400 — the user stays in the flow.

### First-run dashboard (`apps/web/src/app/dashboard/page.tsx`)
- When `overview.totalRequests === 0`, the stats grid and tables are replaced with an `OnboardingCard` — three-step checklist (Add API key / Point SDK / Watch it learn) with direct CTAs to the relevant dashboard pages plus the docs.
- Once the first request lands, the card disappears and the normal stats/tables take over. No flag persisted — it's derived from live data.

## Test plan

- [x] `tsc --noEmit` clean on gateway + web
- [ ] Open `/login?error=denied` in browser → neutral-tone copy
- [ ] Open `/login?error=expired` → amber banner
- [ ] Open `/login?error=oauth_failed` → red banner
- [ ] Click "Sign in with Google" → get to Google consent → click cancel → land back at `/login?error=denied`
- [ ] Visit `/login?return=/dashboard/playground` → sign in → land at `/dashboard/playground` instead of `/dashboard`
- [ ] Fresh account (0 requests) → dashboard shows the onboarding card, not the empty stats
- [ ] After a first successful request → onboarding card disappears on next refresh

## Out of scope

- Magic-link sign-in (Resend subscription doesn't support it yet).
- Middleware-level return-path capture for expired sessions — currently only works when the user arrives at `/login?return=...` directly. Can land in a follow-up.

Closes #80

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
