### PR TITLE
feat(chat): prompt presets, fork conversation, share links

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -10,10 +10,12 @@ import { CopyButton } from "../../../components/chat/CopyButton";
 import { MarkdownMessage } from "../../../components/chat/MarkdownMessage";
 import { ModelInfoPopover } from "../../../components/chat/ModelInfoPopover";
 import { ConversationSidebar } from "../../../components/chat/ConversationSidebar";
+import { PromptPresetPicker } from "../../../components/chat/PromptPresetPicker";
 import { useChatSession } from "../../../components/chat/use-chat-session";
 import { useSessionPersist } from "../../../components/chat/use-session-persist";
 import { useSavedConversations } from "../../../components/chat/use-saved-conversations";
 import type { ChatMessage, MessageAction } from "../../../components/chat/types";
+import type { PromptPreset } from "../../../components/chat/presets";
 
 interface ProviderInfo {
   name: string;
@@ -85,6 +87,58 @@ export default function PlaygroundPage() {
     }
   }
 
+  async function handleFork(messageIndex: number) {
+    // Take messages up through (inclusive) the chosen turn and create a new
+    // conversation from them. Load it as the active session so the user can
+    // continue from the branch point without losing the original.
+    const slice = session.messages.slice(0, messageIndex + 1);
+    if (slice.length === 0) return;
+    const firstUser = slice.find((m) => m.role === "user")?.content?.trim() || "Forked conversation";
+    const truncated = firstUser.replace(/\s+/g, " ").slice(0, 59);
+    const title = `${truncated}… (fork)`;
+    const id = await saved.create(slice, title);
+    if (!id) return;
+    session.loadMessages(slice);
+    setActiveConversationId(id);
+  }
+
+  async function handleShare() {
+    if (!activeConversationId) {
+      // Auto-save first so there's something to share.
+      if (session.messages.length === 0) return;
+      const id = await saved.create(session.messages);
+      if (!id) return;
+      setActiveConversationId(id);
+      // Small wait so the server has committed; then share.
+      await new Promise((r) => setTimeout(r, 200));
+      return doShare(id);
+    }
+    return doShare(activeConversationId);
+  }
+
+  async function doShare(id: string) {
+    try {
+      const res = await gatewayClientFetch<{ token: string }>(`/v1/conversations/${id}/share`, {
+        method: "POST",
+      });
+      const url = `${window.location.origin}/shared/${res.token}`;
+      try {
+        await navigator.clipboard.writeText(url);
+        alert(`Share link copied to clipboard:\n\n${url}`);
+      } catch {
+        // Clipboard blocked — show the URL directly so the user can copy manually.
+        prompt("Share link:", url);
+      }
+    } catch {
+      alert("Failed to create share link.");
+    }
+  }
+
+  function handlePresetPick(preset: PromptPreset) {
+    if (preset.systemPrompt) setSystemPrompt(preset.systemPrompt);
+    setInput(preset.body);
+  }
+
   async function handleSend() {
     const text = input;
     setInput("");
@@ -125,6 +179,21 @@ export default function PlaygroundPage() {
     // Show on every message, user and assistant alike — "copy what I said" is useful too.
     showFor: () => true,
     render: (msg) => <CopyButton text={msg.content} />,
+  };
+
+  const forkAction: MessageAction = {
+    id: "fork",
+    showFor: (msg) => msg.role === "assistant",
+    render: (_msg, i) => (
+      <button
+        type="button"
+        onClick={() => handleFork(i)}
+        className="px-2 py-0.5 text-xs text-zinc-500 hover:text-zinc-300 border border-transparent hover:border-zinc-700 rounded transition-colors"
+        title="Fork conversation from here"
+      >
+        Fork
+      </button>
+    ),
   };
 
   // Render assistant messages as markdown; user prompts stay as plain text so
@@ -191,6 +260,15 @@ export default function PlaygroundPage() {
                 New Topic
               </button>
             )}
