### PR TITLE
fix(#89): quality trend chart bucket collapse

### DIFF
--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -154,7 +154,7 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
 
     const rows = await db
       .select({
-        bucket: sql<string>`strftime(${fmt}, datetime(${feedback.createdAt} / 1000, 'unixepoch'))`,
+        bucket: sql<string>`strftime(${fmt}, datetime(${feedback.createdAt}, 'unixepoch'))`,
         avgScore: sql<number>`avg(${feedback.score})`,
         count: sql<number>`count(*)`,
         userCount: sql<number>`sum(case when ${feedback.source} = 'user' then 1 else 0 end)`,

--- a/packages/gateway/tests/feedback-trend.test.ts
+++ b/packages/gateway/tests/feedback-trend.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { feedback, requests } from "@provara/db";
+import { nanoid } from "nanoid";
+import { createFeedbackRoutes } from "../src/routes/feedback.js";
+import { createAdaptiveRouter } from "../src/routing/adaptive.js";
+import { makeTestDb } from "./_setup/db.js";
+
+async function buildTestApp() {
+  const db = await makeTestDb();
+  const adaptive = await createAdaptiveRouter(db);
+  const app = new Hono();
+  app.route("/v1/feedback", createFeedbackRoutes(db, adaptive));
+  return { db, app };
+}
+
+describe("GET /v1/feedback/quality/trend", () => {
+  it("buckets feedback across distinct days (regression: #89)", async () => {
+    const { db, app } = await buildTestApp();
+
+    // Seed a parent request so the feedback rows can reference a real request_id
+    const requestId = nanoid();
+    await db.insert(requests).values({
+      id: requestId,
+      provider: "openai",
+      model: "gpt-4.1-nano",
+      prompt: "test",
+      response: "ok",
+    }).run();
+
+    // Three feedback rows on three different days (5 days ago, 3 days ago, today)
+    const dayMs = 86_400_000;
+    const now = Date.now();
+    const daysAgo = (n: number) => new Date(now - n * dayMs);
+
+    for (const [offset, score] of [[5, 3], [3, 4], [0, 5]] as const) {
+      await db.insert(feedback).values({
+        id: nanoid(),
+        requestId,
+        score,
+        source: "user",
+        createdAt: daysAgo(offset),
+      }).run();
+    }
+
+    const res = await app.request("/v1/feedback/quality/trend?range=7d");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      series: { bucket: string; avgScore: number; count: number }[];
+      range: string;
+    };
+
+    // Three rows on three distinct days must yield three buckets — this would have been
+    // 1 bucket before the fix because every row collapsed to 1970-01-21.
+    expect(body.series.length).toBe(3);
+
+    // Buckets should be YYYY-MM-DD strings, all within the current decade (rules out the
+    // 1970 collapse).
+    for (const row of body.series) {
+      expect(row.bucket).toMatch(/^20\d{2}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("accepts range=24h and returns hourly buckets", async () => {
+    const { db, app } = await buildTestApp();
+    const requestId = nanoid();
+    await db.insert(requests).values({
+      id: requestId,
+      provider: "openai",
+      model: "gpt-4.1-nano",
+      prompt: "test",
+      response: "ok",
+    }).run();
+
+    // Two rows an hour apart in the last 24h
+    await db.insert(feedback).values({
+      id: nanoid(),
+      requestId,
+      score: 4,
+      source: "user",
+      createdAt: new Date(Date.now() - 2 * 3600_000),
+    }).run();
+    await db.insert(feedback).values({
+      id: nanoid(),
+      requestId,
+      score: 5,
+      source: "user",
+      createdAt: new Date(Date.now() - 1 * 3600_000),
+    }).run();
+
+    const res = await app.request("/v1/feedback/quality/trend?range=24h");
+    const body = (await res.json()) as { series: { bucket: string }[] };
+    expect(body.series.length).toBeGreaterThanOrEqual(2);
+    for (const row of body.series) {
+      expect(row.bucket).toMatch(/^20\d{2}-\d{2}-\d{2} \d{2}:00$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`/v1/feedback/quality/trend` was dividing `feedback.createdAt` by 1000 before `datetime(..., 'unixepoch')`. Drizzle's `mode: "timestamp"` stores unix-seconds, not milliseconds, so the extra division produced ~1776 seconds → every row formatted to `1970-01-21` → one GROUP BY bucket → chart always rendered a single point.

## Changes

- **`packages/gateway/src/routes/feedback.ts`** — drop the `/ 1000` from the `datetime()` call.
- **`packages/gateway/tests/feedback-trend.test.ts`** (new) — two regression tests:
  - Seeds three feedback rows on three distinct days → expects three distinct buckets + rejects 1970-range formatting.
  - Seeds two rows an hour apart with `range=24h` → expects hourly bucket formatting.

## Test plan

- [x] `npm test -w packages/gateway` → 16/16 (14 pre-existing + 2 new) passing
- [x] `tsc --noEmit` clean
- [ ] Deploy; open Quality Analytics → Quality Score Trend → chart shows multiple points with visible week-over-week variation

Closes #89

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
