### PR TITLE
fix(#105): copy public/ into web Dockerfile runner stage

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -42,6 +42,7 @@ ENV HOSTNAME=0.0.0.0
 
 COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /app/apps/web/public ./apps/web/public
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary

Fixes prod /docs/api: Scalar was rendering its error UI ("Document 'api-1' could not be loaded") with a blank fallback div because `/openapi.yaml` 404'd in production.

Closes #105.

### Root cause

Next.js `output: "standalone"` produces a minimal server bundle in `.next/standalone`, but **`public/` is not automatically included** — neither is `.next/static`. Both must be copied explicitly. The runner stage copied `.next/static` but not `public/`.

So `apps/web/public/openapi.yaml` — which the prebuild sync script generates from `packages/gateway/openapi.yaml` — never made it into the runtime image. Scalar fetched `/openapi.yaml`, got 404, and fell back to its error layout.

This affects every file in `apps/web/public/` on prod, not just the OpenAPI spec.

### Fix

One line added to the runner stage:

```dockerfile
COPY --from=builder /app/apps/web/public ./apps/web/public
```

## Test plan

- [ ] Railway build succeeds.
- [ ] `https://www.provara.xyz/openapi.yaml` returns 200 with YAML content.
- [ ] `https://www.provara.xyz/docs/api` renders the Scalar reference without the error UI.

**Not locally verified:** did not run `docker build` on this machine. Railway is the real test. This is a documented Next.js gotcha — see https://nextjs.org/docs/app/building-your-application/deploying#docker-image.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)