### PR TITLE
feat(chat): markdown rendering, inline cost/latency/tokens, stop, copy

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,10 +17,14 @@
     "@provara/db": "*",
     "@scalar/api-reference-react": "^0.9.23",
     "@xyflow/react": "^12.10.2",
+    "highlight.js": "^11.11.1",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "recharts": "^3.8.1"
+    "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
+    "rehype-highlight": "^7.0.2",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -6,9 +6,11 @@ import { ChatInput, type ChatInputHandle } from "../../../components/chat/ChatIn
 import { MessageList } from "../../../components/chat/MessageList";
 import { SettingsPanel } from "../../../components/chat/SettingsPanel";
 import { StarRating } from "../../../components/chat/StarRating";
+import { CopyButton } from "../../../components/chat/CopyButton";
+import { MarkdownMessage } from "../../../components/chat/MarkdownMessage";
 import { useChatSession } from "../../../components/chat/use-chat-session";
 import { useSessionPersist } from "../../../components/chat/use-session-persist";
-import type { MessageAction } from "../../../components/chat/types";
+import type { ChatMessage, MessageAction } from "../../../components/chat/types";
 
 interface ProviderInfo {
   name: string;
@@ -70,6 +72,22 @@ export default function PlaygroundPage() {
     ),
   };
 
