### PR TITLE
fix(#112): server-side sort for Recent Requests

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -121,11 +121,18 @@ export default function Dashboard() {
   const [totalRequests, setTotalRequests] = useState(0);
   const [reqPage, setReqPage] = useState(0);
   const [reqPageSize, setReqPageSize] = useState(10);
+  const [reqSortKey, setReqSortKey] = useState<string | null>(null);
+  const [reqSortDir, setReqSortDir] = useState<"asc" | "desc" | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const fetchRequests = useCallback(async (page: number, pageSize: number) => {
+  const fetchRequests = useCallback(async (page: number, pageSize: number, sortKey: string | null, sortDir: "asc" | "desc" | null) => {
     try {
-      const data = await gatewayClientFetch<{ requests: RequestRow[]; total: number }>(`/v1/analytics/requests?limit=${pageSize}&offset=${page * pageSize}`);
+      const params = new URLSearchParams({ limit: String(pageSize), offset: String(page * pageSize) });
+      if (sortKey && sortDir) {
+        params.set("orderBy", sortKey);
+        params.set("order", sortDir);
+      }
+      const data = await gatewayClientFetch<{ requests: RequestRow[]; total: number }>(`/v1/analytics/requests?${params}`);
       setRecentRequests(data.requests || []);
       setTotalRequests(data.total || 0);
     } catch (err) {
@@ -150,20 +157,20 @@ export default function Dashboard() {
 
   useEffect(() => {
     fetchDashboard();
-    fetchRequests(0, reqPageSize);
+    fetchRequests(0, reqPageSize, reqSortKey, reqSortDir);
 
     // Auto-refresh every 10 seconds
     const interval = setInterval(() => {
       fetchDashboard();
-      fetchRequests(reqPage, reqPageSize);
+      fetchRequests(reqPage, reqPageSize, reqSortKey, reqSortDir);
     }, 10_000);
     return () => clearInterval(interval);
-  }, [fetchDashboard, fetchRequests, reqPage, reqPageSize]);
+  }, [fetchDashboard, fetchRequests, reqPage, reqPageSize, reqSortKey, reqSortDir]);
 
-  // Also fetch immediately on page/size change
+  // Also fetch immediately on page/size/sort change
   useEffect(() => {
-    fetchRequests(reqPage, reqPageSize);
-  }, [reqPage, reqPageSize, fetchRequests]);
+    fetchRequests(reqPage, reqPageSize, reqSortKey, reqSortDir);
+  }, [reqPage, reqPageSize, reqSortKey, reqSortDir, fetchRequests]);
 
   // Add a subtle live indicator
   const [lastRefresh, setLastRefresh] = useState(new Date());
@@ -226,6 +233,15 @@ export default function Dashboard() {
                 onPageChange: setReqPage,
                 pageSize: reqPageSize,
                 onPageSizeChange: (size) => { setReqPageSize(size); setReqPage(0); },
+              }}
+              serverSort={{
+                sortKey: reqSortKey,
+                sortDir: reqSortDir,
+                onSortChange: (key, dir) => {
+                  setReqSortKey(key);
+                  setReqSortDir(dir);
+                  setReqPage(0);
+                },
               }}
             />
           </section>

--- a/apps/web/src/components/data-table.tsx
+++ b/apps/web/src/components/data-table.tsx
@@ -12,6 +12,8 @@ export interface Column<T> {
   getValue?: (row: T) => string | number | null;
 }
 
+type SortDir = "asc" | "desc" | null;
+
 interface DataTableProps<T> {
   columns: Column<T>[];
   data: T[];
@@ -26,9 +28,16 @@ interface DataTableProps<T> {
     pageSize: number;
     onPageSizeChange: (size: number) => void;
   };
+  // Server-side sort. Pair with serverPagination so the parent can refetch
+  // with orderBy/order query params when the user clicks a sortable header.
+  // Without this, server-paginated tables silently no-op on sort clicks
+  // (can't client-sort across pages you don't have).
+  serverSort?: {
+    sortKey: string | null;
+    sortDir: SortDir;
+    onSortChange: (sortKey: string | null, sortDir: SortDir) => void;
+  };
 }
-
-type SortDir = "asc" | "desc" | null;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function DataTable<T extends Record<string, any>>({
@@ -38,14 +47,18 @@ export function DataTable<T extends Record<string, any>>({
   pageSizeOptions = [10, 25, 50, 100],
   emptyMessage = "No data available.",
   serverPagination,
+  serverSort,
 }: DataTableProps<T>) {
-  const [sortKey, setSortKey] = useState<string | null>(null);
-  const [sortDir, setSortDir] = useState<SortDir>(null);
+  const [localSortKey, setLocalSortKey] = useState<string | null>(null);
+  const [localSortDir, setLocalSortDir] = useState<SortDir>(null);
   const [filters, setFilters] = useState<Record<string, string>>({});
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(defaultPageSize);
 
   const isServerPaginated = !!serverPagination;
+  const isServerSorted = !!serverSort;
+  const sortKey = isServerSorted ? serverSort.sortKey : localSortKey;
+  const sortDir: SortDir = isServerSorted ? serverSort.sortDir : localSortDir;
 
   // Client-side filtering (applies even with server pagination — filters the current page)
   const filtered = useMemo(() => {
@@ -62,9 +75,14 @@ export function DataTable<T extends Record<string, any>>({
     );
   }, [data, filters, columns]);
 
-  // Client-side sorting
+  // Client-side sorting.
+  // If serverSort is controlling the state, the parent already asked the server
+  // for sorted data — render it as-is. If the table is server-paginated but no
+  // serverSort handler was provided, we can't sort across pages we don't have,
+  // so we render unsorted and the click still flips the arrow (degraded but
+  // not worse than before).
   const sorted = useMemo(() => {
-    if (isServerPaginated) return filtered;
+    if (isServerSorted || isServerPaginated) return filtered;
     if (!sortKey || !sortDir) return filtered;
 
     const col = columns.find((c) => c.key === sortKey);
@@ -84,7 +102,7 @@ export function DataTable<T extends Record<string, any>>({
       }
       return sortDir === "desc" ? -cmp : cmp;
     });
-  }, [filtered, sortKey, sortDir, columns, isServerPaginated]);
+  }, [filtered, sortKey, sortDir, columns, isServerPaginated, isServerSorted]);
 
   // Pagination
   const currentPageSize = isServerPaginated ? serverPagination.pageSize : pageSize;
@@ -96,12 +114,20 @@ export function DataTable<T extends Record<string, any>>({
     : sorted.slice(currentPage * currentPageSize, (currentPage + 1) * currentPageSize);
 
   function handleSort(key: string) {
+    let nextKey: string | null = sortKey;
+    let nextDir: SortDir = sortDir;
     if (sortKey === key) {
-      if (sortDir === "asc") setSortDir("desc");
-      else if (sortDir === "desc") { setSortKey(null); setSortDir(null); }
+      if (sortDir === "asc") nextDir = "desc";
+      else if (sortDir === "desc") { nextKey = null; nextDir = null; }
     } else {
-      setSortKey(key);
-      setSortDir("asc");
+      nextKey = key;
+      nextDir = "asc";
+    }
+    if (isServerSorted) {
+      serverSort.onSortChange(nextKey, nextDir);
+    } else {
+      setLocalSortKey(nextKey);
+      setLocalSortDir(nextDir);
     }
   }
 

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -809,6 +809,18 @@ paths:
           in: query
           schema:
             type: string
+        - name: orderBy
+          in: query
+          description: Column to sort by. Values outside the server whitelist are ignored (falls back to `createdAt`).
+          schema:
+            type: string
+            enum: [createdAt, latencyMs, inputTokens, outputTokens, provider, model, taskType, complexity, routedBy, cost]
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
       responses:
         "200":
           description: Paginated request list including `cached`, `usedFallback`, and `fallbackErrors` per row.

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -1,8 +1,25 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { requests, costLogs, abTests, feedback } from "@provara/db";
-import { desc, sql, eq, and, gte } from "drizzle-orm";
+import { desc, asc, sql, eq, and, gte } from "drizzle-orm";
+import type { SQLWrapper } from "drizzle-orm";
 import { getTenantId } from "../auth/tenant.js";
+
+// Whitelist of columns exposed to client-driven sort on /requests. Never map
+// raw user input into a SQL expression — anything not in this table silently
+// falls back to the default (createdAt desc).
+const REQUESTS_SORT_COLUMNS: Record<string, SQLWrapper> = {
+  createdAt: requests.createdAt,
+  latencyMs: requests.latencyMs,
+  inputTokens: requests.inputTokens,
+  outputTokens: requests.outputTokens,
+  provider: requests.provider,
+  model: requests.model,
+  taskType: requests.taskType,
+  complexity: requests.complexity,
+  routedBy: requests.routedBy,
+  cost: costLogs.cost,
+};
 
 export function createAnalyticsRoutes(db: Db) {
   const app = new Hono();
@@ -15,6 +32,13 @@ export function createAnalyticsRoutes(db: Db) {
     const provider = c.req.query("provider");
     const model = c.req.query("model");
     const taskType = c.req.query("taskType");
+    const orderByParam = c.req.query("orderBy");
+    const orderParam = c.req.query("order") === "asc" ? "asc" : "desc";
+
+    const sortCol = orderByParam ? REQUESTS_SORT_COLUMNS[orderByParam] : undefined;
+    const orderExpr = sortCol
+      ? (orderParam === "asc" ? asc(sortCol) : desc(sortCol))
+      : desc(requests.createdAt);
 
     const rows = (await db
       .select({
@@ -39,7 +63,7 @@ export function createAnalyticsRoutes(db: Db) {
       .from(requests)
       .leftJoin(costLogs, eq(requests.id, costLogs.requestId))
       .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
-      .orderBy(desc(requests.createdAt))
+      .orderBy(orderExpr)
       .limit(limit)
       .offset(offset)
       .all())


### PR DESCRIPTION
## Summary

Closes #112.

Sort headers on the dashboard's Recent Requests table were a no-op. `DataTable` (components/data-table.tsx:67) short-circuited client sort whenever `serverPagination` was set, and the backend had no `orderBy` param. Users clicking a column header got a rotating arrow and nothing else.

## Changes

### Backend

- `GET /v1/analytics/requests` accepts `orderBy` + `order` query params.
- A whitelist in `routes/analytics.ts` maps accepted keys (`createdAt`, `latencyMs`, `inputTokens`, `outputTokens`, `provider`, `model`, `taskType`, `complexity`, `routedBy`, `cost`) to Drizzle column references. Anything outside the whitelist is silently ignored — raw user input never touches a SQL expression.
- Default behavior unchanged: `createdAt desc` when no sort is specified.

### Frontend

- `DataTable` gains an optional `serverSort` prop: `{ sortKey, sortDir, onSortChange }`. When supplied, header clicks invoke the parent's handler instead of mutating local state.
- Without `serverSort`, server-paginated tables stay in the old degraded state (unsorted, no misleading reorder) — still better than the current "rotating arrow, no effect" behavior.
- Dashboard Recent Requests section wires up sort state, passes it through to the API, and resets page to 0 on sort change.

### OpenAPI

- Documents the new `orderBy` and `order` params with the enum of valid values.

### Audit

Only one server-paginated `DataTable` instance exists in the app (Dashboard Recent Requests). Logs page has its own paginated table with no sort UI, so it's unaffected. No other call sites needed changes.

## Test plan

- [x] `tsc --noEmit` clean on both gateway and web.
- [x] All 21 gateway tests pass.
- [ ] Manual: click each sortable column header on Dashboard Recent Requests. Confirm the order reflects the full dataset (page through and verify rows are in global sort order, not per-page).
- [ ] Manual: sort, then paginate. Confirm sort persists across pages.
- [ ] Manual: send an unknown `orderBy` via URL (`?orderBy=evil`) — confirm response uses default `createdAt desc`.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)