+            {session.messages.some((m) => m.role === "assistant") && (
+              <button
+                onClick={handleShare}
+                className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
+                title="Create a public share link"
+              >
+                Share
+              </button>
+            )}
             <button
               onClick={handleNewConversation}
               className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
@@ -205,7 +283,7 @@ export default function PlaygroundPage() {
           streaming={session.streaming}
           streamingContent={session.streamingContent}
           topicStartIndex={session.topicStartIndex}
-          actions={[copyAction, ratingAction]}
+          actions={[copyAction, forkAction, ratingAction]}
           renderContent={renderContent}
           emptyState={
             <div className="flex items-center justify-center h-full">
@@ -225,6 +303,7 @@ export default function PlaygroundPage() {
           onChange={setInput}
           onSend={handleSend}
           disabled={session.streaming}
+          leftAddon={<PromptPresetPicker onPick={handlePresetPick} />}
           rightAddon={
             session.streaming ? (
               <button

--- a/apps/web/src/app/shared/[token]/page.tsx
+++ b/apps/web/src/app/shared/[token]/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { gatewayClientFetch } from "../../../lib/gateway-client";
+import { MessageList } from "../../../components/chat/MessageList";
+import { MarkdownMessage } from "../../../components/chat/MarkdownMessage";
+import type { ChatMessage } from "../../../components/chat/types";
+
+interface SharedConversation {
+  token: string;
+  title: string;
+  messages: ChatMessage[];
+  createdAt: string;
+  conversationCreatedAt: string;
+}
+
+export default function SharedConversationPage() {
+  const params = useParams();
+  const token = (params?.token as string) || "";
+  const [data, setData] = useState<SharedConversation | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    if (!token) return;
+    gatewayClientFetch<SharedConversation>(`/v1/shared/${token}`)
+      .then(setData)
+      .catch(() => setNotFound(true));
+  }, [token]);
+
+  function renderContent(msg: ChatMessage) {
+    if (msg.role === "assistant") {
+      return <MarkdownMessage content={msg.content} />;
+    }
+    return <p className="text-sm whitespace-pre-wrap">{msg.content}</p>;
+  }
+
+  if (notFound) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-8">
+        <div className="text-center">
+          <h1 className="text-xl font-semibold mb-2">Link expired</h1>
+          <p className="text-sm text-zinc-400">This share link has been revoked or never existed.</p>
+          <a href="/" className="inline-block mt-4 text-blue-400 hover:text-blue-300 underline text-sm">
+            Go to Provara
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-sm text-zinc-500">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen flex-col">
+      <div className="border-b border-zinc-800 px-4 py-3 flex items-center justify-between">
+        <div>
+          <p className="text-xs text-zinc-500 uppercase tracking-widest">Shared conversation</p>
+          <h1 className="text-sm font-medium text-zinc-200">{data.title}</h1>
+        </div>
+        <a
+          href="/"
+          className="text-xs text-zinc-400 hover:text-zinc-200 border border-zinc-700 rounded-lg px-3 py-1.5 transition-colors"
+        >
+          Try Provara →
+        </a>
+      </div>
+      <MessageList
+        messages={data.messages}
+        streaming={false}
+        streamingContent=""
+        topicStartIndex={0}
+        renderContent={renderContent}
+        emptyState={<p className="text-center text-zinc-500 mt-8">This conversation is empty.</p>}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/PromptPresetPicker.tsx
+++ b/apps/web/src/components/chat/PromptPresetPicker.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PROMPT_PRESETS, type PromptPreset } from "./presets";
+
+interface Props {
+  onPick: (preset: PromptPreset) => void;
+}
+
+/**
+ * "Presets" button (mounted as an `inputAddon` on ChatInput). Click opens a
+ * small popover grouped by category; clicking a preset fires `onPick` which
+ * the playground uses to populate the input and (if set) the system prompt.
+ */
+export function PromptPresetPicker({ onPick }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    window.addEventListener("mousedown", onDown);
+    return () => window.removeEventListener("mousedown", onDown);
+  }, [open]);
+
+  const grouped = useMemo(() => {
+    const by: Record<string, PromptPreset[]> = {};
+    for (const p of PROMPT_PRESETS) {
+      by[p.category] = by[p.category] || [];
+      by[p.category].push(p);
+    }
+    return by;
+  }, []);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title="Prompt presets"
+        aria-label="Prompt presets"
+        className="h-[44px] px-3 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-900 border border-zinc-700 rounded-xl transition-colors shrink-0"
+      >
+        Presets
+      </button>
+      {open && (
+        <div className="absolute left-0 bottom-12 z-10 w-72 rounded-lg border border-zinc-800 bg-zinc-950 shadow-xl p-2 max-h-96 overflow-y-auto">
+          {Object.entries(grouped).map(([category, presets]) => (
+            <div key={category} className="mb-2 last:mb-0">
+              <p className="text-[10px] text-zinc-500 uppercase tracking-widest px-2 py-1">
+                {category}
+              </p>
+              {presets.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => {
+                    onPick(p);
+                    setOpen(false);
+                  }}
+                  className="w-full text-left px-2 py-1.5 text-xs text-zinc-300 hover:bg-zinc-800 rounded transition-colors"
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/presets.ts
+++ b/apps/web/src/components/chat/presets.ts
@@ -1,0 +1,78 @@
+/**
+ * Starter prompt library. Curated list; no user-editable presets yet —
+ * that can land once there's demand. Categorized so the picker can
+ * group visually; each preset optionally pairs a system prompt to set
+ * context, and a body that populates the input.
+ */
+export interface PromptPreset {
+  id: string;
+  category: string;
+  label: string;
+  systemPrompt?: string;
+  body: string;
+}
+
+export const PROMPT_PRESETS: PromptPreset[] = [
+  {
+    id: "code-review",
+    category: "Coding",
+    label: "Code review",
+    systemPrompt:
+      "You are a careful senior engineer. When reviewing code, flag correctness bugs first, performance second, style last. Be specific — cite line numbers.",
+    body: "Review the following code for bugs, performance issues, and clarity:\n\n```\n// paste your code here\n```",
+  },
+  {
+    id: "explain-code",
+    category: "Coding",
+    label: "Explain this code",
+    body: "Explain what this code does, line by line, as if I'm a mid-level engineer unfamiliar with the library:\n\n```\n// paste your code here\n```",
+  },
+  {
+    id: "write-tests",
+    category: "Coding",
+    label: "Write tests",
+    systemPrompt:
+      "You write pragmatic unit tests. No mocks unless necessary. Focus on behavior, not implementation.",
+    body: "Write tests for this function. Cover the happy path, edge cases, and one failure mode:\n\n```\n// paste your function here\n```",
+  },
+  {
+    id: "summarize",
+    category: "Writing",
+    label: "Summarize",
+    body: "Summarize the following in 3 bullet points. Keep it concise and factual:\n\n",
+  },
+  {
+    id: "rewrite-clear",
+    category: "Writing",
+    label: "Rewrite for clarity",
+    body: "Rewrite the following to be clearer and more direct. Preserve the meaning; tighten the prose:\n\n",
+  },
+  {
+    id: "brainstorm",
+    category: "Writing",
+    label: "Brainstorm names",
+    body: "Brainstorm 10 names for the following. Mix short/punchy with longer/descriptive:\n\n",
+  },
+  {
+    id: "compare-options",
+    category: "Thinking",
+    label: "Compare options",
+    systemPrompt:
+      "You help users think through decisions. Give a structured comparison with explicit tradeoffs; state your recommendation last with one-sentence rationale.",
+    body: "Help me decide between the following options. Compare tradeoffs and recommend one:\n\nOption A: \nOption B: ",
+  },
+  {
+    id: "devils-advocate",
+    category: "Thinking",
+    label: "Devil's advocate",
+    systemPrompt:
+      "Push back hard. Your job is to stress-test an argument — point out unstated assumptions, overlooked counter-evidence, and rhetorical weaknesses.",
+    body: "Here's my argument. Play devil's advocate — what am I missing?\n\n",
+  },
+  {
+    id: "eli5",
+    category: "Q&A",
+    label: "Explain like I'm 5",
+    body: "Explain the following concept in plain English, as if talking to a smart non-expert. Use concrete analogies:\n\n",
+  },
+];

--- a/packages/db/drizzle/0019_tricky_triathlon.sql
+++ b/packages/db/drizzle/0019_tricky_triathlon.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `shares` (
+	`token` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`tenant_id` text,
+	`created_at` integer NOT NULL,
+	`revoked_at` integer
+);

--- a/packages/db/drizzle/meta/0019_snapshot.json
+++ b/packages/db/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1799 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7d434a1d-2da8-45b1-ab4f-652b600af4f1",
+  "prevId": "c2d45bac-2669-41ba-9a38-c2fab55ef52f",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1776434800227,
       "tag": "0018_magenta_ezekiel",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1776435233427,
+      "tag": "0019_tricky_triathlon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -289,6 +289,23 @@ export const conversations = sqliteTable("conversations", {
     .$defaultFn(() => new Date()),
 });
 
+/**
+ * Public share tokens for saved conversations. A row here grants anyone
+ * holding the token read access to the referenced conversation without
+ * auth. The token is a long random string (nanoid) so guessing is
+ * impractical; `revokedAt` lets the owner turn off access after the fact
+ * without deleting the row (preserves audit trail).
+ */
+export const shares = sqliteTable("shares", {
+  token: text("token").primaryKey(),
+  conversationId: text("conversation_id").notNull(),
+  tenantId: text("tenant_id"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  revokedAt: integer("revoked_at", { mode: "timestamp" }),
+});
+
 export const semanticCache = sqliteTable("semantic_cache", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -444,6 +444,73 @@ paths:
         "200":
           description: Deleted
 
+  /v1/conversations/{id}/share:
+    post:
+      tags: [Conversations]
+      summary: Create or return an active share token for a conversation
+      description: |
+        If a non-revoked share already exists for this conversation, its
+        token is returned (200). Otherwise a new token is minted (201).
+      operationId: shareConversation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Existing share returned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShareToken"
+        "201":
+          description: New share created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShareToken"
+        "404":
+          description: Conversation not found
+
+  /v1/shares/{token}:
+    delete:
+      tags: [Conversations]
+      summary: Revoke a share token
+      operationId: revokeShare
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Revoked
+
+  /v1/shared/{token}:
+    get:
+      tags: [Conversations]
+      summary: Public read of a shared conversation (no auth required)
+      operationId: readSharedConversation
+      security: []
+      parameters:
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Shared conversation contents
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SharedConversation"
+        "404":
+          description: Share not found or revoked
+
   /v1/admin/tokens:
     get:
       tags: [Tokens]
@@ -1101,6 +1168,36 @@ components:
             $ref: "#/components/schemas/Error"
 
   schemas:
+    ShareToken:
+      type: object
+      required: [token, createdAt]
+      properties:
+        token:
+          type: string
+          description: Opaque public share token; prefixed `sh_`.
+        createdAt:
+          type: string
+          format: date-time
+
+    SharedConversation:
+      type: object
+      required: [token, title, messages, createdAt, conversationCreatedAt]
+      properties:
+        token:
+          type: string
+        title:
+          type: string
+        messages:
+          type: array
+          items:
+            type: object
+        createdAt:
+          type: string
+          format: date-time
+        conversationCreatedAt:
+          type: string
+          format: date-time
+
     ConversationSummary:
       type: object
       required: [id, title, createdAt, updatedAt]

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -16,6 +16,7 @@ import { createTenantMiddleware } from "./auth/tenant.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createConversationRoutes } from "./routes/conversations.js";
+import { createShareHandlers } from "./routes/shares.js";
 import { createRoutingConfigRoutes } from "./routes/routing-config.js";
 import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
@@ -67,6 +68,12 @@ export async function createRouter(ctx: RouterContext) {
     app.route("/auth", createAuthRoutes(ctx.db));
   }
 
+  // Public share read — uses a distinct path (/v1/shared/:token, past tense)
+  // so the `/v1/shares/*` admin-auth middleware registered below doesn't
+  // accidentally gate it. Admin create/revoke operations use /v1/shares/*.
+  const shareHandlers = createShareHandlers(ctx.db);
+  app.get("/v1/shared/:token", shareHandlers.getPublic);
+
   // Auth middleware — checks Bearer token on /v1/chat/completions
   app.use("/v1/*", createAuthMiddleware(ctx.db));
 
@@ -78,6 +85,10 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/feedback/*", adminAuth);
   app.use("/v1/conversations", adminAuth);
   app.use("/v1/conversations/*", adminAuth);
+  // Authed share routes: create + revoke. Public read is /v1/shared/:token (above).
+  app.use("/v1/shares/*", adminAuth);
+  app.post("/v1/conversations/:id/share", shareHandlers.create);
+  app.delete("/v1/shares/:token", shareHandlers.revoke);
   app.use("/v1/admin/*", adminAuth);
   app.use("/v1/providers", adminAuth);
   app.use("/v1/providers/*", adminAuth);

--- a/packages/gateway/src/routes/shares.ts
+++ b/packages/gateway/src/routes/shares.ts
@@ -1,0 +1,97 @@
+import type { Context } from "hono";
+import type { Db } from "@provara/db";
+import { conversations, shares } from "@provara/db";
+import { and, eq, isNull } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantId } from "../auth/tenant.js";
+
+/**
+ * Handler set for conversation share-link endpoints. Kept as loose handlers
+ * (not a pre-mounted sub-app) because they span two mount paths and two
+ * auth tiers:
+ *
+ *   GET    /v1/shares/:token                — public, mounted BEFORE auth middleware
+ *   POST   /v1/conversations/:id/share      — authed, admin middleware applies
+ *   DELETE /v1/shares/:token                — authed, admin middleware applies
+ *
+ * Tokens are long random strings (`sh_<32>`); guessing is impractical. A
+ * conversation can have at most one active (non-revoked) share at a time —
+ * hitting POST again just returns the existing token rather than minting
+ * orphans.
+ */
+export function createShareHandlers(db: Db) {
+  async function getPublic(c: Context) {
+    const token = c.req.param("token");
+    if (!token) return c.json({ error: { message: "token required", type: "bad_request" } }, 400);
+    const share = await db
+      .select()
+      .from(shares)
+      .where(and(eq(shares.token, token), isNull(shares.revokedAt)))
+      .get();
+    if (!share) {
+      return c.json({ error: { message: "Share not found or revoked", type: "not_found" } }, 404);
+    }
+    const conv = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.id, share.conversationId))
+      .get();
+    if (!conv) {
+      return c.json({ error: { message: "Conversation not found", type: "not_found" } }, 404);
+    }
+    let messages: unknown = [];
+    try {
+      messages = JSON.parse(conv.messages);
+    } catch {}
+    return c.json({
+      token,
+      title: conv.title,
+      messages,
+      createdAt: share.createdAt,
+      conversationCreatedAt: conv.createdAt,
+    });
+  }
+
+  async function create(c: Context) {
+    const tenantId = getTenantId(c.req.raw);
+    const id = c.req.param("id");
+    if (!id) return c.json({ error: { message: "id required", type: "bad_request" } }, 400);
+    const where = tenantId
+      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
+      : eq(conversations.id, id);
+    const conv = await db.select().from(conversations).where(where).get();
+    if (!conv) {
+      return c.json({ error: { message: "Conversation not found", type: "not_found" } }, 404);
+    }
+
+    const existing = await db
+      .select()
+      .from(shares)
+      .where(and(eq(shares.conversationId, id), isNull(shares.revokedAt)))
+      .get();
+    if (existing) {
+      return c.json({ token: existing.token, createdAt: existing.createdAt });
+    }
+
+    const token = `sh_${nanoid(32)}`;
+    const createdAt = new Date();
+    await db
+      .insert(shares)
+      .values({ token, conversationId: id, tenantId: tenantId || null, createdAt })
+      .run();
+    return c.json({ token, createdAt }, 201);
+  }
+
+  async function revoke(c: Context) {
+    const tenantId = getTenantId(c.req.raw);
+    const token = c.req.param("token");
+    if (!token) return c.json({ error: { message: "token required", type: "bad_request" } }, 400);
+    const where = tenantId
+      ? and(eq(shares.token, token), eq(shares.tenantId, tenantId))
+      : eq(shares.token, token);
+    await db.update(shares).set({ revokedAt: new Date() }).where(where).run();
+    return c.json({ revoked: true });
+  }
+
+  return { getPublic, create, revoke };
+}

--- a/packages/gateway/tests/shares.test.ts
+++ b/packages/gateway/tests/shares.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { createConversationRoutes } from "../src/routes/conversations.js";
+import { createShareHandlers } from "../src/routes/shares.js";
+import { makeTestDb } from "./_setup/db.js";
+
+async function buildApp() {
+  const db = await makeTestDb();
+  const app = new Hono();
+  const shares = createShareHandlers(db);
+  app.route("/v1/conversations", createConversationRoutes(db));
+  app.post("/v1/conversations/:id/share", shares.create);
+  app.get("/v1/shared/:token", shares.getPublic);
+  app.delete("/v1/shares/:token", shares.revoke);
+  return { db, app };
+}
+
+async function createConv(app: Hono) {
+  const res = await app.request("/v1/conversations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      messages: [
+        { role: "user", content: "What is Provara?" },
+        { role: "assistant", content: "A multi-provider LLM gateway." },
+      ],
+    }),
+  });
+  return (await res.json()) as { id: string };
+}
+
+describe("share links", () => {
+  it("create → public read → revoke → read returns 404", async () => {
+    const { app } = await buildApp();
+    const { id } = await createConv(app);
+
+    const shareRes = await app.request(`/v1/conversations/${id}/share`, { method: "POST" });
+    expect(shareRes.status).toBe(201);
+    const { token } = await shareRes.json();
+    expect(token).toMatch(/^sh_/);
+
+    // Public read
+    const pubRes = await app.request(`/v1/shared/${token}`);
+    expect(pubRes.status).toBe(200);
+    const pub = await pubRes.json();
+    expect(pub.title).toBe("What is Provara?");
+    expect(pub.messages).toHaveLength(2);
+
+    // Revoke
+    const revokeRes = await app.request(`/v1/shares/${token}`, { method: "DELETE" });
+    expect(revokeRes.status).toBe(200);
+
+    // Post-revoke read
+    const goneRes = await app.request(`/v1/shared/${token}`);
+    expect(goneRes.status).toBe(404);
+  });
+
+  it("repeated POST returns the same active token (no orphan minting)", async () => {
+    const { app } = await buildApp();
+    const { id } = await createConv(app);
+
+    const first = await (await app.request(`/v1/conversations/${id}/share`, { method: "POST" })).json();
+    const second = await (await app.request(`/v1/conversations/${id}/share`, { method: "POST" })).json();
+    expect(first.token).toBe(second.token);
+  });
+
+  it("POST for non-existent conversation returns 404", async () => {
+    const { app } = await buildApp();
+    const res = await app.request("/v1/conversations/does-not-exist/share", { method: "POST" });
+    expect(res.status).toBe(404);
+  });
+
+  it("public read of unknown token returns 404", async () => {
+    const { app } = await buildApp();
+    const res = await app.request("/v1/shared/sh_bogus");
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Tier 4 playground additions — three features in one PR because they share the same underlying surface (message actions, saved conversations from #129, input-area slots from #108) and land as small additions to established machinery.

## Features

### Prompt presets
- Curated static library: 9 starters across Coding / Writing / Thinking / Q&A, each with optional system prompt + body.
- **`PromptPresetPicker`**: popover mounted as `ChatInput`'s `leftAddon`. Click fills the input (and system prompt if present).
- User-editable presets deferred — no DB table yet. Will add once there's demand.

### Fork conversation
- **Fork** `MessageAction` on every assistant turn. Slices the transcript up through and including that turn, creates a new saved conversation titled `"<first user turn>… (fork)"`, loads it as the active session. Original stays intact in the sidebar.

### Share links
- **New `shares` table**: `token` (`sh_` + nanoid(32)), `conversationId`, `tenantId`, `createdAt`, `revokedAt`. Migration 0019.
- **Routes across two mount paths and two auth tiers:**
  - `GET /v1/shared/:token` — **public** read, registered before auth middleware. Distinct `/v1/shared/` path so the `/v1/shares/*` admin-auth middleware doesn't gate it.
  - `POST /v1/conversations/:id/share` — authed; reuses existing active share (no orphan tokens).
  - `DELETE /v1/shares/:token` — authed; sets `revokedAt`.
  - OpenAPI documents all three with `security: []` on the public GET.
- **Top-bar "Share" button** in the playground. Auto-saves first if unsaved, then POSTs, copies the resulting `/shared/<token>` URL to clipboard.
- **New public route** `apps/web/src/app/shared/[token]/page.tsx` — renders the shared conversation read-only (same `MessageList` + `MarkdownMessage` as the playground, no input, no actions). "Try Provara →" CTA in the top bar.

## Design notes

**Why the `/v1/shared/` vs `/v1/shares/` split?** Hono applies `app.use(path, middleware)` to all routes under that path, regardless of registration order. If the public GET lived at `/v1/shares/:token`, the admin-auth middleware registered for `/v1/shares/*` would also gate it. Split into two nouns: "shared" (the public artifact) vs "shares" (the admin resource).

**Why single active share per conversation?** Repeated `POST .../share` returns the existing token instead of minting new ones. Avoids token proliferation when users click Share twice. Revoke is still one-at-a-time; explicit DELETE lets the owner cut off access then re-share with a fresh token if needed.

**Why `alert()` for the clipboard confirmation?** MVP. Real product would use a toast. Tech-debt-sized, not a redesign — trivially replaceable with a proper notification component later.

## Test plan

- [x] `tsc --noEmit` clean on gateway + web.
- [x] `vitest run` — **64/64 gateway** (4 new tests for shares: create/read/revoke round-trip, repeat-POST-returns-same-token, missing-conversation 404, bogus-token 404), **16/16 web**.
- [x] `playwright test` — **7/7 pass** (existing suites unchanged).
- [ ] Manual QA on Railway:
  - Open preset picker → pick "Code review" → input populates, system prompt populates
  - Fork an assistant turn mid-conversation → new entry in sidebar, original preserved
  - Share a conversation → URL copies, opens in incognito, shows read-only transcript
  - Revoke via DELETE → subsequent `/shared/<token>` returns "Link expired"

## Out of scope (future)

- User-editable preset library (DB table + CRUD + UI).
- Toast notifications replacing `alert()` / `prompt()` fallbacks.
- Revoke button in the playground UI (backend is there; frontend wiring deferred).
- Share expiration.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)