### PR TITLE
fix(#101): copy gateway openapi.yaml into web Docker build

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,6 +19,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY package.json package-lock.json tsconfig.json ./
 COPY apps/web ./apps/web
 COPY packages/db ./packages/db
+COPY packages/gateway/openapi.yaml ./packages/gateway/openapi.yaml
 
 ENV NEXT_TELEMETRY_DISABLED=1
 


### PR DESCRIPTION
## Summary

Fixes the Railway build failure introduced by #97:

```
[sync-openapi] source not found: /app/packages/gateway/openapi.yaml
npm error Lifecycle script `build` failed with error: exit code 1
```

Closes #101.

### Root cause

`apps/web/scripts/sync-openapi.mjs` (added in #97) runs as `prebuild` and copies `packages/gateway/openapi.yaml` into `apps/web/public/`. The web Dockerfile only copies `apps/web/` and `packages/db/` into the builder stage — the gateway package was never in the container, so the source file wasn't there when `npm run build` ran.

Locally this worked because the resolve-relative path found the file on the host filesystem — the regression only surfaced under Docker.

### Fix

Add one line to the web Dockerfile's builder stage:

```dockerfile
COPY packages/gateway/openapi.yaml ./packages/gateway/openapi.yaml
```

Surgical — copies only the spec file, not the gateway's source or deps.

### Rejected alternative

Making `sync-openapi.mjs` soft-fail on missing source. Would have silently hidden real errors (renames, accidental deletes) in dev. Better to make the build context correct.

## Test plan

- [x] `docker build -f apps/web/Dockerfile .` succeeds locally.
- [ ] Railway build on master succeeds.
- [ ] `/docs/api` renders Scalar reference on deployed instance.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)