### PR TITLE
feat(#120): semantic cache for advertisable token savings

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,35 @@ The adaptive winner isn't chosen on quality alone. Each candidate is scored agai
 
 Profiles can be set per API token (via `/v1/admin/tokens`) so a production workload and a throwaway experiment can share the same adaptive scores but route differently.
 
+## How Provara saves tokens
+
+Token cost is a per-token charge from the upstream provider. Wire-level compression (gzip, brotli) doesn't reduce it — tokens are already a compressed representation. The only honest paths to savings are **semantic**: don't bill tokens you've already paid for.
+
+Provara runs two cache layers before any provider call:
+
+1. **Exact-match cache** — in-memory, 5-minute TTL. A byte-for-byte identical prompt hits this in microseconds. No tokens billed. Default-on for deterministic requests (`temperature = 0`).
+2. **Semantic cache** — embeddings + cosine similarity. A prompt that's *semantically equivalent* to one you've seen recently — even if the wording differs — returns the cached response. Also zero tokens billed. Default-on when an OpenAI API key is available.
+
+On a hit from either layer, the `requests` row records `cached = true`, `cache_source = "exact" | "semantic"`, and the `tokens_saved_input` / `tokens_saved_output` columns capture what would have been billed. The dashboard and `/v1/analytics/cache/savings` endpoint aggregate these into the advertisable "Tokens Saved" number.
+
+### Semantic cache mechanics
+
+- **Eligibility:** single-turn user requests with an optional system prompt. Multi-turn conversations miss (history-matching semantics are unresolved — better to miss cleanly than guess).
+- **Match criteria:** same `(tenant, provider, model)`, same system-prompt hash, cosine similarity ≥ `PROVARA_SEMANTIC_CACHE_THRESHOLD` (default `0.97`).
+- **Safety net:** prompts that look personalized ("my ...", "our ...", emails, phone numbers) skip the semantic match. They still hit the exact cache. This is a soft heuristic, not a security boundary.
+- **Model:** `text-embedding-3-small` by default (`PROVARA_EMBEDDING_MODEL`). Cached vectors are tagged with their embedding model, so switching models invalidates the semantic cache without returning stale cross-space matches.
+- **Storage:** DB-backed (`semantic_cache` table) with an in-memory mirror rehydrated on boot. LRU eviction at 10,000 entries per tenant.
+- **Opt-out:** per-request (`{"cache": false}`), per-deployment (`PROVARA_SEMANTIC_CACHE_ENABLED=false`).
+
+### Tuning
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `PROVARA_SEMANTIC_CACHE_ENABLED` | `true` | Hard off-switch. When `false`, the semantic layer is skipped entirely; exact-match cache is unaffected. |
+| `PROVARA_SEMANTIC_CACHE_THRESHOLD` | `0.97` | Cosine similarity required for a match. Raise to err on the side of correctness (fewer hits, zero false positives); lower for aggressive deduplication. |
+| `PROVARA_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model. Must be one of `text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`. |
+| `PROVARA_EMBEDDING_PROVIDER` | `openai` | Only `openai` is supported in the MVP. Unknown values disable semantic cache. |
+
 ## A/B Testing Guide
 
 ![A/B Tests](public/abtests.png)

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -46,6 +46,20 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
+function SavingsCard({ savings }: { savings: { tokensSavedTotal: number; hits: { exact: number; semantic: number; total: number }; hitRate: number } | null }) {
+  const saved = savings?.tokensSavedTotal || 0;
+  const pct = ((savings?.hitRate || 0) * 100).toFixed(1);
+  return (
+    <div className="bg-gradient-to-br from-emerald-950/40 via-zinc-900 to-zinc-900 border border-emerald-900/40 rounded-lg p-5">
+      <p className="text-sm text-emerald-300 mb-1">Tokens Saved</p>
+      <p className="text-2xl font-semibold">{formatTokens(saved)}</p>
+      <p className="text-xs text-zinc-500 mt-1">
+        {pct}% hit rate · {savings?.hits.semantic || 0} semantic / {savings?.hits.exact || 0} exact
+      </p>
+    </div>
+  );
+}
+
 function OnboardingCard() {
   return (
     <section className="bg-gradient-to-br from-blue-950/40 via-zinc-900 to-zinc-900 border border-blue-900/40 rounded-xl p-8">
@@ -114,10 +128,19 @@ const requestColumns: Column<RequestRow>[] = [
   }},
 ];
 
+interface CacheSavings {
+  tokensSavedInput: number;
+  tokensSavedOutput: number;
+  tokensSavedTotal: number;
+  hits: { exact: number; semantic: number; total: number };
+  hitRate: number;
+}
+
 export default function Dashboard() {
   const [overview, setOverview] = useState<Overview | null>(null);
   const [costsByModel, setCostsByModel] = useState<CostByModel[]>([]);
   const [recentRequests, setRecentRequests] = useState<RequestRow[]>([]);
+  const [cacheSavings, setCacheSavings] = useState<CacheSavings | null>(null);
   const [totalRequests, setTotalRequests] = useState(0);
   const [reqPage, setReqPage] = useState(0);
   const [reqPageSize, setReqPageSize] = useState(10);
@@ -142,12 +165,14 @@ export default function Dashboard() {
 
   const fetchDashboard = useCallback(async () => {
     try {
-      const [overviewData, costsData] = await Promise.all([
+      const [overviewData, costsData, savingsData] = await Promise.all([
         gatewayClientFetch<Overview>(`/v1/analytics/overview`),
         gatewayClientFetch<{ costs: CostByModel[] }>(`/v1/analytics/costs/by-model`),
+        gatewayClientFetch<CacheSavings>(`/v1/analytics/cache/savings`).catch(() => null),
       ]);
       setOverview(overviewData);
       setCostsByModel(costsData.costs || []);
+      setCacheSavings(savingsData);
     } catch (err) {
       console.error("Failed to fetch dashboard data:", err);
     } finally {
@@ -202,11 +227,12 @@ export default function Dashboard() {
       ) : (
         <>
           {/* Overview Stats */}
-          <div className="grid grid-cols-4 gap-4">
+          <div className="grid grid-cols-5 gap-4">
             <StatCard label="Total Requests" value={formatNumber(overview?.totalRequests || 0)} />
             <StatCard label="Total Cost" value={formatCost(overview?.totalCost || 0)} />
             <StatCard label="Avg Latency" value={formatLatency(overview?.avgLatency || 0)} />
             <StatCard label="Active Providers" value={String(overview?.providerCount || 0)} />
+            <SavingsCard savings={cacheSavings} />
           </div>
 
           {/* Cost by Model */}

--- a/packages/db/drizzle/0017_chilly_tana_nile.sql
+++ b/packages/db/drizzle/0017_chilly_tana_nile.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `semantic_cache` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`system_prompt_hash` text,
+	`prompt_text` text NOT NULL,
+	`embedding` blob NOT NULL,
+	`embedding_dim` integer NOT NULL,
+	`embedding_model` text NOT NULL,
+	`response` text NOT NULL,
+	`input_tokens` integer NOT NULL,
+	`output_tokens` integer NOT NULL,
+	`hit_count` integer DEFAULT 0 NOT NULL,
+	`created_at` integer NOT NULL,
+	`last_hit_at` integer
+);
+--> statement-breakpoint
+ALTER TABLE `requests` ADD `cache_source` text;--> statement-breakpoint
+ALTER TABLE `requests` ADD `tokens_saved_input` integer;--> statement-breakpoint
+ALTER TABLE `requests` ADD `tokens_saved_output` integer;

--- a/packages/db/drizzle/meta/0017_snapshot.json
+++ b/packages/db/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,1702 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "714a76b2-c400-4e2f-939f-367301741527",
+  "prevId": "a26005ef-b427-4058-bc57-66b9dd0051cc",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776393483411,
       "tag": "0016_motionless_shinobi_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1776431053750,
+      "tag": "0017_chilly_tana_nile",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, real, uniqueIndex, primaryKey } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, blob, uniqueIndex, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
@@ -81,6 +81,11 @@ export const requests = sqliteTable("requests", {
   routedBy: text("routed_by"),
   usedFallback: integer("used_fallback", { mode: "boolean" }).notNull().default(false),
   cached: integer("cached", { mode: "boolean" }).notNull().default(false),
+  /** "exact" | "semantic" when cached=true. Null when cached=false. */
+  cacheSource: text("cache_source"),
+  /** Tokens that would have been billed but weren't, because of a cache hit. */
+  tokensSavedInput: integer("tokens_saved_input"),
+  tokensSavedOutput: integer("tokens_saved_output"),
   fallbackErrors: text("fallback_errors"),
   tenantId: text("tenant_id"),
   abTestId: text("ab_test_id").references(() => abTests.id),
@@ -264,6 +269,31 @@ export const modelScores = sqliteTable("model_scores", {
 }, (table) => [
   primaryKey({ columns: [table.taskType, table.complexity, table.provider, table.model] }),
 ]);
+
+export const semanticCache = sqliteTable("semantic_cache", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  provider: text("provider").notNull(),
+  model: text("model").notNull(),
+  /** Hash of the concatenated system prompt (if any). Matches exactly on lookup. */
+  systemPromptHash: text("system_prompt_hash"),
+  /** Raw user text that was embedded. Stored for debugging / observability. */
+  promptText: text("prompt_text").notNull(),
+  /** Float32Array packed as bytes. Dim depends on the embedding model at write time. */
+  embedding: blob("embedding", { mode: "buffer" }).notNull(),
+  /** Dim of the embedding so we can reject cross-model matches after a model change. */
+  embeddingDim: integer("embedding_dim").notNull(),
+  /** Embedding model that produced this vector. */
+  embeddingModel: text("embedding_model").notNull(),
+  response: text("response").notNull(),
+  inputTokens: integer("input_tokens").notNull(),
+  outputTokens: integer("output_tokens").notNull(),
+  hitCount: integer("hit_count").notNull().default(0),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  lastHitAt: integer("last_hit_at", { mode: "timestamp" }),
+});
 
 export const appConfig = sqliteTable("app_config", {
   key: text("key").primaryKey(),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -924,6 +924,50 @@ paths:
         "200":
           description: Cache stats
 
+  /v1/analytics/cache/savings:
+    get:
+      tags: [Cache, Analytics]
+      summary: Tokens saved by cache hits (exact + semantic)
+      description: |
+        Sum of input and output tokens that were served from cache and therefore
+        not billed to the upstream provider. Broken down by cache source (exact
+        vs semantic) and by model.
+      operationId: cacheSavings
+      responses:
+        "200":
+          description: Savings stats
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [tokensSavedInput, tokensSavedOutput, tokensSavedTotal, hits, hitRate, byModel]
+                properties:
+                  tokensSavedInput:
+                    type: integer
+                  tokensSavedOutput:
+                    type: integer
+                  tokensSavedTotal:
+                    type: integer
+                  hits:
+                    type: object
+                    properties:
+                      exact: { type: integer }
+                      semantic: { type: integer }
+                      total: { type: integer }
+                  hitRate:
+                    type: number
+                    description: Cache hits / total requests (0–1)
+                  byModel:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        provider: { type: string }
+                        model: { type: string }
+                        tokensSavedInput: { type: integer }
+                        tokensSavedOutput: { type: integer }
+                        hits: { type: integer }
+
 components:
   securitySchemes:
     BearerAuth:
@@ -1013,6 +1057,10 @@ components:
         cached:
           type: boolean
           description: True if this response was served from the local completion cache.
+        cacheSource:
+          type: string
+          enum: [exact, semantic]
+          description: Which cache layer served the response. Only present when `cached = true`.
         routing:
           $ref: "#/components/schemas/RoutingMetadata"
         errors:
@@ -1151,6 +1199,19 @@ components:
         cached:
           type: boolean
           description: True if this row was written by a cache hit (no provider call was made).
+        cacheSource:
+          type: string
+          nullable: true
+          enum: [exact, semantic]
+          description: Which cache layer served this row. Null when `cached = false`.
+        tokensSavedInput:
+          type: integer
+          nullable: true
+          description: Input tokens that would have been billed but weren't. Non-null only on cache hits.
+        tokensSavedOutput:
+          type: integer
+          nullable: true
+          description: Output tokens that would have been billed but weren't. Non-null only on cache hits.
         fallbackErrors:
           type: string
           nullable: true

--- a/packages/gateway/src/cache/semantic.ts
+++ b/packages/gateway/src/cache/semantic.ts
@@ -1,0 +1,242 @@
+import { nanoid } from "nanoid";
+import { eq, sql } from "drizzle-orm";
+import type { Db } from "@provara/db";
+import { semanticCache } from "@provara/db";
+import type { ChatMessage, CompletionResponse } from "../providers/types.js";
+import {
+  cosineSimilarity,
+  decodeEmbedding,
+  encodeEmbedding,
+  type EmbeddingProvider,
+} from "../embeddings/index.js";
+
+/**
+ * Default similarity threshold. Errs toward false negatives — a miss means
+ * we call the LLM (correctness preserved); a false positive returns a
+ * similar-but-wrong answer. Tune via PROVARA_SEMANTIC_CACHE_THRESHOLD.
+ */
+const DEFAULT_THRESHOLD = 0.97;
+
+const MAX_ENTRIES_PER_TENANT = 10_000;
+
+/**
+ * Single cache row held in memory for fast cosine scan. DB is source of
+ * truth; memory is rehydrated on boot and updated on every write.
+ */
+interface CacheRow {
+  id: string;
+  tenantKey: string;
+  provider: string;
+  model: string;
+  systemPromptHash: string | null;
+  embedding: number[];
+  embeddingDim: number;
+  embeddingModel: string;
+  response: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Key groups cache entries that can possibly match each other. */
+function tenantKey(tenantId: string | null, provider: string, model: string): string {
+  return `${tenantId ?? "anon"}::${provider}::${model}`;
+}
+
+/** Deterministic hash of a system prompt (or empty string if none). */
+export function hashSystemPrompt(messages: ChatMessage[]): string {
+  const sys = messages
+    .filter((m) => m.role === "system")
+    .map((m) => m.content)
+    .join("\n");
+  let hash = 0;
+  for (let i = 0; i < sys.length; i++) {
+    hash = ((hash << 5) - hash + sys.charCodeAt(i)) | 0;
+  }
+  return hash.toString(36);
+}
+
+/**
+ * The cache is eligible only for single-turn user requests. Multi-turn
+ * semantics (does the whole history have to match? what about summarization
+ * drift?) are out of scope for the MVP — we miss cleanly rather than guess.
+ */
+export function isCacheEligible(messages: ChatMessage[]): boolean {
+  const userMessages = messages.filter((m) => m.role === "user");
+  if (userMessages.length !== 1) return false;
+  // System messages are allowed; assistant turns are not (means history).
+  const hasAssistant = messages.some((m) => m.role === "assistant");
+  return !hasAssistant;
+}
+
+/**
+ * Soft heuristic: skip semantic matching when the prompt looks personalized
+ * ("my …", "our …", emails, phone numbers). We still write to cache (the
+ * exact-match path handles replays), but we don't risk cross-user
+ * semantic collision. This is a safety net, not a security boundary —
+ * documented accordingly in the README.
+ */
+const PERSONAL_SIGNALS = [
+  /\bmy\s/i,
+  /\bour\s/i,
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/,
+  /\b\d{3}[-.\s]?\d{3}[-.\s]?\d{4}\b/,
+];
+export function looksPersonalized(text: string): boolean {
+  return PERSONAL_SIGNALS.some((r) => r.test(text));
+}
+
+export type SemanticCache = Awaited<ReturnType<typeof createSemanticCache>>;
+
+export async function createSemanticCache(db: Db, embeddings: EmbeddingProvider) {
+  const threshold = parseFloat(
+    process.env.PROVARA_SEMANTIC_CACHE_THRESHOLD || String(DEFAULT_THRESHOLD),
+  );
+
+  /** In-memory mirror, grouped by tenantKey for fast per-cell scan. */
+  const memory = new Map<string, CacheRow[]>();
+
+  async function hydrate(): Promise<void> {
+    const rows = await db.select().from(semanticCache).all();
+    for (const row of rows) {
+      const key = tenantKey(row.tenantId, row.provider, row.model);
+      const embedding = decodeEmbedding(row.embedding as Buffer);
+      const existing = memory.get(key) ?? [];
+      existing.push({
+        id: row.id,
+        tenantKey: key,
+        provider: row.provider,
+        model: row.model,
+        systemPromptHash: row.systemPromptHash,
+        embedding,
+        embeddingDim: row.embeddingDim,
+        embeddingModel: row.embeddingModel,
+        response: row.response,
+        inputTokens: row.inputTokens,
+        outputTokens: row.outputTokens,
+      });
+      memory.set(key, existing);
+    }
+  }
+
+  await hydrate();
+
+  /**
+   * Returns the best semantic match at or above threshold, or null. Rejects
+   * vectors whose embedding_model differs from the caller's — a model change
+   * produces embeddings in a different space and comparing across them is
+   * nonsense.
+   */
+  async function get(
+    messages: ChatMessage[],
+    tenantId: string | null,
+    provider: string,
+    model: string,
+  ): Promise<{ row: CacheRow; similarity: number } | null> {
+    if (!isCacheEligible(messages)) return null;
+    const userMsg = messages.find((m) => m.role === "user")?.content ?? "";
+    if (looksPersonalized(userMsg)) return null;
+
+    const key = tenantKey(tenantId, provider, model);
+    const bucket = memory.get(key);
+    if (!bucket || bucket.length === 0) return null;
+
+    const systemHash = hashSystemPrompt(messages);
+    const queryVec = await embeddings.embed(userMsg);
+
+    let best: { row: CacheRow; similarity: number } | null = null;
+    for (const row of bucket) {
+      if (row.embeddingModel !== embeddings.model) continue;
+      if (row.systemPromptHash !== systemHash) continue;
+      if (row.embeddingDim !== queryVec.length) continue;
+      const sim = cosineSimilarity(queryVec, row.embedding);
+      if (sim >= threshold && (!best || sim > best.similarity)) {
+        best = { row, similarity: sim };
+      }
+    }
+
+    if (best) {
+      // Fire-and-forget hit tracking; don't block the response.
+      const hitId = best.row.id;
+      void db
+        .update(semanticCache)
+        .set({ hitCount: sql`${semanticCache.hitCount} + 1`, lastHitAt: new Date() })
+        .where(eq(semanticCache.id, hitId))
+        .run()
+        .catch(() => {});
+    }
+    return best;
+  }
+
+  /**
+   * Write a completed LLM response into the cache. Called after a successful
+   * non-cache path. Non-blocking from the caller's perspective — embedding
+   * happens here, so callers should `void` the promise.
+   */
+  async function put(
+    messages: ChatMessage[],
+    tenantId: string | null,
+    provider: string,
+    model: string,
+    response: CompletionResponse,
+  ): Promise<void> {
+    if (!isCacheEligible(messages)) return;
+    const userMsg = messages.find((m) => m.role === "user")?.content ?? "";
+    if (!userMsg) return;
+
+    const vec = await embeddings.embed(userMsg);
+    const systemHash = hashSystemPrompt(messages);
+    const id = nanoid();
+
+    const row: CacheRow = {
+      id,
+      tenantKey: tenantKey(tenantId, provider, model),
+      provider,
+      model,
+      systemPromptHash: systemHash,
+      embedding: vec,
+      embeddingDim: vec.length,
+      embeddingModel: embeddings.model,
+      response: response.content,
+      inputTokens: response.usage.inputTokens,
+      outputTokens: response.usage.outputTokens,
+    };
+
+    const key = row.tenantKey;
+    const bucket = memory.get(key) ?? [];
+    bucket.push(row);
+    // LRU-ish: oldest first out when bucket gets big.
+    if (bucket.length > MAX_ENTRIES_PER_TENANT) {
+      const evicted = bucket.shift();
+      if (evicted) {
+        void db.delete(semanticCache).where(eq(semanticCache.id, evicted.id)).run().catch(() => {});
+      }
+    }
+    memory.set(key, bucket);
+
+    await db
+      .insert(semanticCache)
+      .values({
+        id,
+        tenantId,
+        provider,
+        model,
+        systemPromptHash: systemHash,
+        promptText: userMsg,
+        embedding: encodeEmbedding(vec),
+        embeddingDim: vec.length,
+        embeddingModel: embeddings.model,
+        response: response.content,
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+      })
+      .run();
+  }
+
+  function stats(): { entries: number; threshold: number; buckets: number } {
+    let total = 0;
+    for (const bucket of memory.values()) total += bucket.length;
+    return { entries: total, threshold, buckets: memory.size };
+  }
+
+  return { get, put, stats };
+}

--- a/packages/gateway/src/embeddings/index.ts
+++ b/packages/gateway/src/embeddings/index.ts
@@ -1,0 +1,95 @@
+import OpenAI from "openai";
+
+export interface EmbeddingProvider {
+  /** Return a dense vector for `text`. Fixed-length per-provider. */
+  embed(text: string): Promise<number[]>;
+  readonly dim: number;
+  readonly name: string;
+  readonly model: string;
+}
+
+function createOpenAIEmbeddings(apiKey: string, model: string, dim: number): EmbeddingProvider {
+  const client = new OpenAI({ apiKey });
+  return {
+    name: "openai",
+    model,
+    dim,
+    async embed(text: string): Promise<number[]> {
+      const res = await client.embeddings.create({ model, input: text });
+      const v = res.data[0]?.embedding;
+      if (!v || v.length !== dim) {
+        throw new Error(`[embeddings] openai returned ${v?.length ?? 0} dims, expected ${dim}`);
+      }
+      return v;
+    },
+  };
+}
+
+export interface EmbeddingFactoryConfig {
+  /** DB-stored keys. Precedence over env vars, mirroring the provider registry. */
+  dbKeys?: Record<string, string>;
+}
+
+/**
+ * Resolve an embedding provider from env + DB keys. Returns null when the
+ * semantic cache is disabled or no API key is available — callers should
+ * treat null as "semantic cache is off" rather than an error.
+ */
+export function createEmbeddingProvider(config: EmbeddingFactoryConfig = {}): EmbeddingProvider | null {
+  if (process.env.PROVARA_SEMANTIC_CACHE_ENABLED === "false") return null;
+
+  const providerName = (process.env.PROVARA_EMBEDDING_PROVIDER || "openai").toLowerCase();
+  if (providerName !== "openai") {
+    console.warn(`[embeddings] unknown provider "${providerName}", disabling semantic cache`);
+    return null;
+  }
+
+  const apiKey = config.dbKeys?.["OPENAI_API_KEY"] || process.env.OPENAI_API_KEY;
+  if (!apiKey) return null;
+
+  const model = process.env.PROVARA_EMBEDDING_MODEL || "text-embedding-3-small";
+  // text-embedding-3-small → 1536, text-embedding-3-large → 3072, ada-002 → 1536.
+  // Keep a small allow-list; unknown models disable the cache rather than
+  // guess a dim and silently corrupt stored vectors.
+  const dims: Record<string, number> = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+  };
+  const dim = dims[model];
+  if (!dim) {
+    console.warn(`[embeddings] unknown model "${model}", disabling semantic cache`);
+    return null;
+  }
+
+  return createOpenAIEmbeddings(apiKey, model, dim);
+}
+
+/** Cosine similarity for two same-length numeric vectors. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(`[embeddings] cosine: length mismatch ${a.length} vs ${b.length}`);
+  }
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+/** Encode Float32 vector as a compact Buffer for DB storage. */
+export function encodeEmbedding(v: number[]): Buffer {
+  const f = new Float32Array(v);
+  return Buffer.from(f.buffer, f.byteOffset, f.byteLength);
+}
+
+/** Decode the Buffer back to a number[] of the same length. */
+export function decodeEmbedding(buf: Buffer): number[] {
+  const f = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
+  return Array.from(f);
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -21,11 +21,12 @@ await runMigrations(db, resolve(process.cwd(), "packages/db/drizzle"));
 await hydrateJudgeConfig(db);
 await hydrateRoutingConfig(db);
 
+const dbKeys = await getDecryptedKeys(db);
 const registry = await createProviderRegistry({
-  getKeys: () => getDecryptedKeys(db),
+  getKeys: () => dbKeys,
   getCustomProviders: () => loadCustomProviders(db),
 });
-const app = await createRouter({ registry, db });
+const app = await createRouter({ registry, db, dbKeys });
 
 // Discover available models from each provider's API at startup
 registry.refreshModels().then((results) => {

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -26,17 +26,30 @@ import { loadRules, checkContent, logViolations } from "./guardrails/engine.js";
 import { getTenantId } from "./auth/tenant.js";
 import { createJudge } from "./routing/judge.js";
 import { getCached, putCache, cacheStats } from "./cache/index.js";
+import { createSemanticCache, type SemanticCache } from "./cache/semantic.js";
+import { createEmbeddingProvider } from "./embeddings/index.js";
 import { getMode } from "./config.js";
 
 interface RouterContext {
   registry: ProviderRegistry;
   db: Db;
+  /** DB-stored API keys for resolving the embedding provider. Same map
+   *  the ProviderRegistry receives. Optional — null-safe. */
+  dbKeys?: Record<string, string>;
 }
 
 export async function createRouter(ctx: RouterContext) {
   const app = new Hono();
   const routingEngine = await createRoutingEngine({ registry: ctx.registry, db: ctx.db });
   const judge = createJudge(ctx.registry, ctx.db, routingEngine.adaptive);
+
+  // Semantic cache — null when no embedding provider is available (no
+  // API key, disabled via env var, or unknown model). Treat as "off":
+  // exact-match cache still works and the LLM path is unaffected.
+  const embeddings = createEmbeddingProvider({ dbKeys: ctx.dbKeys });
+  const semanticCache: SemanticCache | null = embeddings
+    ? await createSemanticCache(ctx.db, embeddings)
+    : null;
 
   // Enable CORS for web dashboard and browser-based API clients
   app.use("/*", cors({
@@ -187,64 +200,116 @@ export async function createRouter(ctx: RouterContext) {
 
     const tenantId = tokenInfo?.tenant || getTenantId(c.req.raw) || null;
 
-    // Check cache before calling any provider
+    // Check cache before calling any provider.
+    // Cache lookup order: exact-match (in-memory) → semantic-match (embedding
+    // cosine). A hit on either returns immediately without billing the
+    // provider and logs tokensSaved* so the dashboard can advertise savings.
     const skipCache = !isCacheable || routingResult.routedBy === "ab-test";
-    if (!skipCache) {
-      const cached = getCached(request.messages, routingResult.provider, routingResult.model);
-      if (cached) {
-        const cacheHitId = nanoid();
-        await ctx.db
-          .insert(requests)
-          .values({
-            id: cacheHitId,
-            provider: cached.provider,
-            model: cached.model,
-            prompt: JSON.stringify(request.messages),
-            response: cached.content,
-            inputTokens: cached.usage.inputTokens,
-            outputTokens: cached.usage.outputTokens,
-            latencyMs: 0,
+    const returnCachedHit = async (
+      content: string,
+      providerForResp: string,
+      modelForResp: string,
+      cacheSource: "exact" | "semantic",
+      inputTokens: number,
+      outputTokens: number,
+      hitId: string,
+    ) => {
+      await ctx.db
+        .insert(requests)
+        .values({
+          id: hitId,
+          provider: providerForResp,
+          model: modelForResp,
+          prompt: JSON.stringify(request.messages),
+          response: content,
+          inputTokens,
+          outputTokens,
+          latencyMs: 0,
+          taskType: routingResult.taskType,
+          complexity: routingResult.complexity,
+          routedBy: routingResult.routedBy,
+          usedFallback: false,
+          cached: true,
+          cacheSource,
+          tokensSavedInput: inputTokens,
+          tokensSavedOutput: outputTokens,
+          tenantId,
+          abTestId: routingResult.abTestId || null,
+        })
+        .run();
+      c.header("X-Provara-Request-Id", hitId);
+      c.header("X-Provara-Cache", cacheSource);
+      return c.json({
+        id: `chatcmpl-${hitId}`,
+        object: "chat.completion",
+        created: Math.floor(Date.now() / 1000),
+        model: modelForResp,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content },
+            finish_reason: "stop",
+          },
+        ],
+        usage: {
+          prompt_tokens: inputTokens,
+          completion_tokens: outputTokens,
+          total_tokens: inputTokens + outputTokens,
+        },
+        _provara: {
+          provider: providerForResp,
+          latencyMs: 0,
+          cached: true,
+          cacheSource,
+          routing: {
             taskType: routingResult.taskType,
             complexity: routingResult.complexity,
             routedBy: routingResult.routedBy,
             usedFallback: false,
-            cached: true,
-            tenantId,
-            abTestId: routingResult.abTestId || null,
-          })
-          .run();
+            usedLlmFallback: routingResult.usedLlmFallback,
+          },
+        },
+      });
+    };
 
-        c.header("X-Provara-Request-Id", cacheHitId);
-        return c.json({
-          id: `chatcmpl-${cached.id}`,
-          object: "chat.completion",
-          created: Math.floor(Date.now() / 1000),
-          model: routingResult.model,
-          choices: [
-            {
-              index: 0,
-              message: { role: "assistant", content: cached.content },
-              finish_reason: "stop",
-            },
-          ],
-          usage: {
-            prompt_tokens: cached.usage.inputTokens,
-            completion_tokens: cached.usage.outputTokens,
-            total_tokens: cached.usage.inputTokens + cached.usage.outputTokens,
-          },
-          _provara: {
-            provider: cached.provider,
-            latencyMs: 0,
-            cached: true,
-            routing: {
-              taskType: routingResult.taskType,
-              complexity: routingResult.complexity,
-              routedBy: routingResult.routedBy,
-              usedFallback: false,
-              usedLlmFallback: routingResult.usedLlmFallback,
-            },
-          },
-        });
+    if (!skipCache) {
+      const cached = getCached(request.messages, routingResult.provider, routingResult.model);
+      if (cached) {
+        return returnCachedHit(
+          cached.content,
+          cached.provider,
+          cached.model,
+          "exact",
+          cached.usage.inputTokens,
+          cached.usage.outputTokens,
+          nanoid(),
+        );
+      }
+
+      // Semantic cache is best-effort: any error (embedding API down, quota,
+      // timeout) falls through to the LLM path silently.
+      if (semanticCache) {
+        try {
+          const match = await semanticCache.get(
+            request.messages,
+            tenantId,
+            routingResult.provider,
+            routingResult.model,
+          );
+          if (match) {
+            return returnCachedHit(
+              match.row.response,
+              match.row.provider,
+              match.row.model,
+              "semantic",
+              match.row.inputTokens,
+              match.row.outputTokens,
+              nanoid(),
+            );
+          }
+        } catch (err) {
+          console.warn("[semantic-cache] lookup failed:", err instanceof Error ? err.message : err);
+        }
       }
     }
 
@@ -370,14 +435,25 @@ export async function createRouter(ctx: RouterContext) {
                 }).catch(() => {});
 
                 if (!skipCache) {
-                  putCache(request.messages, usedProvider, usedModel, {
+                  const completedResponse: CompletionResponse = {
                     id: requestId,
                     provider: usedProvider,
                     model: usedModel,
                     content: fullContent,
                     usage,
                     latencyMs,
-                  });
+                  };
+                  putCache(request.messages, usedProvider, usedModel, completedResponse);
+                  if (semanticCache) {
+                    void semanticCache
+                      .put(request.messages, tenantId, usedProvider, usedModel, completedResponse)
+                      .catch((err) => {
+                        console.warn(
+                          "[semantic-cache] writeback failed:",
+                          err instanceof Error ? err.message : err,
+                        );
+                      });
+                  }
                 }
 
                 judge.maybeJudge({
@@ -514,6 +590,16 @@ export async function createRouter(ctx: RouterContext) {
     // Cache the response for future identical requests
     if (!skipCache) {
       putCache(request.messages, usedProvider, usedModel, response);
+      if (semanticCache) {
+        void semanticCache
+          .put(request.messages, tenantId, usedProvider, usedModel, response)
+          .catch((err) => {
+            console.warn(
+              "[semantic-cache] writeback failed:",
+              err instanceof Error ? err.message : err,
+            );
+          });
+      }
     }
 
     // Fire-and-forget: LLM-as-judge quality scoring on a sample of responses

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -232,6 +232,68 @@ export function createAnalyticsRoutes(db: Db) {
     });
   });
 
+  // Cache savings — how many tokens we didn't bill the provider for, because
+  // of cache hits (exact + semantic). This is the advertisable number.
+  app.get("/cache/savings", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const tenantFilter = tenantId ? eq(requests.tenantId, tenantId) : undefined;
+
+    const totals = await db
+      .select({
+        tokensSavedInput: sql<number>`coalesce(sum(${requests.tokensSavedInput}), 0)`,
+        tokensSavedOutput: sql<number>`coalesce(sum(${requests.tokensSavedOutput}), 0)`,
+        totalRequests: sql<number>`count(*)`,
+      })
+      .from(requests)
+      .where(tenantFilter)
+      .get();
+
+    const hitCounts = await db
+      .select({
+        cacheSource: requests.cacheSource,
+        count: sql<number>`count(*)`,
+      })
+      .from(requests)
+      .where(
+        tenantFilter
+          ? and(tenantFilter, eq(requests.cached, true))
+          : eq(requests.cached, true),
+      )
+      .groupBy(requests.cacheSource)
+      .all();
+
+    const byModel = await db
+      .select({
+        provider: requests.provider,
+        model: requests.model,
+        tokensSavedInput: sql<number>`coalesce(sum(${requests.tokensSavedInput}), 0)`,
+        tokensSavedOutput: sql<number>`coalesce(sum(${requests.tokensSavedOutput}), 0)`,
+        hits: sql<number>`count(*)`,
+      })
+      .from(requests)
+      .where(
+        tenantFilter
+          ? and(tenantFilter, eq(requests.cached, true))
+          : eq(requests.cached, true),
+      )
+      .groupBy(requests.provider, requests.model)
+      .all();
+
+    const exactHits = hitCounts.find((r) => r.cacheSource === "exact")?.count || 0;
+    const semanticHits = hitCounts.find((r) => r.cacheSource === "semantic")?.count || 0;
+    const totalHits = exactHits + semanticHits;
+    const totalRequests = totals?.totalRequests || 0;
+
+    return c.json({
+      tokensSavedInput: totals?.tokensSavedInput || 0,
+      tokensSavedOutput: totals?.tokensSavedOutput || 0,
+      tokensSavedTotal: (totals?.tokensSavedInput || 0) + (totals?.tokensSavedOutput || 0),
+      hits: { exact: exactHits, semantic: semanticHits, total: totalHits },
+      hitRate: totalRequests > 0 ? totalHits / totalRequests : 0,
+      byModel,
+    });
+  });
+
   // Pipeline stage stats — per-stage request counts and latency
   app.get("/pipeline", async (c) => {
     const tenantId = getTenantId(c.req.raw);

--- a/packages/gateway/tests/semantic-cache.test.ts
+++ b/packages/gateway/tests/semantic-cache.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { cosineSimilarity, encodeEmbedding, decodeEmbedding } from "../src/embeddings/index.js";
+import {
+  createSemanticCache,
+  hashSystemPrompt,
+  isCacheEligible,
+  looksPersonalized,
+} from "../src/cache/semantic.js";
+import type { EmbeddingProvider } from "../src/embeddings/index.js";
+import type { ChatMessage, CompletionResponse } from "../src/providers/types.js";
+import { makeTestDb } from "./_setup/db.js";
+
+describe("embeddings math", () => {
+  it("cosineSimilarity: identical vectors = 1", () => {
+    expect(cosineSimilarity([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 5);
+  });
+
+  it("cosineSimilarity: orthogonal vectors = 0", () => {
+    expect(cosineSimilarity([1, 0, 0], [0, 1, 0])).toBeCloseTo(0, 5);
+  });
+
+  it("cosineSimilarity: opposite vectors = -1", () => {
+    expect(cosineSimilarity([1, 0], [-1, 0])).toBeCloseTo(-1, 5);
+  });
+
+  it("encode/decode round-trips a Float32 vector", () => {
+    const v = [0.1, -0.2, 0.3, 0.4];
+    const buf = encodeEmbedding(v);
+    const decoded = decodeEmbedding(buf);
+    expect(decoded.length).toBe(v.length);
+    for (let i = 0; i < v.length; i++) {
+      expect(decoded[i]).toBeCloseTo(v[i], 5);
+    }
+  });
+});
+
+describe("cache eligibility + safety", () => {
+  it("single-turn user message is eligible", () => {
+    expect(isCacheEligible([{ role: "user", content: "hi" }])).toBe(true);
+  });
+
+  it("system + single user is eligible", () => {
+    expect(
+      isCacheEligible([
+        { role: "system", content: "you are helpful" },
+        { role: "user", content: "hi" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("multi-turn with prior assistant is not eligible", () => {
+    expect(
+      isCacheEligible([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+        { role: "user", content: "and you?" },
+      ]),
+    ).toBe(false);
+  });
+
+  it("looksPersonalized catches first-person signals", () => {
+    expect(looksPersonalized("my email is x@y.com")).toBe(true);
+    expect(looksPersonalized("our quarterly results")).toBe(true);
+    expect(looksPersonalized("call me at 555-123-4567")).toBe(true);
+  });
+
+  it("looksPersonalized leaves generic questions alone", () => {
+    expect(looksPersonalized("what is the capital of France?")).toBe(false);
+    expect(looksPersonalized("write a quicksort in Rust")).toBe(false);
+  });
+
+  it("hashSystemPrompt produces matching hashes for identical system prompts", () => {
+    const a = hashSystemPrompt([
+      { role: "system", content: "be brief" },
+      { role: "user", content: "hi" },
+    ]);
+    const b = hashSystemPrompt([
+      { role: "system", content: "be brief" },
+      { role: "user", content: "different user msg" },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it("hashSystemPrompt differs when system prompts differ", () => {
+    const a = hashSystemPrompt([{ role: "system", content: "be brief" }, { role: "user", content: "x" }]);
+    const b = hashSystemPrompt([{ role: "system", content: "be verbose" }, { role: "user", content: "x" }]);
+    expect(a).not.toBe(b);
+  });
+});
+
+function makeStubEmbeddings(vectors: Record<string, number[]>, model = "text-embedding-3-small"): EmbeddingProvider {
+  return {
+    name: "stub",
+    model,
+    dim: 4,
+    async embed(text: string) {
+      const v = vectors[text];
+      if (!v) throw new Error(`stub: no vector for "${text}"`);
+      return v;
+    },
+  };
+}
+
+const dummyResponse = (content: string): CompletionResponse => ({
+  id: "stub-id",
+  provider: "openai",
+  model: "gpt-4.1-nano",
+  content,
+  usage: { inputTokens: 10, outputTokens: 20 },
+  latencyMs: 100,
+});
+
+describe("semantic cache integration", () => {
+  it("returns cached response on a high-similarity match", async () => {
+    const db = await makeTestDb();
+    const vectors: Record<string, number[]> = {
+      "what is the capital of France?": [1, 0, 0, 0],
+      "capital city of France?": [0.98, 0.02, 0, 0], // cosine sim ~0.9998 with above
+    };
+    const embeddings = makeStubEmbeddings(vectors);
+    const cache = await createSemanticCache(db, embeddings);
+
+    const messages1: ChatMessage[] = [{ role: "user", content: "what is the capital of France?" }];
+    await cache.put(messages1, null, "openai", "gpt-4.1-nano", dummyResponse("Paris"));
+
+    const messages2: ChatMessage[] = [{ role: "user", content: "capital city of France?" }];
+    const hit = await cache.get(messages2, null, "openai", "gpt-4.1-nano");
+
+    expect(hit).not.toBeNull();
+    expect(hit?.row.response).toBe("Paris");
+    expect(hit!.similarity).toBeGreaterThan(0.97);
+  });
+
+  it("misses when similarity is below threshold", async () => {
+    const db = await makeTestDb();
+    const vectors: Record<string, number[]> = {
+      "what is the capital of France?": [1, 0, 0, 0],
+      "how do I bake bread?": [0, 1, 0, 0], // orthogonal → cosine 0
+    };
+    const embeddings = makeStubEmbeddings(vectors);
+    const cache = await createSemanticCache(db, embeddings);
+
+    await cache.put(
+      [{ role: "user", content: "what is the capital of France?" }],
+      null,
+      "openai",
+      "gpt-4.1-nano",
+      dummyResponse("Paris"),
+    );
+
+    const miss = await cache.get(
+      [{ role: "user", content: "how do I bake bread?" }],
+      null,
+      "openai",
+      "gpt-4.1-nano",
+    );
+    expect(miss).toBeNull();
+  });
+
+  it("isolates cache entries by tenant", async () => {
+    const db = await makeTestDb();
+    const vectors: Record<string, number[]> = {
+      "same question": [1, 0, 0, 0],
+    };
+    const embeddings = makeStubEmbeddings(vectors);
+    const cache = await createSemanticCache(db, embeddings);
+
+    await cache.put(
+      [{ role: "user", content: "same question" }],
+      "tenant-a",
+      "openai",
+      "gpt-4.1-nano",
+      dummyResponse("answer for A"),
+    );
+
+    const missForB = await cache.get(
+      [{ role: "user", content: "same question" }],
+      "tenant-b",
+      "openai",
+      "gpt-4.1-nano",
+    );
+    expect(missForB).toBeNull();
+
+    const hitForA = await cache.get(
+      [{ role: "user", content: "same question" }],
+      "tenant-a",
+      "openai",
+      "gpt-4.1-nano",
+    );
+    expect(hitForA?.row.response).toBe("answer for A");
+  });
+
+  it("skips semantic match for personalized prompts", async () => {
+    const db = await makeTestDb();
+    const vectors: Record<string, number[]> = {
+      "my favorite color is blue": [1, 0, 0, 0],
+    };
+    const embeddings = makeStubEmbeddings(vectors);
+    const cache = await createSemanticCache(db, embeddings);
+
+    await cache.put(
+      [{ role: "user", content: "my favorite color is blue" }],
+      null,
+      "openai",
+      "gpt-4.1-nano",
+      dummyResponse("Nice."),
+    );
+
+    const miss = await cache.get(
+      [{ role: "user", content: "my favorite color is blue" }],
+      null,
+      "openai",
+      "gpt-4.1-nano",
+    );
+    expect(miss).toBeNull();
+  });
+
+  it("rejects cross-model matches when embedding model changes", async () => {
+    const db = await makeTestDb();
+    const vectors: Record<string, number[]> = { "q": [1, 0, 0, 0] };
+
+    const e1 = makeStubEmbeddings(vectors, "text-embedding-3-small");
+    const cache1 = await createSemanticCache(db, e1);
+    await cache1.put([{ role: "user", content: "q" }], null, "openai", "gpt-4.1-nano", dummyResponse("a"));
+
+    const e2 = makeStubEmbeddings(vectors, "text-embedding-3-large");
+    const cache2 = await createSemanticCache(db, e2);
+    const hit = await cache2.get([{ role: "user", content: "q" }], null, "openai", "gpt-4.1-nano");
+    expect(hit).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #120. Ships the advertisable "Provara saves you tokens" claim with real, measured backing — not marketing.

Every incoming chat completion now flows through two cache layers before any provider call:

1. **Exact-match cache** (existing) — byte-identical prompt, microsecond lookup.
2. **Semantic cache** (new) — embedding + cosine similarity. Prompts semantically equivalent to recent cache entries return cached responses. Same tokens saved, different words.

On a hit from either layer, the `requests` row records `cached = true`, `cache_source = "exact" \| "semantic"`, and `tokens_saved_input` / `tokens_saved_output` capture what would have been billed. Dashboard aggregates into a "Tokens Saved" tile. `/v1/analytics/cache/savings` returns totals and breakdowns.

## What's in the PR

| Area | Change |
|---|---|
| Embeddings | New `src/embeddings/` module with `EmbeddingProvider` interface, OpenAI `text-embedding-3-small` implementation, env-driven factory with null fallback, cosine similarity + Float32 encode/decode |
| Semantic cache | New `src/cache/semantic.ts` with in-memory mirror + DB source of truth (same pattern as adaptive router). Tenant-scoped, cross-model-safe, personalized-prompt-skip heuristic |
| Schema | `semantic_cache` table, `cache_source` + `tokens_saved_*` columns on `requests`. Migration 0017 |
| Router | Cache order: exact → semantic → LLM. Writeback on success (non-blocking). Opt-out via `cache: false` or `PROVARA_SEMANTIC_CACHE_ENABLED=false`. Embedding failures fall through silently |
| Analytics | `GET /v1/analytics/cache/savings` with totals, hit rate, exact/semantic split, per-model breakdown |
| Dashboard | New "Tokens Saved" stat card with hit-rate and cache-source breakdown |
| Docs | README "How Provara saves tokens" section + OpenAPI updates |
| Tests | 16 new tests in `tests/semantic-cache.test.ts` covering cosine math, encode/decode, eligibility, personalization guard, tenant isolation, cross-model rejection, end-to-end similarity |

## Design choices (from #120's plan, locked)

- **Uniform OpenAI embeddings for MVP.** Multi-provider later if demand materializes.
- **In-memory brute-force cosine scan.** ≤10K entries/tenant, sub-millisecond. pgvector / Redis Stack when we scale past that (see #121).
- **Single-turn only.** Multi-turn history-match semantics are out-of-scope for MVP — we miss cleanly rather than guess.
- **Tenant-scoped.** Security hard constraint.
- **Threshold 0.97 default.** Errs toward false negatives. Tunable via `PROVARA_SEMANTIC_CACHE_THRESHOLD`.
- **A/B tests still skip cache** entirely — they exist specifically to generate comparison data.

## Env vars

| Var | Default | Purpose |
|---|---|---|
| `PROVARA_SEMANTIC_CACHE_ENABLED` | `true` | Hard off-switch |
| `PROVARA_SEMANTIC_CACHE_THRESHOLD` | `0.97` | Cosine threshold |
| `PROVARA_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model |
| `PROVARA_EMBEDDING_PROVIDER` | `openai` | Only `openai` supported in MVP |

## Test plan

- [x] `tsc --noEmit` clean on gateway + web.
- [x] All 37 gateway tests pass (21 existing + 16 new).
- [ ] Manual: send a prompt, then a semantically-similar variant. Confirm second request returns cached response with `cacheSource: "semantic"` in `_provara` and 0ms latency.
- [ ] Manual: check `/dashboard` for the new "Tokens Saved" tile with non-zero hit count.
- [ ] Manual: hit `/v1/analytics/cache/savings` and confirm the shape matches the OpenAPI spec.
- [ ] Manual (Railway): confirm migration 0017 runs cleanly on deploy.

## Out of scope (follow-ups)

Opening as separate issues after MVP is in production:
- Multi-turn conversation cache with history-match strategy.
- Additional embedding providers (Voyage, Cohere, local).
- TTL / time-decay on stale cache entries.
- LLMLingua-style prompt compression (second savings path).
- Structural prompt minification (trivial 5–15% wins).

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)