### PR TITLE
style(chat): bezeled-card playground layout + tooltip clarifying New Topic vs Clear

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -206,7 +206,7 @@ export default function PlaygroundPage() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)]">
+    <div className="flex h-[calc(100vh-3.5rem)] gap-3 p-3">
       <ConversationSidebar
         open={showConversations}
         list={saved.list}
@@ -216,9 +216,9 @@ export default function PlaygroundPage() {
         onDelete={handleDeleteConversation}
         loading={saved.loading}
       />
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 flex flex-col min-w-0 gap-3">
         {/* Top bar */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-zinc-800">
+        <div className="flex items-center gap-3 px-4 py-3 bg-zinc-900 border border-zinc-800 rounded-lg">
           <button
             onClick={() => setShowConversations((v) => !v)}
             title={showConversations ? "Hide conversations" : "Show conversations"}
@@ -255,6 +255,7 @@ export default function PlaygroundPage() {
             {session.messages.length > 0 && (
               <button
                 onClick={session.startNewTopic}
+                title="Draws a divider and stops sending prior messages to the model — saves tokens when you change subject without wanting to lose the transcript."
                 className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
               >
                 New Topic
@@ -271,6 +272,7 @@ export default function PlaygroundPage() {
             )}
             <button
               onClick={handleNewConversation}
+              title="Start a fresh conversation. The current chat stays saved in the sidebar."
               className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
             >
               Clear

--- a/apps/web/src/components/chat/ChatInput.tsx
+++ b/apps/web/src/components/chat/ChatInput.tsx
@@ -55,7 +55,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
   }
 
   return (
-    <div className="border-t border-zinc-800 px-4 py-3">
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-3">
       <div className="flex gap-3 items-end max-w-4xl mx-auto">
         {leftAddon}
         <textarea
@@ -66,7 +66,7 @@ export const ChatInput = forwardRef<ChatInputHandle, Props>(function ChatInput(
           placeholder={placeholder}
           disabled={disabled}
           rows={1}
-          className="flex-1 bg-zinc-900 border border-zinc-700 rounded-xl px-4 py-3 text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:border-blue-500 resize-none disabled:opacity-50 overflow-hidden"
+          className="flex-1 bg-zinc-950 border border-zinc-800 rounded-xl px-4 py-3 text-sm text-zinc-200 placeholder-zinc-500 focus:outline-none focus:border-blue-500 resize-none disabled:opacity-50 overflow-hidden"
           style={{ minHeight: "44px", maxHeight: "200px" }}
           onInput={(e) => {
             const t = e.target as HTMLTextAreaElement;

--- a/apps/web/src/components/chat/ConversationSidebar.tsx
+++ b/apps/web/src/components/chat/ConversationSidebar.tsx
@@ -37,7 +37,7 @@ export function ConversationSidebar({
 }: Props) {
   if (!open) return null;
   return (
-    <div className="w-60 border-r border-zinc-800 bg-zinc-900/40 flex flex-col overflow-hidden">
+    <div className="w-60 bg-zinc-900 border border-zinc-800 rounded-lg flex flex-col overflow-hidden">
       <div className="p-2 border-b border-zinc-800">
         <button
           type="button"

--- a/apps/web/src/components/chat/MessageList.tsx
+++ b/apps/web/src/components/chat/MessageList.tsx
@@ -30,7 +30,7 @@ export function MessageList({
   }, [messages, streamingContent]);
 
   return (
-    <div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-6">
+    <div className="flex-1 bg-zinc-900 border border-zinc-800 rounded-lg overflow-y-auto scrollbar-thin px-4 py-6">
       <div className="max-w-4xl mx-auto space-y-6">
         {messages.length === 0 && !streamingContent && emptyState}
 

--- a/apps/web/src/components/chat/SettingsPanel.tsx
+++ b/apps/web/src/components/chat/SettingsPanel.tsx
@@ -14,7 +14,7 @@ interface Props {
 export function SettingsPanel({ open, title = "Settings", children }: Props) {
   if (!open) return null;
   return (
-    <div className="w-72 border-l border-zinc-800 bg-zinc-900/50 p-4 space-y-5 overflow-y-auto">
+    <div className="w-72 bg-zinc-900 border border-zinc-800 rounded-lg p-4 space-y-5 overflow-y-auto">
       <h3 className="text-sm font-semibold text-zinc-300">{title}</h3>
       {children}
     </div>


### PR DESCRIPTION
## Summary

The playground's top/bottom-divider-rule layout was the one region of the app still using horizontal rules instead of the dashboard's card-based style. This PR brings it in line: each major region (sidebar, top bar, messages, input, settings drawer) is now a floating bezeled card with the page background showing through the gaps.

Also: tooltips on **New Topic** and **Clear** making the subtle distinction between them discoverable (they do different things; the labels alone don't convey it).

## Changes

### Layout

- `playground/page.tsx` — outer flex gains `p-3 gap-3`, main column gains `gap-3`. Top bar drops `border-b`, picks up full card styling.
- `MessageList` — root gets card border + `rounded-lg`; scroll behavior unchanged.
- `ChatInput` — swaps `border-t` for full card. Textarea background bumped to `zinc-950` so it reads as an input against the new card rather than blending in.
- `ConversationSidebar` — `border-r` → full card border + rounded.
- `SettingsPanel` — `border-l` → full card border + rounded.

### Tooltips

- **New Topic**: "Draws a divider and stops sending prior messages to the model — saves tokens when you change subject without wanting to lose the transcript."
- **Clear**: "Start a fresh conversation. The current chat stays saved in the sidebar."

Why keep both buttons? They serve different goals:
- **New Topic** — same conversation, different subject, prior context dropped from the API payload (token savings, transcript preserved with a divider)
- **Clear** / **+ New conversation** — abandon the current chat entirely; prior is already auto-saved in the sidebar

The tooltip is the lightest-weight fix for "same conversation vs new conversation" confusion.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — 16/16 web.
- [x] `playwright test` — 7/7 (layout didn't break focus, model selector, send button state).
- [ ] Manual QA on Railway: sidebar/top-bar/messages/input/settings all render as floating cards with visible gaps; tooltips appear on hover; card layout doesn't regress on narrow viewports.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)