### PR TITLE
feat(#95): 5-star playground rating + in-session updates

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -3,6 +3,39 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { gatewayClientFetch, gatewayUrl, adminHeaders } from "../../../lib/gateway-client";
 
+function StarRating({
+  value,
+  onChange,
+}: {
+  value?: number;
+  onChange: (v: number) => void;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  const displayed = hover ?? value ?? 0;
+  return (
+    <div className="flex items-center gap-0.5" onMouseLeave={() => setHover(null)}>
+      {[1, 2, 3, 4, 5].map((star) => {
+        const filled = star <= displayed;
+        return (
+          <button
+            key={star}
+            type="button"
+            onClick={() => onChange(star)}
+            onMouseEnter={() => setHover(star)}
+            title={`Rate ${star} of 5`}
+            aria-label={`Rate ${star} of 5`}
+            className={`w-6 h-6 flex items-center justify-center text-base leading-none transition-colors ${
+              filled ? "text-amber-400 hover:text-amber-300" : "text-zinc-700 hover:text-zinc-500"
+            }`}
+          >
+            ★
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 interface ProviderInfo {
   name: string;
   models: string[];
@@ -13,7 +46,8 @@ interface Message {
   content: string;
   model?: string;
   requestId?: string;
-  feedback?: "up" | "down";
+  /** 1-5 star rating; undefined = not rated yet */
+  feedbackScore?: number;
 }
 
 interface ProvaraMetadata {
@@ -229,10 +263,17 @@ export default function PlaygroundPage() {
     sessionStorage.removeItem("pg:messages");
   }
 
-  async function handleFeedback(messageIndex: number, verdict: "up" | "down") {
+  async function handleRate(messageIndex: number, score: number) {
     const msg = messages[messageIndex];
-    if (!msg?.requestId || msg.feedback) return;
-    const score = verdict === "up" ? 5 : 1;
+    if (!msg?.requestId || score < 1 || score > 5) return;
+    if (msg.feedbackScore === score) return; // no-op on re-click of same star
+
+    // Optimistic update — flip the UI immediately, roll back if the POST fails
+    const previousScore = msg.feedbackScore;
+    const optimistic = messages.map((m, i) => (i === messageIndex ? { ...m, feedbackScore: score } : m));
+    setMessages(optimistic);
+    sessionStorage.setItem("pg:messages", JSON.stringify(optimistic));
+
     try {
       const hdrs: Record<string, string> = { "Content-Type": "application/json", ...adminHeaders() };
       if (apiToken) hdrs["Authorization"] = `Bearer ${apiToken}`;
@@ -242,12 +283,16 @@ export default function PlaygroundPage() {
         headers: hdrs,
         body: JSON.stringify({ requestId: msg.requestId, score }),
       });
-      if (!res.ok) return;
-      const updated = messages.map((m, i) => (i === messageIndex ? { ...m, feedback: verdict } : m));
-      setMessages(updated);
-      sessionStorage.setItem("pg:messages", JSON.stringify(updated));
+      if (!res.ok) {
+        // Roll back
+        const rolled = messages.map((m, i) => (i === messageIndex ? { ...m, feedbackScore: previousScore } : m));
+        setMessages(rolled);
+        sessionStorage.setItem("pg:messages", JSON.stringify(rolled));
+      }
     } catch {
-      // Swallow — UI stays unmarked, user can retry
+      const rolled = messages.map((m, i) => (i === messageIndex ? { ...m, feedbackScore: previousScore } : m));
+      setMessages(rolled);
+      sessionStorage.setItem("pg:messages", JSON.stringify(rolled));
     }
   }
 
@@ -350,35 +395,11 @@ export default function PlaygroundPage() {
                   <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
                 </div>
                 {msg.role === "assistant" && !isGuardrail && msg.requestId && (
-                  <div className="flex gap-1 mt-1.5 ml-1">
-                    <button
-                      onClick={() => handleFeedback(i, "up")}
-                      disabled={!!msg.feedback}
-                      title={msg.feedback === "up" ? "Thanks — feedback recorded" : "Good response"}
-                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${
-                        msg.feedback === "up"
-                          ? "bg-emerald-900/40 border-emerald-700 text-emerald-300"
-                          : msg.feedback
-                          ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
-                          : "border-zinc-700 text-zinc-400 hover:text-emerald-300 hover:border-emerald-700"
-                      }`}
-                    >
-                      👍
-                    </button>
-                    <button
-                      onClick={() => handleFeedback(i, "down")}
-                      disabled={!!msg.feedback}
-                      title={msg.feedback === "down" ? "Thanks — feedback recorded" : "Poor response"}
-                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${
-                        msg.feedback === "down"
-                          ? "bg-rose-900/40 border-rose-700 text-rose-300"
-                          : msg.feedback
-                          ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
-                          : "border-zinc-700 text-zinc-400 hover:text-rose-300 hover:border-rose-700"
-                      }`}
-                    >
-                      👎
-                    </button>
+                  <div className="mt-1.5 ml-1">
+                    <StarRating
+                      value={msg.feedbackScore}
+                      onChange={(v) => handleRate(i, v)}
+                    />
                   </div>
                 )}
               </div>

--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -44,13 +44,40 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
     }
 
     const tokenInfo = getTokenInfo(c.req.raw);
-    const id = nanoid();
+    const resolvedTenant = tenantId || tokenInfo?.tenant || null;
 
+    // Upsert: one user-feedback row per (requestId, tenant). If the caller is
+    // updating their rating, patch the existing row in place so we don't flood
+    // the table with duplicates. Adaptive updates only fire on first insert —
+    // rating changes don't re-push the EMA (avoids double-counting the same
+    // signal from the same user).
+    const existing = await db
+      .select()
+      .from(feedback)
+      .where(
+        and(
+          eq(feedback.requestId, body.requestId),
+          eq(feedback.source, "user"),
+          resolvedTenant ? eq(feedback.tenantId, resolvedTenant) : sql`${feedback.tenantId} IS NULL`,
+        ),
+      )
+      .get();
+
+    if (existing) {
+      await db
+        .update(feedback)
+        .set({ score: body.score, comment: body.comment ?? existing.comment })
+        .where(eq(feedback.id, existing.id))
+        .run();
+      return c.json({ id: existing.id, requestId: body.requestId, score: body.score, updated: true });
+    }
+
+    const id = nanoid();
     await db.insert(feedback)
       .values({
         id,
         requestId: body.requestId,
-        tenantId: tenantId || tokenInfo?.tenant || null,
+        tenantId: resolvedTenant,
         score: body.score,
         comment: body.comment || null,
         source: "user",
@@ -64,11 +91,11 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
         request.provider,
         request.model,
         body.score,
-        "user"
+        "user",
       );
     }
 
-    return c.json({ id, requestId: body.requestId, score: body.score }, 201);
+    return c.json({ id, requestId: body.requestId, score: body.score, updated: false }, 201);
   });
 
   // List recent feedback

--- a/packages/gateway/tests/feedback-upsert.test.ts
+++ b/packages/gateway/tests/feedback-upsert.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { feedback, requests } from "@provara/db";
+import { nanoid } from "nanoid";
+import { eq } from "drizzle-orm";
+import { createFeedbackRoutes } from "../src/routes/feedback.js";
+import { createAdaptiveRouter } from "../src/routing/adaptive.js";
+import { makeTestDb } from "./_setup/db.js";
+
+async function buildTestApp() {
+  const db = await makeTestDb();
+  const adaptive = await createAdaptiveRouter(db);
+  const app = new Hono();
+  app.route("/v1/feedback", createFeedbackRoutes(db, adaptive));
+  return { db, app };
+}
+
+async function seedRequest(db: Awaited<ReturnType<typeof makeTestDb>>) {
+  const id = nanoid();
+  await db.insert(requests).values({
+    id,
+    provider: "openai",
+    model: "gpt-4.1-nano",
+    prompt: "test",
+    response: "ok",
+    taskType: "general",
+    complexity: "medium",
+  }).run();
+  return id;
+}
+
+describe("POST /v1/feedback (#95 upsert)", () => {
+  it("second rating for the same request updates the existing row in place", async () => {
+    const { db, app } = await buildTestApp();
+    const requestId = await seedRequest(db);
+
+    // First rating — inserts
+    const first = await app.request("/v1/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, score: 4 }),
+    });
+    expect(first.status).toBe(201);
+    const firstBody = (await first.json()) as { id: string; score: number; updated: boolean };
+    expect(firstBody.score).toBe(4);
+    expect(firstBody.updated).toBe(false);
+
+    // Second rating — updates
+    const second = await app.request("/v1/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, score: 2 }),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { id: string; score: number; updated: boolean };
+    expect(secondBody.score).toBe(2);
+    expect(secondBody.updated).toBe(true);
+    expect(secondBody.id).toBe(firstBody.id); // same row
+
+    // DB-level assertion: exactly one user-source row for this request, with the latest score
+    const rows = await db.select().from(feedback).where(eq(feedback.requestId, requestId)).all();
+    expect(rows.length).toBe(1);
+    expect(rows[0].score).toBe(2);
+  });
+
+  it("rejects invalid scores and leaves the existing rating untouched", async () => {
+    const { db, app } = await buildTestApp();
+    const requestId = await seedRequest(db);
+
+    await app.request("/v1/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, score: 3 }),
+    });
+
+    const bad = await app.request("/v1/feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId, score: 7 }),
+    });
+    expect(bad.status).toBe(400);
+
+    const rows = await db.select().from(feedback).where(eq(feedback.requestId, requestId)).all();
+    expect(rows.length).toBe(1);
+    expect(rows[0].score).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the binary thumbs-up/down playground feedback (score 5 or 1) with a 5-star rating component that can be updated mid-session. Server-side becomes upsert so a user iterating on their rating doesn't flood the feedback table with duplicates or double-feed the adaptive router.

## Changes

- **`packages/gateway/src/routes/feedback.ts`** — `POST /v1/feedback` now upserts for user feedback. If a row exists for `(requestId, source='user', tenantId)`, update the score in place and return `updated: true` + 200. Otherwise insert + fire `adaptive.updateScore` once + return `updated: false` + 201. Rating changes no longer re-push the EMA.
- **`apps/web/src/app/dashboard/playground/page.tsx`**
  - New `StarRating` component: 5 amber stars, hover preview, click-to-set, click-different-star-to-update.
  - `Message.feedback` (`"up"|"down"`) replaced with `Message.feedbackScore` (1–5).
  - `handleRate(messageIndex, score)` does optimistic update + roll-back on server failure.
  - Removed "lock after first click" behavior.
- **`packages/gateway/tests/feedback-upsert.test.ts`** (new)
  - Two consecutive POSTs with different scores → one row, latest score, `updated` transitions `false → true`, same `id`.
  - Invalid score rejected and the existing rating untouched.

## Test plan

- [x] `npm test -w packages/gateway` → 18/18 passing (16 pre-existing + 2 new)
- [x] `tsc --noEmit` clean on gateway + web
- [ ] Deploy; rate a playground response 4 stars, change to 2 stars, refresh — still shows 2 stars, one `feedback` row in DB
- [ ] Post-deploy sanity: rate the same response twice with identical score — no extra row, `updated: true` returned

## Design choices worth calling out

- **Optimistic UI** — the UX feels snappy because the stars update before the POST round-trip completes. Server failure rolls back, but this is rare.
- **No adaptive re-push on update** — conservative. A user changing 5 → 2 doesn't "subtract 3" from the EMA. Alternative (re-push with signed delta) is more complex and may over-correct.
- **No judge-source upsert** — judge scores still insert fresh rows. Different semantics: a judge scoring the same response twice (e.g. at different rates) is legitimately new signal.

Closes #95

Authored-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)
