### PR TITLE
fix(#87): hero wrap + link terms-of-service on login

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense } from "react";
+import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { PublicNav } from "../../components/public-nav";
@@ -103,7 +104,11 @@ function LoginContent() {
 
         <div className="pt-2 text-center space-y-2">
           <p className="text-xs text-zinc-500">
-            By signing in, you agree to our terms of service.
+            By signing in, you agree to our{" "}
+            <Link href="/terms" className="text-zinc-400 hover:text-zinc-200 underline underline-offset-2 transition-colors">
+              terms of service
+            </Link>
+            .
           </p>
           <p className="text-xs text-zinc-600">
             Want to self-host instead?{" "}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -188,8 +188,10 @@ export default function Home() {
                 <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse" />
                 Self-hostable · OpenAI-compatible · Open source
               </div>
-              <h1 className="text-5xl sm:text-6xl font-bold tracking-tight leading-[1.05]">
-                One gateway. Every LLM provider.
+              <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.05]">
+                One gateway.
+                <br />
+                Every LLM provider.
                 <br />
                 <span className="text-blue-400">Smarter with every request.</span>
               </h1>


### PR DESCRIPTION
## Summary

Two UAT fixes from the UX polish shipped in #80 and #81.

## Changes

- **`apps/web/src/app/page.tsx`** — hero H1 now uses explicit `<br />` between each clause ("One gateway." / "Every LLM provider." / blue "Smarter with every request.") so the text can't break mid-clause on common viewports. Dropped base font-size one step on the smallest screens (`text-4xl` → `sm:text-5xl` → `md:text-6xl`).
- **`apps/web/src/app/login/page.tsx`** — "terms of service" in the footer copy is now a proper `<Link href="/terms">` with underline styling instead of plain text.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Preview `/` at 1440px, 1024px, 768px, 375px — no mid-clause wraps at any width
- [ ] Click "terms of service" on `/login` → lands at `/terms`

Closes #87

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
