### PR TITLE
fix(docs): hide Scalar section-flare pushing content below the fold

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -68,3 +68,17 @@ button, [role="button"], a, select, summary, label[for] {
   background: rgba(63, 63, 70, 0.4);
   font-weight: 600;
 }
+
+/*
+ * Scalar /docs/api: hide the decorative "section-flare" glow that, under our
+ * CSS reset + classic-layout combo, renders as an opaque ~viewport-height
+ * block above the actual content — pushing the first heading past the fold
+ * on page load. It's purely visual (pointer-events: none), so hiding it
+ * keeps the docs semantically intact. Root cause is Scalar's responsive
+ * detection landing on `standalone-mobile` at desktop widths; the flare
+ * is sized for that layout. Fix upstream if the class detection is ever
+ * corrected; until then this one-liner avoids the regression.
+ */
+.scalar-app .section-flare {
+  display: none !important;
+}

--- a/apps/web/tests/e2e/docs.spec.ts
+++ b/apps/web/tests/e2e/docs.spec.ts
@@ -1,26 +1,71 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Guards the /docs/api regressions we fought through #110 and #118:
- * - No empty viewport-height gap above content
- * - No horizontal scroll
+ * Minimal-but-realistic OpenAPI with info + at least one path. An empty
+ * `paths: {}` doesn't trigger Scalar's hero layout (which is what produces
+ * the section-flare that regressed twice). This spec exercises the same
+ * code path the real Provara spec does on prod.
  */
-test("/docs/api mounts Scalar without a full-viewport empty block above", async ({ page }) => {
-  // Serve the OpenAPI spec locally so Scalar can render it.
-  await page.route("**/openapi.yaml", (route) =>
+const OPENAPI_WITH_PATHS = `openapi: 3.0.3
+info:
+  title: Test API
+  version: 0.1.0
+  description: Minimal spec used to exercise Scalar's hero + section-flare rendering.
+paths:
+  /health:
+    get:
+      summary: Health check
+      responses:
+        "200":
+          description: OK
+  /v1/echo:
+    post:
+      summary: Echo
+      responses:
+        "200":
+          description: Echoed
+`;
+
+function stubSpec(page: import("@playwright/test").Page) {
+  return page.route("**/openapi.yaml", (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/x-yaml",
-      body: "openapi: 3.0.3\ninfo:\n  title: Test\n  version: 0.0.0\npaths: {}\n",
+      body: OPENAPI_WITH_PATHS,
     }),
   );
-  await page.goto("/docs/api");
+}
 
-  // Scalar's React component mounts inside our wrapper div. Even before full
-  // content loads, there should not be a 100vh blank region at the top of
-  // the document. Check that *some* Scalar content is within the first
-  // viewport.
-  await page.waitForTimeout(2000); // give Scalar time to render
+/**
+ * Guards /docs/api regressions — #110 (CDN→classic), #118 (React component),
+ * and #134 (section-flare eating the fold). The earlier version of this
+ * test stubbed `paths: {}`, which hid the bug from #134 because Scalar's
+ * hero layout doesn't activate without any paths.
+ */
+test("/docs/api: hero h1 renders within the first viewport", async ({ page }) => {
+  await stubSpec(page);
+  await page.goto("/docs/api");
+  await page.waitForTimeout(2500);
+
+  // The spec's title becomes an h1 with class `section-header-label`.
+  // When the section-flare bug is present, this h1 sits at ~1000+ pixels.
+  const h1 = await page.evaluate(() => {
+    const el = document.querySelector("h1.section-header-label");
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return { top: Math.round(rect.top), text: el.textContent?.trim() || "" };
+  });
+  expect(h1, "no h1.section-header-label found — Scalar never rendered the hero").not.toBeNull();
+  expect(h1!.text).toContain("Test API");
+  // Allow some top margin/padding but reject the ~1000px flare gap.
+  expect(h1!.top, `h1 at ${h1!.top}px — likely pushed below the fold by section-flare`).toBeLessThan(400);
+});
+
+test("/docs/api: some visible text in the first viewport", async ({ page }) => {
+  await stubSpec(page);
+  await page.goto("/docs/api");
+  await page.waitForTimeout(2000);
+
   const firstVisibleText = await page.evaluate(() => {
     const vh = window.innerHeight;
     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -36,20 +81,12 @@ test("/docs/api mounts Scalar without a full-viewport empty block above", async 
     }
     return null;
   });
-  // If the only visible text is far below the fold, we've regressed.
   expect(firstVisibleText, "no visible text in first viewport").not.toBeNull();
   expect(firstVisibleText!.top).toBeLessThan(400);
 });
 
-test("/docs/api has no horizontal scroll", async ({ page }) => {
-  await page.route("**/openapi.yaml", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/x-yaml",
-      body: "openapi: 3.0.3\ninfo:\n  title: Test\n  version: 0.0.0\npaths: {}\n",
-    }),
-  );
-
+test("/docs/api: no horizontal scroll at common widths", async ({ page }) => {
+  await stubSpec(page);
   for (const width of [1280, 1440, 1920]) {
     await page.setViewportSize({ width, height: 800 });
     await page.goto("/docs/api");


### PR DESCRIPTION
## Summary

`/docs/api` was **still** rendering a viewport-height empty block above the content after #110 and #118. Playwright inspection of the live site finally nailed the cause.

## Root cause

Scalar renders a decorative `.section-flare` element — a subtle glow/gradient overlay. On our deploy, it's landing at **top:0, height:900, width:1440** (exactly viewport size) which pushes the first heading (`<h1>Provara Gateway API</h1>`) down to document position **1027** — off-screen on any viewport under ~1000px tall.

Scalar's CSS for `.section-flare` only sets `top/right/pointer-events` — no height. The 900px height comes from Scalar landing on its **`scalar-api-references-standalone-mobile`** layout class at 1440px viewport (responsive-detection quirk), where the flare is sized for mobile hero use. On desktop it just sits there eating the fold.

## Fix

One-line CSS override in `globals.css`:

```css
.scalar-app .section-flare { display: none !important }
```

The flare is `pointer-events: none` and otherwise purely decorative, so hiding it keeps the docs semantically intact. If Scalar ever fixes the standalone-mobile misdetection at desktop widths, this override becomes a no-op.

## Verified locally

| Metric | Before | After |
|---|---|---|
| h1 position | top 1027 | top 167 |
| Initial viewport content | empty gradient | search bar, title, description, server/auth/client cards, first endpoint |

Screenshot in the PR thread below.

## Why did this escape the earlier fixes?

- #110 (CDN → `layout: "classic"`) changed config but the flare element is rendered regardless of layout mode.
- #118 (CDN → React component) switched the mount mechanism but not what Scalar renders.
- #109's `/docs/api` e2e test stubbed an empty OpenAPI spec (`paths: {}`) — which doesn't trigger the full hero section, so the flare didn't render large enough to fail the assertion. On the real spec with info + paths, the hero activates and the flare sizes up.

**Follow-up to consider**: update the e2e test to use a spec with some paths so it would catch this class of regression.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `next build` passes.
- [x] Local playwright inspection shows h1 at top 167 (from 1027).
- [ ] Railway redeploy: `www.provara.xyz/docs/api` shows content immediately on load.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)