### PR TITLE
fix: exclude tool configs from web tsconfig (Railway build)

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -30,6 +30,9 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "tests/e2e/**"
   ]
 }


### PR DESCRIPTION
## Summary

Hotfix for a Railway build failure that started after #109 landed the vitest harness:

```
./vitest.config.ts:3:19
Type error: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations.
```

Not actually caused by #124 (adaptive split) — #124 just triggered a redeploy that surfaced the pre-existing failure from #109.

## Root cause

Next.js's build-time typecheck follows `apps/web/tsconfig.json`'s `include` globs, which pull in every `.ts` / `.tsx` under the app — including `vitest.config.ts`. That file imports `@vitejs/plugin-react`, a devDep that isn't resolvable in the Railway Docker build environment for reasons that didn't matter until Next decided to typecheck the config.

## Fix

Exclude tool configs and e2e specs from the main tsconfig:

```json
"exclude": [
  "node_modules",
  "vitest.config.ts",
  "playwright.config.ts",
  "tests/e2e/**"
]
```

These are tooling configs / e2e specs. They have no business being in the app's build typecheck. Vitest still compiles its own config via esbuild. Playwright compiles specs via its own config. Unit tests under `tests/*.test.{ts,tsx}` remain in scope and typecheck normally.

## Test plan

- [x] `tsc --noEmit` clean locally.
- [x] `npx next build` succeeds locally.
- [x] `npx vitest run` passes (13/13).
- [ ] Railway build goes green on this PR.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)