### PR TITLE
fix(#91): hero copy re-edit

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -189,11 +189,8 @@ export default function Home() {
                 Self-hostable · OpenAI-compatible · Open source
               </div>
               <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.05]">
-                One gateway.
-                <br />
-                Every LLM provider.
-                <br />
-                <span className="text-blue-400">Smarter with every request.</span>
+                <span className="block">One Gateway. Every LLM</span>
+                <span className="block mt-6 text-blue-400">Smarter with every request</span>
               </h1>
               <p className="mt-6 text-lg text-zinc-400 leading-relaxed">
                 Route traffic across OpenAI, Anthropic, Groq, DeepSeek, xAI, and more — then watch the gateway learn which models perform best on your workload and quietly shift routing toward them. No retraining, no manual tuning, no SDK swap.


### PR DESCRIPTION
## Summary

Hero copy re-edit per UAT feedback. New layout:

```
One Gateway. Every LLM

Smarter with every request
```

Two visual blocks with a gap between them, capital "G" on Gateway, no trailing periods, "provider." dropped from the first line.

## Changes

- `apps/web/src/app/page.tsx` — replaced the three-line `<br />`-joined H1 with two `<span className="block">` elements, `mt-6` on the blue second line to create the visible separation.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Preview `/` — two distinct blocks with a gap, correct capitalization, no periods

Closes #91

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
