### PR TITLE
feat(ui): non-blocking toast notifications; replace share alert()

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -14,6 +14,7 @@ import { PromptPresetPicker } from "../../../components/chat/PromptPresetPicker"
 import { useChatSession } from "../../../components/chat/use-chat-session";
 import { useSessionPersist } from "../../../components/chat/use-session-persist";
 import { useSavedConversations } from "../../../components/chat/use-saved-conversations";
+import { useToast } from "../../../components/toast";
 import type { ChatMessage, MessageAction } from "../../../components/chat/types";
 import type { PromptPreset } from "../../../components/chat/presets";
 
@@ -38,6 +39,7 @@ export default function PlaygroundPage() {
 
   const session = useChatSession();
   const saved = useSavedConversations();
+  const toast = useToast();
 
   useEffect(() => {
     gatewayClientFetch<{ providers: ProviderInfo[] }>("/v1/providers")
@@ -124,13 +126,16 @@ export default function PlaygroundPage() {
       const url = `${window.location.origin}/shared/${res.token}`;
       try {
         await navigator.clipboard.writeText(url);
-        alert(`Share link copied to clipboard:\n\n${url}`);
+        toast.success("Share link copied to clipboard");
       } catch {
-        // Clipboard blocked — show the URL directly so the user can copy manually.
-        prompt("Share link:", url);
+        // Clipboard blocked — log the URL for the user's console fallback
+        // and surface a toast. Sticky (duration: 0) so they have time to
+        // open devtools.
+        console.info("[share] clipboard blocked. URL:", url);
+        toast.error("Couldn't copy to clipboard — URL logged to console", 0);
       }
     } catch {
-      alert("Failed to create share link.");
+      toast.error("Failed to create share link");
     }
   }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { AuthProvider } from "../lib/auth-context";
+import { ToastProvider } from "../components/toast";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -16,7 +17,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="bg-zinc-950 text-zinc-100 antialiased">
         <AuthProvider>
-          {children}
+          <ToastProvider>{children}</ToastProvider>
         </AuthProvider>
       </body>
     </html>

--- a/apps/web/src/components/toast.tsx
+++ b/apps/web/src/components/toast.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+
+export type ToastVariant = "success" | "error" | "info";
+
+interface ToastEntry {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+  /** ms until auto-dismiss. 0 = sticky (user must click to close). */
+  duration: number;
+}
+
+interface ToastContextValue {
+  show: (message: string, opts?: { variant?: ToastVariant; duration?: number }) => void;
+  success: (message: string, duration?: number) => void;
+  error: (message: string, duration?: number) => void;
+  info: (message: string, duration?: number) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast() must be used within <ToastProvider>");
+  return ctx;
+}
+
+const DEFAULT_DURATION = 3000;
+
+/**
+ * Minimal non-blocking toast. Mount <ToastProvider> at the root; any
+ * descendant calls `useToast().show(...)` to append a toast. Toasts
+ * auto-dismiss after `duration` ms (default 3000) and fade out via CSS.
+ * Clicking a toast dismisses it immediately.
+ *
+ * One-concern-per-file; no dep. If we ever need richer behavior (swipe
+ * to dismiss, undo buttons, promise variants) swap for a library like
+ * sonner and keep the same useToast() API.
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastEntry[]>([]);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const show = useCallback(
+    (message: string, opts: { variant?: ToastVariant; duration?: number } = {}) => {
+      const id = Date.now() + Math.random();
+      const variant = opts.variant ?? "info";
+      const duration = opts.duration ?? DEFAULT_DURATION;
+      setToasts((prev) => [...prev, { id, message, variant, duration }]);
+    },
+    [],
+  );
+
+  const ctx: ToastContextValue = {
+    show,
+    success: (msg, duration) => show(msg, { variant: "success", duration }),
+    error: (msg, duration) => show(msg, { variant: "error", duration }),
+    info: (msg, duration) => show(msg, { variant: "info", duration }),
+  };
+
+  return (
+    <ToastContext.Provider value={ctx}>
+      {children}
+      <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none">
+        {toasts.map((t) => (
+          <ToastItem key={t.id} toast={t} onDismiss={() => dismiss(t.id)} />
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+function ToastItem({ toast, onDismiss }: { toast: ToastEntry; onDismiss: () => void }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger the enter transition on next paint.
+    const raf = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  useEffect(() => {
+    if (toast.duration === 0) return;
+    const id = setTimeout(() => {
+      setVisible(false);
+      // Give the fade-out transition time before removing from the DOM.
+      setTimeout(onDismiss, 200);
+    }, toast.duration);
+    return () => clearTimeout(id);
+  }, [toast.duration, onDismiss]);
+
+  const colors: Record<ToastVariant, string> = {
+    success: "bg-emerald-950/90 border-emerald-800 text-emerald-200",
+    error: "bg-red-950/90 border-red-800 text-red-200",
+    info: "bg-zinc-900/90 border-zinc-700 text-zinc-200",
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setVisible(false);
+        setTimeout(onDismiss, 200);
+      }}
+      className={`pointer-events-auto text-left text-sm px-4 py-2.5 border rounded-lg shadow-lg backdrop-blur-sm transition-all duration-200 max-w-sm cursor-pointer ${colors[toast.variant]} ${
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+      }`}
+    >
+      {toast.message}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

`alert()` and `prompt()` on share blocked the page until the user clicked to dismiss. For a "copied to clipboard" confirmation that's excessive friction — the user already took the action they expected feedback for.

## Changes

- **New `components/toast.tsx`** — minimal `ToastProvider` + `useToast()` hook. `success` / `error` / `info` variants with emerald / red / zinc color differentiation. Auto-dismiss after 3s (configurable; `0` = sticky until clicked). CSS fade + slide transition. Bottom-right stack, clickable to dismiss early. ~100 lines, no new dep.
- **Mounted in `apps/web/src/app/layout.tsx`** so any page can `useToast().success(...)` without extra wiring.
- **Playground share** now calls `toast.success("Share link copied to clipboard")` instead of `alert()`. Clipboard-blocked fallback uses `toast.error(..., 0)` (sticky) and logs the URL to console so the user can copy manually.

## Why not a library

Evaluated `sonner` / `react-hot-toast` — both are ~10KB + extra dep + peer-dep complexity. For a single consumer and a tiny feature surface, one file is the right call. If we ever need swipe-to-dismiss, undo buttons, or promise variants, we swap the implementation and keep the `useToast()` API as the stable contract — callers don't change.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — 16/16 web.
- [x] `playwright test` — 7/7 (toast didn't break existing flows).
- [ ] Manual QA on Railway:
  - Share a conversation → green toast appears bottom-right, fades after ~3s
  - Share with clipboard blocked (Firefox incognito, or deny permission) → red sticky toast appears; URL in console
  - Click any toast → dismisses immediately

## Out of scope / future

- Apply toast to other user-initiated confirmations: rate submission, conversation save, etc. Easy follow-up once the pattern is established.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)