### PR TITLE
fix(#113): replay preserves original classification

### DIFF
--- a/apps/web/src/app/dashboard/logs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/logs/[id]/page.tsx
@@ -192,12 +192,19 @@ export default function RequestDetailPage() {
     try {
       const messages = formatMessages(request.prompt);
       const start = performance.now();
+      // Preserve the original request's cell so the replay's EMA signal
+      // lands where it belongs. Without these hints the router falls into
+      // its "model-only pin" branch and defaults to general/medium,
+      // polluting that cell with misclassified samples (#113).
+      const replayBody: Record<string, unknown> = {
+        model: replayModel,
+        messages,
+      };
+      if (request.taskType) replayBody.routing_hint = request.taskType;
+      if (request.complexity) replayBody.complexity_hint = request.complexity;
       const res = await gatewayFetchRaw("/v1/chat/completions", {
         method: "POST",
-        body: JSON.stringify({
-          model: replayModel,
-          messages,
-        }),
+        body: JSON.stringify(replayBody),
       });
       const latencyMs = Math.round(performance.now() - start);
       const data = await res.json();
@@ -471,6 +478,9 @@ export default function RequestDetailPage() {
         <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4 space-y-4">
           <p className="text-xs text-zinc-500">
             Send the same prompt to a different model and compare results.
+            {request.taskType && request.complexity && (
+              <> Ratings on this replay train the <code className="text-zinc-400">{request.taskType}/{request.complexity}</code> cell, matching the original.</>
+            )}
           </p>
           <div className="flex gap-3 items-end">
             <div className="flex-1">


### PR DESCRIPTION
## Summary

Closes #113.

Replaying any log previously landed in `general/medium` regardless of the original request's classification, polluting the adaptive-routing matrix with misclassified samples.

## Root cause

`handleReplay` in `apps/web/src/app/dashboard/logs/[id]/page.tsx:187` posted only `{ model, messages }`. That tripped the gateway's "model-only pin" branch in `routing/index.ts:123-138`, which pins the provider-for-model but **skips classification entirely**, defaulting to `taskType: "general"` and `complexity: "medium"`.

The original request went through the full classifier. Throwing that away on replay was the bug.

## Fix

Pass `routing_hint` + `complexity_hint` from the original's `request.taskType` / `request.complexity` in the replay POST when both are non-null. Replays of pre-classifier data (nullable fields on the DB row) keep the current behavior.

Also surfaced to the user: the replay description now reads "Ratings on this replay train the `<taskType>/<complexity>` cell, matching the original." So the EMA plumbing is visible, not hidden.

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] Manual: replay a log from a non-general cell, rate the replay, confirm the EMA bumps on the matching `(taskType, complexity, replay_model)` cell — not on `general/medium`.
- [ ] Replay a pre-classifier log (nullable taskType) — confirm current default-behavior still fires.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)