### PR TITLE
fix(#99): playground input refocus after send

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -115,6 +115,14 @@ export default function PlaygroundPage() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, streamingContent]);
 
+  // The textarea is disabled while `streaming` is true, which blurs it. When
+  // streaming flips back to false, React re-enables the element on the next
+  // commit — refocus here so the user can keep typing without clicking back in.
+  // Also fires once on mount (streaming starts false) to give the page focus.
+  useEffect(() => {
+    if (!streaming) inputRef.current?.focus();
+  }, [streaming]);
+
   const allModels = providers.flatMap((p) =>
     p.models.map((m) => ({ provider: p.name, model: m }))
   );
@@ -244,7 +252,6 @@ export default function PlaygroundPage() {
     } finally {
       setStreaming(false);
       sessionStorage.removeItem("pg:streaming");
-      inputRef.current?.focus();
     }
   }
 


### PR DESCRIPTION
## Summary

Fix UAT bug: after sending a message in the playground chat, the textarea lost focus and required a click to return.

Closes #99.

### Root cause

The textarea has `disabled={streaming}`. When `setStreaming(true)` fires, React commits `disabled=true` and the browser blurs the element (disabled inputs cannot hold focus). When streaming completes, `streamInBackground`'s finally block called:

```ts
setStreaming(false);
sessionStorage.removeItem("pg:streaming");
inputRef.current?.focus();
```

`setStreaming(false)` schedules a re-render — it does not update the DOM synchronously. So `.focus()` ran on the still-disabled element and the browser rejected it.

### Fix

Replace the imperative focus call with a `useEffect` keyed on `[streaming]`. The effect runs *after* React commits `disabled=false`, so focus lands on an enabled element.

Side benefit: the same effect fires on mount (initial `streaming` is false), so the page loads with the input already focused — one fewer click for the very first message too.

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] Load `/dashboard/playground` — cursor lands in the input on page load.
- [ ] Send a message with **Enter**, wait for the streamed reply, confirm focus is back in the textarea.
- [ ] Send via the **Send** button (mouse click), confirm focus returns after the reply.
- [ ] Trigger the error branch (e.g. bogus model) — focus still returns.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)