### PR TITLE
feat(#103): ε-greedy exploration for adaptive router

### DIFF
--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -969,7 +969,7 @@ components:
           enum: [simple, medium, complex]
         routedBy:
           type: string
-          enum: [classification, routing-hint, ab-test, adaptive, user-override]
+          enum: [classification, routing-hint, ab-test, adaptive, exploration, user-override]
           description: Which branch of the routing engine picked the target.
         usedFallback:
           type: boolean
@@ -1169,6 +1169,9 @@ components:
           type: integer
         providerCount:
           type: integer
+        rate:
+          type: number
+          description: ε-greedy exploration rate (only present on the `exploration` stage)
 
     PipelineStats:
       type: object
@@ -1186,6 +1189,8 @@ components:
             abTest:
               $ref: "#/components/schemas/PipelineStageStats"
             adaptive:
+              $ref: "#/components/schemas/PipelineStageStats"
+            exploration:
               $ref: "#/components/schemas/PipelineStageStats"
             fallback:
               $ref: "#/components/schemas/PipelineStageStats"

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -306,6 +306,12 @@ export function createAnalyticsRoutes(db: Db) {
           active: (feedbackCount?.count || 0) > 0,
           feedbackCount: feedbackCount?.count || 0,
         },
+        exploration: {
+          count: routedByMap["exploration"]?.count || 0,
+          avgLatency: routedByMap["exploration"]?.avgLatency || 0,
+          active: parseFloat(process.env.PROVARA_EXPLORATION_RATE || "0.1") > 0,
+          rate: parseFloat(process.env.PROVARA_EXPLORATION_RATE || "0.1"),
+        },
         fallback: {
           count: fallbackStats?.count || 0,
           avgLatency: Math.round(fallbackStats?.avgLatency || 0),

--- a/packages/gateway/src/routing/adaptive.ts
+++ b/packages/gateway/src/routing/adaptive.ts
@@ -15,6 +15,13 @@ import { getPricing } from "../cost/index.js";
 const EMA_ALPHA = parseFloat(process.env.PROVARA_EMA_ALPHA || "0.2");
 const MIN_SAMPLES = parseInt(process.env.PROVARA_MIN_SAMPLES || "5");
 
+// ε-greedy exploration: with this probability, bypass the EMA and pick
+// uniformly at random from the full candidate list — including models with
+// zero samples. Prevents cold-start lock-in where one model accumulates enough
+// samples to clear MIN_SAMPLES before any competitor does and then wins
+// permanently because no alternative is ever eligible. Set to 0 to disable.
+const EXPLORATION_RATE = parseFloat(process.env.PROVARA_EXPLORATION_RATE || "0.1");
+
 export type FeedbackSource = "user" | "judge";
 
 function getQualityAlpha(source: FeedbackSource): number {
@@ -258,14 +265,28 @@ export async function createAdaptiveRouter(db: Db) {
     }
   }
 
-  // Get the best model for a routing cell, considering quality scores and profile
+  // Get the best model for a routing cell, considering quality scores and profile.
+  // Returns `via: "exploration"` when the ε-greedy branch fired (uniform-random
+  // from allCandidates, ignoring EMA) and `via: "adaptive"` when the EMA-scoring
+  // branch picked the winner. Returns null when no adaptive candidate qualifies
+  // and exploration didn't fire — caller falls through to cheapest-first.
   function getBestModel(
     taskType: TaskType,
     complexity: Complexity,
     profile: RoutingProfile,
     availableProviders: Set<string>,
+    allCandidates: RouteTarget[],
     customWeights?: RoutingWeights
-  ): RouteTarget | null {
+  ): { target: RouteTarget; via: "adaptive" | "exploration" } | null {
+    // ε-greedy: skip the EMA and pick uniformly at random from the full
+    // candidate list. Runs before the sample-count filter so zero-sample
+    // models get a chance to accumulate their first ratings.
+    const eligibleForExploration = allCandidates.filter((c) => availableProviders.has(c.provider));
+    if (eligibleForExploration.length > 1 && Math.random() < EXPLORATION_RATE) {
+      const pick = eligibleForExploration[Math.floor(Math.random() * eligibleForExploration.length)];
+      return { target: pick, via: "exploration" };
+    }
+
     const ck = cellKey(taskType, complexity);
     const cellScores = emaScores.get(ck);
 
@@ -293,7 +314,7 @@ export async function createAdaptiveRouter(db: Db) {
       }
     }
 
-    return best?.target || null;
+    return best ? { target: best.target, via: "adaptive" } : null;
   }
 
   // Get all scores for a cell (for dashboard display)

--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -149,12 +149,19 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
 
     // A/B test candidate (may or may not run before adaptive based on config)
     const abResult = await findActiveAbTest(taskType, complexity);
-    const adaptiveTarget = adaptive.getBestModel(taskType, complexity, profile, availableProviders, request.routingWeights);
+    const adaptiveResult = adaptive.getBestModel(
+      taskType,
+      complexity,
+      profile,
+      availableProviders,
+      allFallbacks,
+      request.routingWeights
+    );
 
     // Ordering:
-    //   - abTestPreempts=true (default): A/B test wins if present, else adaptive.
-    //   - abTestPreempts=false: adaptive wins if it has enough samples, else A/B test.
-    const preferAb = abTestPreempts || !adaptiveTarget;
+    //   - abTestPreempts=true (default): A/B test wins if present, else adaptive/exploration.
+    //   - abTestPreempts=false: adaptive/exploration wins if one was produced, else A/B test.
+    const preferAb = abTestPreempts || !adaptiveResult;
 
     if (preferAb && abResult) {
       return {
@@ -172,17 +179,18 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
       };
     }
 
-    if (adaptiveTarget) {
+    if (adaptiveResult) {
+      const { target, via } = adaptiveResult;
       return {
-        provider: adaptiveTarget.provider,
-        model: adaptiveTarget.model,
+        provider: target.provider,
+        model: target.model,
         taskType,
         complexity,
-        routedBy: "adaptive",
+        routedBy: via === "exploration" ? "exploration" : "adaptive",
         usedFallback: false,
         usedLlmFallback: classification.usedLlmFallback,
         fallbacks: allFallbacks.filter(
-          (t) => !(t.provider === adaptiveTarget.provider && t.model === adaptiveTarget.model)
+          (t) => !(t.provider === target.provider && t.model === target.model)
         ),
       };
     }

--- a/packages/gateway/src/routing/types.ts
+++ b/packages/gateway/src/routing/types.ts
@@ -10,7 +10,7 @@ export interface RoutingResult {
   model: string;
   taskType: TaskType;
   complexity: Complexity;
-  routedBy: "classification" | "user-override" | "routing-hint" | "ab-test" | "adaptive";
+  routedBy: "classification" | "user-override" | "routing-hint" | "ab-test" | "adaptive" | "exploration";
   abTestId?: string;
   usedFallback: boolean;
   usedLlmFallback: boolean;

--- a/packages/gateway/tests/router.test.ts
+++ b/packages/gateway/tests/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { createRoutingEngine } from "../src/routing/index.js";
 import { setRoutingConfig } from "../src/routing/config.js";
 import { makeTestDb } from "./_setup/db.js";
@@ -145,6 +145,82 @@ describe("routing engine", () => {
       if (result.complexity === "medium") {
         expect(result.routedBy).toBe("ab-test");
       }
+    });
+  });
+
+  // ε-greedy exploration (#103): breaks cold-start lock-in where one model
+  // accumulates enough samples to clear MIN_SAMPLES and then wins forever
+  // because no competitor is ever eligible. Math.random is stubbed to make
+  // the two branches deterministic.
+  describe("epsilon-greedy exploration (#103)", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("exploration branch picks a candidate regardless of sample count when Math.random < ε", async () => {
+      // Force exploration: Math.random always returns 0.0, which is < ε=0.1,
+      // and also makes the index pick land on 0 (the first candidate).
+      // Using mockReturnValue (not Once) avoids brittleness if other code paths
+      // consume the mock before getBestModel runs.
+      vi.spyOn(Math, "random").mockReturnValue(0.0);
+
+      const db = await makeTestDb();
+      const registry = makeFakeRegistry([
+        makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+        makeFakeProvider({ name: "anthropic", models: ["claude-opus-4-7"] }),
+      ]);
+      const engine = await createRoutingEngine({ registry, db });
+
+      const result = await engine.route({
+        messages: [{ role: "user", content: "hi" }],
+        routingHint: "general",
+      });
+
+      // Neither model has any samples — the only path that produces a route
+      // without the cheapest-first fallback firing is exploration.
+      expect(result.routedBy).toBe("exploration");
+    });
+
+    it("skips exploration when Math.random >= ε and falls through normally", async () => {
+      // Return 0.5 on every call — well above ε=0.1 default, so exploration never fires.
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+      const db = await makeTestDb();
+      const registry = makeFakeRegistry([
+        makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+        makeFakeProvider({ name: "anthropic", models: ["claude-opus-4-7"] }),
+      ]);
+      const engine = await createRoutingEngine({ registry, db });
+
+      const result = await engine.route({
+        messages: [{ role: "user", content: "hi" }],
+        routingHint: "general",
+      });
+
+      // With no samples anywhere, adaptive returns null and we fall through to
+      // the cheapest-first classification fallback. Critically, routedBy is
+      // NOT "exploration".
+      expect(result.routedBy).not.toBe("exploration");
+    });
+
+    it("exploration is disabled when only one candidate exists (no meaningful choice)", async () => {
+      // Gate at 0.0 would normally force exploration, but the single-candidate
+      // guard should skip the branch and fall through to the normal flow.
+      vi.spyOn(Math, "random").mockReturnValue(0.0);
+
+      const db = await makeTestDb();
+      const registry = makeFakeRegistry([
+        makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+      ]);
+      const engine = await createRoutingEngine({ registry, db });
+
+      const result = await engine.route({
+        messages: [{ role: "user", content: "hi" }],
+        routingHint: "general",
+      });
+
+      expect(result.routedBy).not.toBe("exploration");
+      expect(result.model).toBe("gpt-4.1-nano");
     });
   });
 });


