### PR TITLE
fix(#114): rename Routing matrix — frequency, not top model

### DIFF
--- a/apps/web/src/app/dashboard/routing/page.tsx
+++ b/apps/web/src/app/dashboard/routing/page.tsx
@@ -265,7 +265,10 @@ export default function RoutingPage() {
 
       {/* Routing Matrix */}
       <section>
-        <h2 className="text-lg font-semibold mb-4">Routing Matrix (Top Model per Cell)</h2>
+        <h2 className="text-lg font-semibold mb-1">Most Frequently Called Model per Cell</h2>
+        <p className="text-sm text-zinc-400 mb-4">
+          Based on historical request count. See <a href="/dashboard/quality" className="text-blue-400 hover:text-blue-300 underline">Quality → Adaptive Routing</a> for quality-based routing decisions.
+        </p>
         <RoutingMatrix stats={stats} />
       </section>
 


### PR DESCRIPTION
## Summary

Closes #114.

The Routing page's section heading **"Routing Matrix (Top Model per Cell)"** implied quality-based ranking but the underlying data is request-count. Users reasonably conflated it with the Adaptive Routing heatmap on `/dashboard/quality`, which actually does pick by live EMA score — and the two matrices disagreed because they measure different questions.

## Change

`apps/web/src/app/dashboard/routing/page.tsx:268` — rename the heading to **"Most Frequently Called Model per Cell"** and add a small subhead pointing at the Quality page for quality-based routing decisions. Dropped the "Routing Matrix" prefix: we're on the Routing page and the grid is self-evidently a matrix.

Request-count logic is intentionally preserved. Rejected alternative: re-sourcing the Routing matrix from `/v1/analytics/adaptive/scores` — that was the original plan, but the request-count view is genuinely a different, useful question (where traffic actually went). Honest labeling is the right fix, not a data swap.

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] Manual QA on Railway: heading reads correctly, subhead link to Quality page works.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)