### PR TITLE
feat(#129): persistent saved conversations in playground

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -9,8 +9,10 @@ import { StarRating } from "../../../components/chat/StarRating";
 import { CopyButton } from "../../../components/chat/CopyButton";
 import { MarkdownMessage } from "../../../components/chat/MarkdownMessage";
 import { ModelInfoPopover } from "../../../components/chat/ModelInfoPopover";
+import { ConversationSidebar } from "../../../components/chat/ConversationSidebar";
 import { useChatSession } from "../../../components/chat/use-chat-session";
 import { useSessionPersist } from "../../../components/chat/use-session-persist";
+import { useSavedConversations } from "../../../components/chat/use-saved-conversations";
 import type { ChatMessage, MessageAction } from "../../../components/chat/types";
 
 interface ProviderInfo {
@@ -28,15 +30,60 @@ export default function PlaygroundPage() {
   const [apiToken, setApiToken] = useState("");
   const [input, setInput] = useState("");
   const [showSettings, setShowSettings] = useState(false);
+  const [showConversations, setShowConversations] = useState(true);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
   const inputRef = useRef<ChatInputHandle>(null);
 
   const session = useChatSession();
+  const saved = useSavedConversations();
 
   useEffect(() => {
     gatewayClientFetch<{ providers: ProviderInfo[] }>("/v1/providers")
       .then((data) => setProviders(data.providers || []))
       .catch(console.error);
   }, []);
+
+  // Auto-save when messages change and streaming has completed. Creates on the
+  // first assistant turn of an unsaved session; otherwise PATCHes the active
+  // conversation. Small debounce to avoid a write per keystroke during
+  // streaming (we already skip via `session.streaming`, but defensive).
+  useEffect(() => {
+    if (session.streaming) return;
+    if (session.messages.length === 0) return;
+    const hasAssistant = session.messages.some((m) => m.role === "assistant");
+    if (!hasAssistant) return; // don't save conversations with only a user prompt typed but no reply
+
+    const handle = setTimeout(async () => {
+      if (activeConversationId) {
+        await saved.update(activeConversationId, { messages: session.messages });
+      } else {
+        const id = await saved.create(session.messages);
+        if (id) setActiveConversationId(id);
+      }
+    }, 400);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session.messages, session.streaming]);
+
+  async function handleSelectConversation(id: string) {
+    const detail = await saved.load(id);
+    if (!detail) return;
+    session.loadMessages(detail.messages);
+    setActiveConversationId(id);
+  }
+
+  function handleNewConversation() {
+    session.clear();
+    setActiveConversationId(null);
+  }
+
+  async function handleDeleteConversation(id: string) {
+    await saved.remove(id);
+    if (id === activeConversationId) {
+      session.clear();
+      setActiveConversationId(null);
+    }
+  }
 
   async function handleSend() {
     const text = input;
@@ -91,9 +138,26 @@ export default function PlaygroundPage() {
 
   return (
     <div className="flex h-[calc(100vh-3.5rem)]">
+      <ConversationSidebar
+        open={showConversations}
+        list={saved.list}
+        activeId={activeConversationId}
+        onSelect={handleSelectConversation}
+        onNew={handleNewConversation}
+        onDelete={handleDeleteConversation}
+        loading={saved.loading}
+      />
       <div className="flex-1 flex flex-col min-w-0">
         {/* Top bar */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800">
+          <button
+            onClick={() => setShowConversations((v) => !v)}
+            title={showConversations ? "Hide conversations" : "Show conversations"}
+            aria-label={showConversations ? "Hide conversations" : "Show conversations"}
+            className="w-8 h-8 flex items-center justify-center text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800 rounded-lg transition-colors"
+          >
+            ☰
+          </button>
           <select
             value={selectedModel ? `${selectedProvider}/${selectedModel}` : ""}
             onChange={(e) => handleModelChange(e.target.value)}
@@ -128,7 +192,7 @@ export default function PlaygroundPage() {
               </button>
             )}
             <button
-              onClick={session.clear}
+              onClick={handleNewConversation}
               className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
             >
               Clear

--- a/apps/web/src/components/chat/ConversationSidebar.tsx
+++ b/apps/web/src/components/chat/ConversationSidebar.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { SavedConversationSummary } from "./use-saved-conversations";
+
+interface Props {
+  open: boolean;
+  list: SavedConversationSummary[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  onDelete: (id: string) => void;
+  loading: boolean;
+}
+
+function relativeTime(iso: string): string {
+  const d = new Date(iso).getTime();
+  const diff = Math.max(0, Date.now() - d);
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function ConversationSidebar({
+  open,
+  list,
+  activeId,
+  onSelect,
+  onNew,
+  onDelete,
+  loading,
+}: Props) {
+  if (!open) return null;
+  return (
+    <div className="w-60 border-r border-zinc-800 bg-zinc-900/40 flex flex-col overflow-hidden">
+      <div className="p-2 border-b border-zinc-800">
+        <button
+          type="button"
+          onClick={onNew}
+          className="w-full px-3 py-2 text-xs text-zinc-300 bg-zinc-800 border border-zinc-700 rounded-lg hover:bg-zinc-700 transition-colors"
+        >
+          + New conversation
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto scrollbar-thin">
+        {loading && list.length === 0 && (
+          <p className="text-xs text-zinc-500 p-3">Loading…</p>
+        )}
+        {!loading && list.length === 0 && (
+          <p className="text-xs text-zinc-500 p-3 leading-relaxed">
+            No saved conversations yet. Start chatting — your session will auto-save
+            after the first response.
+          </p>
+        )}
+        {list.map((c) => {
+          const isActive = c.id === activeId;
+          return (
+            <div
+              key={c.id}
+              className={`group px-3 py-2 cursor-pointer border-l-2 transition-colors ${
+                isActive
+                  ? "border-blue-500 bg-zinc-800/60"
+                  : "border-transparent hover:bg-zinc-800/40"
+              }`}
+              onClick={() => onSelect(c.id)}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-xs text-zinc-200 truncate leading-snug">{c.title}</p>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (confirm(`Delete "${c.title}"?`)) onDelete(c.id);
+                  }}
+                  className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-red-400 text-xs transition-opacity"
+                  aria-label="Delete conversation"
+                >
+                  ×
+                </button>
+              </div>
+              <p className="text-[10px] text-zinc-500 mt-0.5">{relativeTime(c.updatedAt)}</p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/use-chat-session.ts
+++ b/apps/web/src/components/chat/use-chat-session.ts
@@ -230,6 +230,18 @@ export function useChatSession() {
     if (typeof window !== "undefined") sessionStorage.removeItem(STORAGE_KEY);
   }, []);
 
+  /**
+   * Replace the active session's messages wholesale — used when loading a
+   * saved conversation from the sidebar. Resets the topic boundary so the
+   * whole loaded transcript is one topic.
+   */
+  const loadMessages = useCallback((next: ChatMessage[]) => {
+    setMessages(next);
+    setStreamingContent("");
+    setTopicStartIndex(0);
+    persistMessages(next);
+  }, [persistMessages]);
+
   const startNewTopic = useCallback(() => {
     setTopicStartIndex(messages.length);
   }, [messages.length]);
@@ -290,6 +302,7 @@ export function useChatSession() {
     send,
     stop,
     clear,
+    loadMessages,
     startNewTopic,
     rate,
   };

--- a/apps/web/src/components/chat/use-saved-conversations.ts
+++ b/apps/web/src/components/chat/use-saved-conversations.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { gatewayClientFetch } from "../../lib/gateway-client";
+import type { ChatMessage } from "./types";
+
+export interface SavedConversationSummary {
+  id: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SavedConversationDetail extends SavedConversationSummary {
+  messages: ChatMessage[];
+}
+
+/**
+ * Persistent conversation list for the current tenant, backed by
+ * /v1/conversations. The list is fetched on mount and refreshed after
+ * every mutating call so the sidebar stays consistent with the server
+ * without fighting with optimistic UI.
+ *
+ * Auto-save contract: callers own when to call `save` — typically after
+ * an assistant turn completes. We dedupe internally: if the conversation
+ * already exists, we PATCH; if not, we POST and capture the new id.
+ */
+export function useSavedConversations() {
+  const [list, setList] = useState<SavedConversationSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await gatewayClientFetch<{ conversations: SavedConversationSummary[] }>(
+        "/v1/conversations",
+      );
+      setList(data.conversations || []);
+    } catch {
+      // Silent — sidebar handles the empty case.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const load = useCallback(async (id: string): Promise<SavedConversationDetail | null> => {
+    try {
+      return await gatewayClientFetch<SavedConversationDetail>(`/v1/conversations/${id}`);
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const create = useCallback(
+    async (messages: ChatMessage[], title?: string): Promise<string | null> => {
+      try {
+        const res = await gatewayClientFetch<{ id: string }>("/v1/conversations", {
+          method: "POST",
+          body: JSON.stringify({ title, messages }),
+        });
+        await refresh();
+        return res.id;
+      } catch {
+        return null;
+      }
+    },
+    [refresh],
+  );
+
+  const update = useCallback(
+    async (id: string, patch: { title?: string; messages?: ChatMessage[] }) => {
+      try {
+        await gatewayClientFetch(`/v1/conversations/${id}`, {
+          method: "PATCH",
+          body: JSON.stringify(patch),
+        });
+        await refresh();
+      } catch {
+        // Silent; next successful refresh will correct.
+      }
+    },
+    [refresh],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        await gatewayClientFetch(`/v1/conversations/${id}`, { method: "DELETE" });
+        await refresh();
+      } catch {}
+    },
+    [refresh],
+  );
+
+  return { list, loading, refresh, load, create, update, remove };
+}

--- a/packages/db/drizzle/0018_magenta_ezekiel.sql
+++ b/packages/db/drizzle/0018_magenta_ezekiel.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`title` text NOT NULL,
+	`messages` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0018_snapshot.json
+++ b/packages/db/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,1754 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c2d45bac-2669-41ba-9a38-c2fab55ef52f",
+  "prevId": "714a76b2-c400-4e2f-939f-367301741527",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776431053750,
       "tag": "0017_chilly_tana_nile",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776434800227,
+      "tag": "0018_magenta_ezekiel",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -270,6 +270,25 @@ export const modelScores = sqliteTable("model_scores", {
   primaryKey({ columns: [table.taskType, table.complexity, table.provider, table.model] }),
 ]);
 
+/**
+ * Persistent playground conversations. Sessions are tenant-scoped; the
+ * `messages` column stores the full transcript as JSON (serialized
+ * `ChatMessage[]`) because turns are a UI grouping, not an analytics
+ * primitive — per-turn data already lives in `requests` + `feedback`.
+ */
+export const conversations = sqliteTable("conversations", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  title: text("title").notNull(),
+  messages: text("messages").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
 export const semanticCache = sqliteTable("semantic_cache", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -332,6 +332,118 @@ paths:
         "200":
           description: Deleted
 
+  /v1/conversations:
+    get:
+      tags: [Conversations]
+      summary: List saved playground conversations for current tenant
+      operationId: listConversations
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+      responses:
+        "200":
+          description: Conversation list (summary only — messages not included)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [conversations]
+                properties:
+                  conversations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ConversationSummary"
+    post:
+      tags: [Conversations]
+      summary: Create a saved conversation
+      operationId: createConversation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [messages]
+              properties:
+                title:
+                  type: string
+                  description: Optional title. Auto-generated from first user message if omitted.
+                messages:
+                  type: array
+                  description: Serialized ChatMessage[] array.
+                  items:
+                    type: object
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationSummary"
+
+  /v1/conversations/{id}:
+    get:
+      tags: [Conversations]
+      summary: Get one conversation with full messages
+      operationId: getConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Conversation detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationDetail"
+        "404":
+          description: Not found
+    patch:
+      tags: [Conversations]
+      summary: Update title and/or messages
+      operationId: updateConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                messages:
+                  type: array
+                  items:
+                    type: object
+      responses:
+        "200":
+          description: Updated
+    delete:
+      tags: [Conversations]
+      summary: Delete a conversation
+      operationId: deleteConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted
+
   /v1/admin/tokens:
     get:
       tags: [Tokens]
@@ -989,6 +1101,33 @@ components:
             $ref: "#/components/schemas/Error"
 
   schemas:
+    ConversationSummary:
+      type: object
+      required: [id, title, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ConversationDetail:
+      allOf:
+        - $ref: "#/components/schemas/ConversationSummary"
+        - type: object
+          required: [messages]
+          properties:
+            messages:
+              type: array
+              description: Full ChatMessage[] for this conversation.
+              items:
+                type: object
+
     Error:
       type: object
       required: [error]

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -15,6 +15,7 @@ import { createAdminMiddleware, requireRole } from "./auth/admin.js";
 import { createTenantMiddleware } from "./auth/tenant.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
+import { createConversationRoutes } from "./routes/conversations.js";
 import { createRoutingConfigRoutes } from "./routes/routing-config.js";
 import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
@@ -75,6 +76,8 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/analytics/*", adminAuth);
   app.use("/v1/api-keys/*", adminAuth);
   app.use("/v1/feedback/*", adminAuth);
+  app.use("/v1/conversations", adminAuth);
+  app.use("/v1/conversations/*", adminAuth);
   app.use("/v1/admin/*", adminAuth);
   app.use("/v1/providers", adminAuth);
   app.use("/v1/providers/*", adminAuth);
@@ -99,6 +102,7 @@ export async function createRouter(ctx: RouterContext) {
 
   // Mount feedback routes
   app.route("/v1/feedback", createFeedbackRoutes(ctx.db, routingEngine.adaptive));
+  app.route("/v1/conversations", createConversationRoutes(ctx.db));
   app.route("/v1/routing/config", createRoutingConfigRoutes(ctx.db));
 
   // Mount token management routes (owner only)

--- a/packages/gateway/src/routes/conversations.ts
+++ b/packages/gateway/src/routes/conversations.ts
@@ -1,0 +1,120 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { conversations } from "@provara/db";
+import { and, desc, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantId } from "../auth/tenant.js";
+
+const DEFAULT_LIMIT = 50;
+const MAX_TITLE_LENGTH = 60;
+
+function defaultTitle(messages: unknown): string {
+  if (!Array.isArray(messages)) return "Untitled";
+  const firstUser = messages.find(
+    (m: { role?: string; content?: string }) => m.role === "user" && typeof m.content === "string" && m.content.trim(),
+  );
+  const raw = (firstUser as { content?: string } | undefined)?.content?.trim();
+  if (!raw) return "Untitled";
+  const collapsed = raw.replace(/\s+/g, " ");
+  return collapsed.length > MAX_TITLE_LENGTH
+    ? `${collapsed.slice(0, MAX_TITLE_LENGTH - 1)}…`
+    : collapsed;
+}
+
+export function createConversationRoutes(db: Db) {
+  const app = new Hono();
+
+  // List conversations for the current tenant. Newest first; title + updatedAt
+  // are enough for a sidebar — messages aren't serialized in the list
+  // response to keep it cheap.
+  app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const limit = Math.min(parseInt(c.req.query("limit") || String(DEFAULT_LIMIT)), 200);
+    const where = tenantId ? eq(conversations.tenantId, tenantId) : undefined;
+    const rows = await db
+      .select({
+        id: conversations.id,
+        title: conversations.title,
+        createdAt: conversations.createdAt,
+        updatedAt: conversations.updatedAt,
+      })
+      .from(conversations)
+      .where(where)
+      .orderBy(desc(conversations.updatedAt))
+      .limit(limit)
+      .all();
+    return c.json({ conversations: rows });
+  });
+
+  app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw) || null;
+    const body = await c.req.json<{ title?: string; messages: unknown }>();
+    const id = nanoid();
+    const title = body.title?.trim() || defaultTitle(body.messages);
+    const now = new Date();
+    await db
+      .insert(conversations)
+      .values({
+        id,
+        tenantId,
+        title,
+        messages: JSON.stringify(body.messages ?? []),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    return c.json({ id, title, createdAt: now, updatedAt: now }, 201);
+  });
+
+  app.get("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const id = c.req.param("id");
+    const where = tenantId
+      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
+      : eq(conversations.id, id);
+    const row = await db.select().from(conversations).where(where).get();
+    if (!row) return c.json({ error: { message: "Not found", type: "not_found" } }, 404);
+    let messages: unknown = [];
+    try {
+      messages = JSON.parse(row.messages);
+    } catch {}
+    return c.json({
+      id: row.id,
+      title: row.title,
+      messages,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
+  });
+
+  app.patch("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const id = c.req.param("id");
+    const where = tenantId
+      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
+      : eq(conversations.id, id);
+
+    const existing = await db.select().from(conversations).where(where).get();
+    if (!existing) return c.json({ error: { message: "Not found", type: "not_found" } }, 404);
+
+    const body = await c.req.json<{ title?: string; messages?: unknown }>();
+    const next: { title?: string; messages?: string; updatedAt: Date } = { updatedAt: new Date() };
+    if (typeof body.title === "string") next.title = body.title.slice(0, 200);
+    if (body.messages !== undefined) next.messages = JSON.stringify(body.messages);
+
+    await db.update(conversations).set(next).where(where).run();
+    return c.json({ id, updated: true, updatedAt: next.updatedAt });
+  });
+
+  app.delete("/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const id = c.req.param("id");
+    const where = tenantId
+      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
+      : eq(conversations.id, id);
+    await db.delete(conversations).where(where).run();
+    return c.json({ deleted: true });
+  });
+
+  return app;
+}

--- a/packages/gateway/tests/conversations.test.ts
+++ b/packages/gateway/tests/conversations.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { createConversationRoutes } from "../src/routes/conversations.js";
+import { makeTestDb } from "./_setup/db.js";
+
+async function buildApp() {
+  const db = await makeTestDb();
+  const app = new Hono();
+  app.route("/v1/conversations", createConversationRoutes(db));
+  return { db, app };
+}
+
+function req(app: Hono, path: string, init?: RequestInit) {
+  return app.request(path, init);
+}
+
+describe("conversations routes", () => {
+  it("creates with auto-title from first user message", async () => {
+    const { app } = await buildApp();
+    const res = await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{ role: "user", content: "What is the capital of France?" }],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.id).toMatch(/.{4,}/);
+    expect(body.title).toBe("What is the capital of France?");
+  });
+
+  it("truncates long titles to 60 chars with an ellipsis", async () => {
+    const { app } = await buildApp();
+    const long = "a".repeat(200);
+    const res = await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: long }] }),
+    });
+    const body = await res.json();
+    expect(body.title.length).toBe(60);
+    expect(body.title.endsWith("…")).toBe(true);
+  });
+
+  it("explicit title in POST overrides auto-title", async () => {
+    const { app } = await buildApp();
+    const res = await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Custom title",
+        messages: [{ role: "user", content: "whatever" }],
+      }),
+    });
+    const body = await res.json();
+    expect(body.title).toBe("Custom title");
+  });
+
+  it("lists newest first and returns summaries (no messages)", async () => {
+    const { app } = await buildApp();
+    await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "first" }] }),
+    });
+    // updatedAt is stored as Unix seconds (Drizzle `mode: "timestamp"`), so
+    // back-to-back inserts share a timestamp. Sleep 1.1s to land on a new
+    // second boundary and give the list query something to order by.
+    await new Promise((r) => setTimeout(r, 1100));
+    await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "second" }] }),
+    });
+
+    const list = await (await req(app, "/v1/conversations")).json();
+    expect(list.conversations).toHaveLength(2);
+    expect(list.conversations[0].title).toBe("second");
+    expect(list.conversations[0].messages).toBeUndefined();
+  });
+
+  it("GET /:id returns full messages", async () => {
+    const { app } = await buildApp();
+    const created = await (await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [
+          { role: "user", content: "ping" },
+          { role: "assistant", content: "pong" },
+        ],
+      }),
+    })).json();
+
+    const detail = await (await req(app, `/v1/conversations/${created.id}`)).json();
+    expect(detail.messages).toHaveLength(2);
+    expect(detail.messages[1].content).toBe("pong");
+  });
+
+  it("PATCH updates messages and bumps updatedAt", async () => {
+    const { app } = await buildApp();
+    const created = await (await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "v1" }] }),
+    })).json();
+
+    const patchRes = await req(app, `/v1/conversations/${created.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "v2" }] }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    const detail = await (await req(app, `/v1/conversations/${created.id}`)).json();
+    expect(detail.messages[0].content).toBe("v2");
+  });
+
+  it("DELETE removes the row", async () => {
+    const { app } = await buildApp();
+    const created = await (await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "x" }] }),
+    })).json();
+
+    await req(app, `/v1/conversations/${created.id}`, { method: "DELETE" });
+    const res = await req(app, `/v1/conversations/${created.id}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #129. Playground gets a persistent left sidebar — like OpenRouter / ChatGPT — where prior chats save automatically and reload on click.

## Changes

### Backend

- New `conversations` table (migration 0018): `id`, `tenantId`, `title`, `messages` JSON, `createdAt`, `updatedAt`.
- `/v1/conversations` routes: `GET /`, `POST /`, `GET /:id`, `PATCH /:id`, `DELETE /:id`. Tenant-scoped via existing `getTenantId`; admin-auth gated.
- Auto-title from first user message, truncated to 60 chars with ellipsis.
- OpenAPI documents the endpoints + `ConversationSummary` / `ConversationDetail` schemas.

### Frontend

- `useSavedConversations` hook: list / create / update / delete / load. Refreshes after every mutation — no optimistic UI, simple and correct.
- `ConversationSidebar`: left rail, active highlight, delete-with-confirm, "+ New conversation" button, relative timestamps, empty-state copy.
- `useChatSession.loadMessages(next)` for wholesale replacement when loading.
- Playground wiring:
  - ☰ toggle shows/hides the sidebar (default: open)
  - Autosave debounced 400ms after an assistant turn lands — creates on first save, PATCHes after
  - Selecting a conversation replaces session state
  - Deleting the active conversation clears the chat
- `sessionStorage` stays as the draft cache for unsaved in-progress chats (survives tab refresh before first save).

## Data model decision

`messages` is JSON on the conversations row, not a separate `conversation_messages` table. Per-turn analytics already live in `requests` + `feedback` — conversations are a UI grouping, not an analytics primitive. One-query load, no join, simpler.

## Test plan

- [x] `tsc --noEmit` clean on gateway + web.
- [x] `vitest run` — 60/60 gateway (7 new integration tests for the route), 16/16 web.
- [x] `playwright test` — 7/7 pass (sidebar didn't break playground focus, model selector, send state, etc.).
- [ ] Manual QA on Railway:
  - Start a chat, see it appear in sidebar after first response
  - Refresh the page → conversation still there, click loads it
  - Delete a conversation, confirm it's gone
  - Toggle sidebar via ☰, confirm playground still works with it collapsed

## Out of scope (deferred)

- Rename UI (PATCH exists; UI to invoke it is a follow-up).
- LLM-generated titles.
- Full-text search across conversations.
- Folders / tagging.
- Sharing links (Tier 4).

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)