### PR DESCRIPTION
## Summary

Breaks cold-start lock-in in the adaptive router. Closes #103.

### Problem

One model accumulates enough samples to clear `PROVARA_MIN_SAMPLES` before any competitor, then wins forever because no alternative is ever eligible. The routing matrix today (see issue body) shows `gpt-4.1-nano` winning nearly every cell — including `coding/complex` at an EMA of **2.44** — because alternatives are stuck below the 5-sample threshold.

### Fix

With probability ε (env `PROVARA_EXPLORATION_RATE`, default `0.1`), the router bypasses the EMA and picks **uniformly at random** from the full candidate list (including models with zero samples). The other 90% runs existing quality/cost/latency scoring unchanged.

### Changes

| File | Change |
|---|---|
| `routing/adaptive.ts` | Add `EXPLORATION_RATE` env var. `getBestModel` gains `allCandidates: RouteTarget[]` param. Return type widens to `{ target; via: "adaptive" \| "exploration" } \| null` |
| `routing/index.ts` | Pass `allFallbacks` as `allCandidates`; unpack `.target`/`.via`; map `via` → `routedBy` |
| `routing/types.ts` | `routedBy` union: add `"exploration"` |
| `routes/analytics.ts` | New `exploration` bucket on `/v1/analytics/pipeline` with the configured rate |
| `openapi.yaml` | Extend `routedBy` enum + `PipelineStageStats.rate` |
| `tests/router.test.ts` | 3 tests: exploration fires, skipped, single-candidate guard |

### Design choices (from issue)

- **Uniform sampling**, not profile-weighted. Profile weighting would let cheap models dominate exploration too, defeating cold-start.
- **Constant ε**, no decay. Users lower the env var manually as the matrix matures.
- **No cost-gating.** Exploration may pick Opus on a simple query. Set `ε=0` if that's a concern.
- **A/B tests still preempt** exploration when `abTestPreempts=true`. Exploration replaces the adaptive slot only.

### Out of scope (follow-up issues worth opening)

- Pipeline visualization node for `exploration` — needs UX-layout decisions (parallel/before/after adaptive node).
- Exploration budget cap (don't burn > N× cheapest-candidate cost per hour).
- Decaying ε over per-cell sample counts.

## Test plan

- [x] `tsc --noEmit` clean for gateway.
- [x] All 21 gateway tests pass, including 3 new exploration tests.
- [ ] Deploy to Railway with `PROVARA_EXPLORATION_RATE=0.2` (temporarily, to accelerate cold-start recovery) and `PROVARA_MIN_SAMPLES=2`. Watch the routing matrix — within a day, `Complex` column cells should start accumulating non-nano samples.
- [ ] Once matrix has coverage, drop `PROVARA_EXPLORATION_RATE` back to `0.1` or `0.05`.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)