+  const copyAction: MessageAction = {
+    id: "copy",
+    // Show on every message, user and assistant alike — "copy what I said" is useful too.
+    showFor: () => true,
+    render: (msg) => <CopyButton text={msg.content} />,
+  };
+
+  // Render assistant messages as markdown; user prompts stay as plain text so
+  // their exact input is preserved visually (no surprise auto-formatting).
+  function renderContent(msg: ChatMessage) {
+    if (msg.role === "assistant") {
+      return <MarkdownMessage content={msg.content} />;
+    }
+    return <p className="text-sm whitespace-pre-wrap">{msg.content}</p>;
+  }
+
   return (
     <div className="flex h-[calc(100vh-3.5rem)]">
       <div className="flex-1 flex flex-col min-w-0">
@@ -121,7 +139,8 @@ export default function PlaygroundPage() {
           streaming={session.streaming}
           streamingContent={session.streamingContent}
           topicStartIndex={session.topicStartIndex}
-          actions={[ratingAction]}
+          actions={[copyAction, ratingAction]}
+          renderContent={renderContent}
           emptyState={
             <div className="flex items-center justify-center h-full">
               <div className="text-center max-w-md">
@@ -140,6 +159,17 @@ export default function PlaygroundPage() {
           onChange={setInput}
           onSend={handleSend}
           disabled={session.streaming}
+          rightAddon={
+            session.streaming ? (
+              <button
+                type="button"
+                onClick={session.stop}
+                className="px-3 h-[44px] bg-red-600 hover:bg-red-500 rounded-xl text-sm font-medium text-white transition-colors shrink-0"
+              >
+                Stop
+              </button>
+            ) : undefined
+          }
         />
       </div>
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -23,3 +23,48 @@ button, [role="button"], a, select, summary, label[for] {
   0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.75); }
   100% { box-shadow: 0 0 0 8px rgba(52, 211, 153, 0); }
 }
+
+/* Markdown rendering in chat bubbles */
+.chat-markdown p { margin: 0.35rem 0; }
+.chat-markdown p:first-child { margin-top: 0; }
+.chat-markdown p:last-child { margin-bottom: 0; }
+.chat-markdown ul, .chat-markdown ol { margin: 0.35rem 0 0.35rem 1.25rem; list-style-position: outside; }
+.chat-markdown ul { list-style: disc; }
+.chat-markdown ol { list-style: decimal; }
+.chat-markdown li { margin: 0.15rem 0; }
+.chat-markdown h1, .chat-markdown h2, .chat-markdown h3, .chat-markdown h4 {
+  font-weight: 600;
+  margin: 0.6rem 0 0.3rem;
+}
+.chat-markdown h1 { font-size: 1.15rem; }
+.chat-markdown h2 { font-size: 1.05rem; }
+.chat-markdown h3 { font-size: 1rem; }
+.chat-markdown h4 { font-size: 0.95rem; }
+.chat-markdown code:not(pre code) {
+  background: rgba(63, 63, 70, 0.6);
+  border: 1px solid rgba(82, 82, 91, 0.5);
+  border-radius: 3px;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.875em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.chat-markdown blockquote {
+  border-left: 3px solid #52525b;
+  padding-left: 0.75rem;
+  color: #a1a1aa;
+  margin: 0.4rem 0;
+}
+.chat-markdown table {
+  border-collapse: collapse;
+  margin: 0.4rem 0;
+  font-size: 0.85em;
+}
+.chat-markdown th, .chat-markdown td {
+  border: 1px solid #3f3f46;
+  padding: 0.25rem 0.5rem;
+  text-align: left;
+}
+.chat-markdown th {
+  background: rgba(63, 63, 70, 0.4);
+  font-weight: 600;
+}

--- a/apps/web/src/components/chat/CopyButton.tsx
+++ b/apps/web/src/components/chat/CopyButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  text: string;
+  label?: string;
+  copiedLabel?: string;
+}
+
+export function CopyButton({ text, label = "Copy", copiedLabel = "Copied" }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function onClick() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard may be blocked in some embedded contexts; fail silently.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="px-2 py-0.5 text-xs text-zinc-500 hover:text-zinc-300 border border-transparent hover:border-zinc-700 rounded transition-colors"
+      aria-label={label}
+    >
+      {copied ? copiedLabel : label}
+    </button>
+  );
+}

--- a/apps/web/src/components/chat/MarkdownMessage.tsx
+++ b/apps/web/src/components/chat/MarkdownMessage.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
+import "highlight.js/styles/github-dark.css";
+import { useState, useRef, type ReactNode } from "react";
+
+/**
+ * Markdown renderer used by the chat client. Adds GFM (tables, strikethrough,
+ * task lists) and highlight.js-based code coloring. Inline `code` and fenced
+ * ```blocks``` get different styling — the latter gets a hover copy button.
+ *
+ * The CSS import (`github-dark.css`) is bundled once at module scope so every
+ * rendered message gets the same theme without runtime fetches.
+ */
+export function MarkdownMessage({ content }: { content: string }) {
+  return (
+    <div className="chat-markdown text-sm">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeHighlight]}
+        components={{
+          // Code block (fenced ```lang...```) wraps in a relatively positioned
+          // container so we can float a copy button in the top-right on hover.
+          pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+          // Inline code stays as a plain <code>, styled via chat-markdown CSS.
+          code: ({ className, children, ...props }) => (
+            <code className={className} {...props}>
+              {children}
+            </code>
+          ),
+          // Links open in a new tab and get visible styling.
+          a: ({ href, children }) => (
+            <a href={href} target="_blank" rel="noreferrer noopener" className="text-blue-400 hover:text-blue-300 underline">
+              {children}
+            </a>
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function CodeBlock({ children }: { children: ReactNode }) {
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLPreElement>(null);
+
+  async function onCopy() {
+    const text = ref.current?.innerText ?? "";
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Some embedded contexts block clipboard writes; fail silently.
+    }
+  }
+
+  return (
+    <div className="relative group my-3">
+      <pre ref={ref} className="overflow-x-auto rounded-lg bg-zinc-950/80 border border-zinc-800 p-3 text-xs">
+        {children}
+      </pre>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity px-2 py-1 text-xs bg-zinc-800 border border-zinc-700 rounded hover:bg-zinc-700 text-zinc-300"
+        aria-label="Copy code"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessageBubble.tsx
+++ b/apps/web/src/components/chat/MessageBubble.tsx
@@ -13,6 +13,31 @@ function defaultContent(msg: ChatMessage): ReactNode {
   return <p className="text-sm whitespace-pre-wrap">{msg.content}</p>;
 }
 
+function formatCost(n: number): string {
+  if (n === 0) return "$0";
+  if (n < 0.0001) return `$${n.toFixed(6)}`;
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(3)}`;
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function Meta({ message }: { message: ChatMessage }) {
+  const parts: string[] = [];
+  if (message.cacheSource) parts.push(`cache: ${message.cacheSource}`);
+  if (message.latencyMs !== undefined) parts.push(formatLatency(message.latencyMs));
+  if (message.cost !== undefined && message.cost > 0) parts.push(formatCost(message.cost));
+  const tokenParts: string[] = [];
+  if (message.inputTokens !== undefined) tokenParts.push(`${message.inputTokens} in`);
+  if (message.outputTokens !== undefined) tokenParts.push(`${message.outputTokens} out`);
+  if (tokenParts.length > 0) parts.push(tokenParts.join(" / "));
+  if (parts.length === 0) return null;
+  return <p className="text-xs text-zinc-500 mt-1 ml-1 font-mono">{parts.join(" · ")}</p>;
+}
+
 export function MessageBubble({ message, index, actions, renderContent }: Props) {
   const isGuardrail =
     message.role === "assistant" && message.content.startsWith("Guardrail triggered:");
@@ -36,6 +61,7 @@ export function MessageBubble({ message, index, actions, renderContent }: Props)
         )}
         {render(message)}
       </div>
+      {message.role === "assistant" && !isGuardrail && <Meta message={message} />}
       {!isGuardrail && actions && actions.length > 0 && (
         <div className="mt-1.5 ml-1 flex items-center gap-2">
           {actions

--- a/apps/web/src/components/chat/types.ts
+++ b/apps/web/src/components/chat/types.ts
@@ -8,6 +8,13 @@ export interface ChatMessage {
   requestId?: string;
   /** 1-5 star rating; undefined = not rated yet */
   feedbackScore?: number;
+  /** Per-turn metrics captured from response headers / trailing SSE event. */
+  cost?: number;
+  latencyMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** "exact" | "semantic" when the response came from cache. */
+  cacheSource?: "exact" | "semantic";
 }
 
 export interface ProvaraMetadata {

--- a/apps/web/src/components/chat/use-chat-session.ts
+++ b/apps/web/src/components/chat/use-chat-session.ts
@@ -42,6 +42,10 @@ export function useChatSession() {
   const [streamingContent, setStreamingContent] = useState("");
   const [topicStartIndex, setTopicStartIndex] = useState(0);
 
+  // AbortController for the active stream. Populated in `send`, cleared in
+  // the finally block. Exposed via `stop()` so the caller can abort mid-stream.
+  const abortRef = useRef<AbortController | null>(null);
+
   const persistMessages = useCallback((next: ChatMessage[]) => {
     if (typeof window !== "undefined") {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -75,6 +79,9 @@ export function useChatSession() {
         sessionStorage.setItem(STREAMING_FLAG_KEY, "true");
       }
 
+      const controller = new AbortController();
+      abortRef.current = controller;
+
       try {
         const hdrs: Record<string, string> = { ...adminHeaders() };
         if (config.apiToken) hdrs["Authorization"] = `Bearer ${config.apiToken}`;
@@ -82,6 +89,7 @@ export function useChatSession() {
         const res = await fetch(gatewayUrl("/v1/chat/completions"), {
           method: "POST",
           credentials: "include",
+          signal: controller.signal,
           headers: hdrs,
           body: JSON.stringify({
             model: config.selectedModel,
@@ -109,6 +117,12 @@ export function useChatSession() {
 
         const headerModel = res.headers.get("X-Provara-Model") || "";
         const requestId = res.headers.get("X-Provara-Request-Id") || undefined;
+        const cacheSource = (res.headers.get("X-Provara-Cache") as "exact" | "semantic" | null) || undefined;
+        // Non-streaming cache hits set cost/latency headers directly. Streaming
+        // hits can't (headers are already sent by the time we know token
+        // counts), so they arrive via the trailing `_provara` SSE event.
+        const headerLatency = Number(res.headers.get("X-Provara-Latency")) || undefined;
+        const headerCost = Number(res.headers.get("X-Provara-Cost")) || undefined;
 
         // Guardrails surface as a pre-response message; they abort the stream.
         const guardrailHeader = res.headers.get("X-Provara-Guardrail");
@@ -135,6 +149,7 @@ export function useChatSession() {
         const decoder = new TextDecoder();
         let fullContent = "";
         let responseModel = "";
+        let streamMeta: { latencyMs?: number; cost?: number; usage?: { inputTokens: number; outputTokens: number } } = {};
 
         while (true) {
           const { done, value } = await reader.read();
@@ -147,6 +162,13 @@ export function useChatSession() {
             if (data === "[DONE]") continue;
             try {
               const parsed = JSON.parse(data);
+              // The gateway emits a final `{_provara: {...}}` event right
+              // before [DONE] with cost/latency/usage so we can attach them
+              // to the message without a second round-trip.
+              if (parsed._provara) {
+                streamMeta = parsed._provara;
+                continue;
+              }
               if (!responseModel && parsed.model) responseModel = parsed.model;
               const delta = parsed.choices?.[0]?.delta?.content || "";
               fullContent += delta;
@@ -164,28 +186,42 @@ export function useChatSession() {
             content: fullContent,
             model: headerModel || responseModel || undefined,
             requestId,
+            cacheSource,
+            cost: streamMeta.cost ?? headerCost,
+            latencyMs: streamMeta.latencyMs ?? headerLatency,
+            inputTokens: streamMeta.usage?.inputTokens,
+            outputTokens: streamMeta.usage?.outputTokens,
           },
         ];
         setMessages(finalMessages);
         setStreamingContent("");
         persistMessages(finalMessages);
       } catch (err) {
-        const final: ChatMessage[] = [
-          ...workingMessages,
-          {
-            role: "assistant",
-            content: `Error: ${err instanceof Error ? err.message : "Request failed"}`,
-          },
-        ];
-        setMessages(final);
-        persistMessages(final);
+        // AbortError is a user-initiated stop; don't surface it as an error.
+        const aborted = err instanceof DOMException && err.name === "AbortError";
+        if (!aborted) {
+          const final: ChatMessage[] = [
+            ...workingMessages,
+            {
+              role: "assistant",
+              content: `Error: ${err instanceof Error ? err.message : "Request failed"}`,
+            },
+          ];
+          setMessages(final);
+          persistMessages(final);
+        }
       } finally {
+        abortRef.current = null;
         setStreaming(false);
         if (typeof window !== "undefined") sessionStorage.removeItem(STREAMING_FLAG_KEY);
       }
     },
     [messages, streaming, topicStartIndex, persistMessages],
   );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
 
   const clear = useCallback(() => {
     setMessages([]);
@@ -252,6 +288,7 @@ export function useChatSession() {
     streamingContent,
     topicStartIndex,
     send,
+    stop,
     clear,
     startNewTopic,
     rate,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,14 @@
         "@provara/db": "*",
         "@scalar/api-reference-react": "^0.9.23",
         "@xyflow/react": "^12.10.2",
+        "highlight.js": "^11.11.1",
         "next": "^15.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "recharts": "^3.8.1"
+        "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
+        "rehype-highlight": "^7.0.2",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -5435,8 +5439,16 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/har-format": {
       "version": "1.2.16",
@@ -5491,7 +5503,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6370,6 +6381,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -7323,6 +7344,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -7974,6 +8005,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
@@ -8074,6 +8132,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html-void-elements": {
@@ -8178,6 +8246,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -8197,6 +8271,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-identifier": {
@@ -9060,6 +9178,66 @@
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -10188,6 +10366,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -10782,6 +10985,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -10920,6 +11150,23 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-format": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-highlight": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
+      "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "lowlight": "^3.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11522,6 +11769,24 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -5,6 +5,7 @@ import type { Db } from "@provara/db";
 import { requests } from "@provara/db";
 import { nanoid } from "nanoid";
 import { logCost } from "./cost/index.js";
+import { calculateCost } from "./cost/pricing.js";
 import { createRoutingEngine, type RoutingProfile } from "./routing/index.js";
 import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
@@ -57,7 +58,7 @@ export async function createRouter(ctx: RouterContext) {
     credentials: true,
     allowHeaders: ["Content-Type", "Authorization", "X-Admin-Key", "X-Stainless-OS", "X-Stainless-Arch", "X-Stainless-Lang", "X-Stainless-Runtime", "X-Stainless-Runtime-Version", "X-Stainless-Package-Version", "X-Stainless-Retry-Count"],
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-Provara-Request-Id", "X-Provara-Errors", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
+    exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-Provara-Request-Id", "X-Provara-Errors", "X-Provara-Cost", "X-Provara-Latency", "X-Provara-Cache", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
   }));
 
   // Mount OAuth routes (public, only in multi_tenant mode)
@@ -389,11 +390,27 @@ export async function createRouter(ctx: RouterContext) {
                   emitChunk(chunk);
                 }
 
+                // Emit a final Provara meta event before [DONE] so the client
+                // can show cost/latency/tokens inline with the response. We
+                // can't set response headers after the stream started, so we
+                // piggyback on the SSE channel with a custom event shape.
+                const streamLatencyMs = Math.round(performance.now() - start);
+                const streamCost = calculateCost(usedModel, usage.inputTokens, usage.outputTokens);
+                const metaEvent = JSON.stringify({
+                  _provara: {
+                    model: usedModel,
+                    provider: usedProvider,
+                    latencyMs: streamLatencyMs,
+                    cost: streamCost,
+                    usage,
+                  },
+                });
+                controller.enqueue(encoder.encode(`data: ${metaEvent}\n\n`));
                 controller.enqueue(encoder.encode("data: [DONE]\n\n"));
                 controller.close();
 
                 // Log after stream completes
-                const latencyMs = Math.round(performance.now() - start);
+                const latencyMs = streamLatencyMs;
                 await ctx.db
                   .insert(requests)
                   .values({
@@ -633,7 +650,10 @@ export async function createRouter(ctx: RouterContext) {
     }
 
     // Return OpenAI-compatible response format
+    const nonStreamCost = calculateCost(usedModel, response.usage.inputTokens, response.usage.outputTokens);
     c.header("X-Provara-Request-Id", requestId);
+    c.header("X-Provara-Latency", String(response.latencyMs));
+    c.header("X-Provara-Cost", nonStreamCost.toFixed(6));
     return c.json({
       id: `chatcmpl-${response.id}`,
       object: "chat.completion",


### PR DESCRIPTION
## Summary

Tier 1 playground polish — four features in one PR because they share the same component surface and #108's refactor made them all low-friction additions to the extracted chat module.

## Changes

### Markdown rendering

- `react-markdown` + `remark-gfm` + `rehype-highlight` (highlight.js, `github-dark.css` theme).
- New `MarkdownMessage` component. GFM tables, strikethrough, task lists all work. Fenced code blocks get a hover "Copy" button reading `innerText` from the `<pre>`.
- User messages stay plain-text; only assistant messages go through the markdown renderer. Rationale: user input should display exactly as typed — no surprise auto-formatting.

### Inline cost / latency / tokens

- **Backend**: `X-Provara-Cost` + `X-Provara-Latency` headers on non-stream responses. Streaming can't set headers after the stream starts, so we emit a trailing `data: {"_provara": {...}}` SSE event before `[DONE]`. Both sources converge into the same `ChatMessage` fields.
- **Types**: `ChatMessage` gains `cost`, `latencyMs`, `inputTokens`, `outputTokens`, `cacheSource` (all optional).
- **Render**: `MessageBubble` now shows a compact meta line under assistant turns:
  `cache: semantic · 847ms · $0.0023 · 234 in / 187 out`
- CORS `exposeHeaders` widened to include the new headers + `X-Provara-Cache`.

### Stop button (AbortController)

- `useChatSession` holds an `abortRef`; exposes `stop()`.
- `fetch(...)` passes `signal: controller.signal` so pressing Stop cancels both the HTTP request and the SSE reader.
- `AbortError` is swallowed as user-initiated — no "Error: aborted" message appears in the transcript.
- Playground renders a red Stop button as `ChatInput`'s `rightAddon` while streaming.

### Copy action

- `CopyButton` component: `navigator.clipboard.writeText` + "Copied" confirmation for 1.2s, fails silently in clipboard-restricted contexts.
- Registered as a `MessageAction`, appears on every message (user + assistant — "copy what I said" is useful too).

## Test plan

- [x] `tsc --noEmit` clean on both gateway and web.
- [x] gateway vitest: 53/53 pass.
- [x] web vitest: 16/16 pass.
- [x] playwright e2e: 7/7 pass (focus guard, model selector, send-button state, landing hero, horizontal scroll, docs layout).
- [ ] Manual QA on Railway: send markdown → renders; code block → syntax highlighted + copy works; streaming → Stop cancels cleanly; cost/latency/tokens show under responses; copy action on any message.

## Notes on design decisions

**Why a trailing SSE event instead of a separate /request/:id fetch for cost?** One round-trip, deterministic timing, no stale read during the time the request row is being inserted. The client already parses the SSE stream anyway — adding one more event type is free.

**Why highlight.js over Shiki?** Pragmatic call — users glance at code, they don't read it. Shiki is a swap-later move if the playground grows into a "serious eval tool."

**Why no new unit tests?** Markdown/copy/stop are trivially RTL-testable but the existing e2e covers the critical regression surface (input focus, send enable/disable). Adding click-and-assert-clipboard would be test-for-the-sake-of-it. Will add if a real bug surfaces.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)