### PR TITLE
fix(security): webhook SSRF + analytics tenant filter + EMA env NaN

### DIFF
--- a/packages/gateway/src/routes/alerts.ts
+++ b/packages/gateway/src/routes/alerts.ts
@@ -5,6 +5,64 @@ import { eq, and, sql, gte, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getTenantId } from "../auth/tenant.js";
 
+/**
+ * Validate a webhook URL before storing/invoking it. Guards against SSRF:
+ * the gateway is a server that sends outbound POSTs to webhook URLs when
+ * alerts fire; a hostile or sloppy operator could point a webhook at
+ * `http://169.254.169.254/` (cloud metadata), `http://localhost:*`
+ * (internal services), or a private IP, and exfiltrate data that way.
+ *
+ * Rules:
+ *  - https:// only (http allowed only for localhost.explicit opt-in via
+ *    PROVARA_ALLOW_HTTP_WEBHOOKS=true, to keep local dev working)
+ *  - Hostname must not resolve to a private/loopback/link-local address
+ *    *by string*. A full DNS-based SSRF defense requires DNS-pinning at
+ *    request time; this catches the common cases without that machinery.
+ *  - Reject obvious cloud-metadata endpoints explicitly.
+ *
+ * Returns null when valid; otherwise a human-readable error reason.
+ */
+function validateWebhookUrl(raw: string): string | null {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return "invalid URL";
+  }
+  const allowHttp = process.env.PROVARA_ALLOW_HTTP_WEBHOOKS === "true";
+  if (u.protocol !== "https:" && !(allowHttp && u.protocol === "http:")) {
+    return "webhook URL must use https://";
+  }
+  const host = u.hostname.toLowerCase();
+
+  // Cloud metadata endpoints (AWS, GCP, Azure, Alibaba, DigitalOcean)
+  const metadataHosts = new Set([
+    "169.254.169.254",
+    "metadata.google.internal",
+    "metadata",
+    "100.100.100.200", // Alibaba
+  ]);
+  if (metadataHosts.has(host)) return "webhook URL points at cloud metadata";
+
+  // Obvious private/loopback/link-local ranges (IPv4 + a few IPv6)
+  const privatePatterns: RegExp[] = [
+    /^127\./,
+    /^10\./,
+    /^192\.168\./,
+    /^172\.(1[6-9]|2[0-9]|3[0-1])\./,
+    /^169\.254\./,
+    /^0\./,
+    /^::1$/,
+    /^fc[0-9a-f]{2}:/i,
+    /^fd[0-9a-f]{2}:/i,
+    /^fe80:/i,
+  ];
+  if (host === "localhost" || privatePatterns.some((r) => r.test(host))) {
+    return "webhook URL points at a private/loopback address";
+  }
+  return null;
+}
+
 export function createAlertRoutes(db: Db) {
   const app = new Hono();
 
@@ -34,6 +92,11 @@ export function createAlertRoutes(db: Db) {
 
     if (!body.name || !body.metric || !body.threshold) {
       return c.json({ error: { message: "name, metric, and threshold are required", type: "validation_error" } }, 400);
+    }
+
+    if (body.webhookUrl) {
+      const err = validateWebhookUrl(body.webhookUrl);
+      if (err) return c.json({ error: { message: err, type: "validation_error" } }, 400);
     }
 
     const id = nanoid();
@@ -69,6 +132,11 @@ export function createAlertRoutes(db: Db) {
     const rule = await db.select().from(alertRules).where(ruleWhere).get();
     if (!rule) {
       return c.json({ error: { message: "Rule not found", type: "not_found" } }, 404);
+    }
+
+    if (body.webhookUrl) {
+      const err = validateWebhookUrl(body.webhookUrl);
+      if (err) return c.json({ error: { message: err, type: "validation_error" } }, 400);
     }
 
     const updates: Record<string, unknown> = {};

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -114,11 +114,19 @@ export function createAnalyticsRoutes(db: Db) {
       return c.json({ error: { message: "Request not found", type: "not_found" } }, 404);
     }
 
-    // Get feedback for this request
+    // Get feedback for this request. The request itself is already scoped to
+    // tenant above, so in practice no cross-tenant feedback can exist for
+    // this requestId. Adding an explicit tenant filter here is
+    // defense-in-depth — if a future write path ever misses the tenant
+    // check, this query won't start silently leaking.
     const feedbackRows = await db
       .select()
       .from(feedback)
-      .where(eq(feedback.requestId, id))
+      .where(
+        tenantId
+          ? and(eq(feedback.requestId, id), eq(feedback.tenantId, tenantId))
+          : eq(feedback.requestId, id),
+      )
       .all();
 
     return c.json({ request: row, feedback: feedbackRows });

--- a/packages/gateway/src/routing/adaptive/ema.ts
+++ b/packages/gateway/src/routing/adaptive/ema.ts
@@ -1,11 +1,23 @@
 import type { FeedbackSource } from "./types.js";
 
 /**
+ * Parse a numeric env var safely. Returns `fallback` when the var is unset,
+ * empty, or not a valid number. The raw `parseFloat(process.env.X || "0.2")`
+ * pattern silently yields NaN on an empty-string value — which poisons
+ * every downstream calculation. This helper clamps that to the default.
+ */
+function numFromEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === "") return fallback;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/**
  * EMA decay factor used for latency tracking and as the global override for
  * quality EMA when per-source vars are unset. 0.1 = slow adaptation,
  * 0.3 = moderate, 0.5 = fast.
  */
-export const EMA_ALPHA = parseFloat(process.env.PROVARA_EMA_ALPHA || "0.2");
+export const EMA_ALPHA = numFromEnv(process.env.PROVARA_EMA_ALPHA, 0.2);
 
 /**
  * Standard exponentially weighted moving average step.
@@ -24,7 +36,14 @@ export function ema(oldValue: number, newValue: number, alpha: number): number {
 export function getQualityAlpha(source: FeedbackSource): number {
   const envVar = source === "user" ? "PROVARA_EMA_ALPHA_USER" : "PROVARA_EMA_ALPHA_JUDGE";
   const specific = process.env[envVar];
-  if (specific !== undefined) return parseFloat(specific);
-  if (process.env.PROVARA_EMA_ALPHA !== undefined) return parseFloat(process.env.PROVARA_EMA_ALPHA);
+  if (specific !== undefined && specific !== "") {
+    const parsed = parseFloat(specific);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  const global = process.env.PROVARA_EMA_ALPHA;
+  if (global !== undefined && global !== "") {
+    const parsed = parseFloat(global);
+    if (Number.isFinite(parsed)) return parsed;
+  }
   return source === "user" ? 0.4 : 0.2;
 }

--- a/packages/gateway/tests/adaptive-modules.test.ts
+++ b/packages/gateway/tests/adaptive-modules.test.ts
@@ -49,6 +49,25 @@ describe("getQualityAlpha", () => {
     expect(getQualityAlpha("user")).toBe(0.8);
     expect(getQualityAlpha("judge")).toBe(0.5);
   });
+
+  it("empty-string env var falls back to default (regression — parseFloat('') = NaN)", () => {
+    process.env.PROVARA_EMA_ALPHA_USER = "";
+    process.env.PROVARA_EMA_ALPHA_JUDGE = "";
+    process.env.PROVARA_EMA_ALPHA = "";
+    expect(getQualityAlpha("user")).toBe(0.4);
+    expect(getQualityAlpha("judge")).toBe(0.2);
+  });
+
+  it("non-numeric env var falls back to default", () => {
+    process.env.PROVARA_EMA_ALPHA_USER = "not-a-number";
+    expect(getQualityAlpha("user")).toBe(0.4);
+  });
+
+  it("falls through empty source-specific to global when global is valid", () => {
+    process.env.PROVARA_EMA_ALPHA = "0.5";
+    process.env.PROVARA_EMA_ALPHA_USER = "";
+    expect(getQualityAlpha("user")).toBe(0.5);
+  });
 });
 
 describe("resolveWeights", () => {

--- a/packages/gateway/tests/alerts.test.ts
+++ b/packages/gateway/tests/alerts.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createAlertRoutes } from "../src/routes/alerts.js";
+import { makeTestDb } from "./_setup/db.js";
+
+async function buildApp() {
+  const db = await makeTestDb();
+  const app = new Hono();
+  app.route("/v1/admin/alerts", createAlertRoutes(db));
+  return app;
+}
+
+function postRule(app: Hono, body: unknown) {
+  return app.request("/v1/admin/alerts/rules", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("alert webhook URL validation (SSRF guard)", () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+  beforeEach(() => {
+    delete process.env.PROVARA_ALLOW_HTTP_WEBHOOKS;
+  });
+
+  const baseRule = { name: "r", metric: "spend", threshold: 1, window: "1h" };
+
+  it("accepts https URL on public host", async () => {
+    const app = await buildApp();
+    const res = await postRule(app, { ...baseRule, webhookUrl: "https://hooks.slack.com/services/x" });
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects http URL by default", async () => {
+    const app = await buildApp();
+    const res = await postRule(app, { ...baseRule, webhookUrl: "http://example.com/hook" });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/https/i);
+  });
+
+  it("allows http when PROVARA_ALLOW_HTTP_WEBHOOKS=true (for local dev)", async () => {
+    process.env.PROVARA_ALLOW_HTTP_WEBHOOKS = "true";
+    const app = await buildApp();
+    const res = await postRule(app, { ...baseRule, webhookUrl: "http://example.com/hook" });
+    expect(res.status).toBe(201);
+  });
+
+  it("rejects cloud metadata endpoints", async () => {
+    const app = await buildApp();
+    for (const host of ["169.254.169.254", "metadata.google.internal", "100.100.100.200"]) {
+      const res = await postRule(app, { ...baseRule, webhookUrl: `https://${host}/x` });
+      expect(res.status, `should reject ${host}`).toBe(400);
+    }
+  });
+
+  it("rejects loopback and private ranges", async () => {
+    const app = await buildApp();
+    const privates = [
+      "https://localhost/x",
+      "https://127.0.0.1/x",
+      "https://10.0.0.5/x",
+      "https://192.168.1.1/x",
+      "https://172.16.0.1/x",
+      "https://172.31.255.255/x",
+    ];
+    for (const url of privates) {
+      const res = await postRule(app, { ...baseRule, webhookUrl: url });
+      expect(res.status, `should reject ${url}`).toBe(400);
+    }
+  });
+
+  it("rejects malformed URL", async () => {
+    const app = await buildApp();
+    const res = await postRule(app, { ...baseRule, webhookUrl: "not a url" });
+    expect(res.status).toBe(400);
+  });
+
+  it("permits omitting webhookUrl entirely", async () => {
+    const app = await buildApp();
+    const res = await postRule(app, baseRule);
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
## Summary

Three audit findings, all non-breaking defense-in-depth.

| # | Finding | File | Impact |
|---|---------|------|--------|
| 1 | **Alerts webhook SSRF** | `routes/alerts.ts` | A hostile/sloppy operator could point a webhook at cloud metadata (`169.254.169.254`) or internal services to exfiltrate data. Closed by URL validator on POST + PATCH. |
| 2 | **Analytics `/requests/:id` feedback** | `routes/analytics.ts:118` | Defense-in-depth tenant filter on the feedback join. Request itself was already tenant-scoped; this closes the gap if a future write path ever misses the check. |
| 3 | **EMA env-var NaN** | `routing/adaptive/ema.ts` | Setting `PROVARA_EMA_ALPHA_USER=""` (common deploy mistake) returned `NaN` from `parseFloat`, silently poisoning every downstream EMA write for the process lifetime. |

## Dropped finding #4

The audit flagged feedback tenantId escalation in `routes/feedback.ts:37-44`. On inspection the code at line 38 already scopes the request lookup by tenant — the exploit path described doesn't exist. Agent overstated; skipped.

## Webhook validation rules

- **https-only** by default. `PROVARA_ALLOW_HTTP_WEBHOOKS=true` opts into http for local dev.
- Explicit reject: cloud metadata hosts (AWS, GCP, Azure, Alibaba), localhost, IPv4 private/loopback/link-local ranges, IPv6 loopback/ULA/link-local.
- Catches common SSRF cases without DNS-time pinning. Full DNS-rebinding defense is a separate concern requiring resolve-and-lock at request time.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — **74/74 pass** (+3 new `getQualityAlpha` tests, +7 new webhook validator tests, existing 64 unchanged).
- [ ] Verify on Railway: existing alert rules with https webhooks still work; creating a new rule with `http://localhost/...` gets rejected; `PROVARA_EMA_ALPHA_USER=""` in env no longer crashes adaptive routing.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)