### PR TITLE
perf: guardrail regex cache + prompt stringify dedup

### DIFF
--- a/packages/gateway/src/guardrails/engine.ts
+++ b/packages/gateway/src/guardrails/engine.ts
@@ -11,6 +11,10 @@ export interface GuardrailRule {
   target: "input" | "output" | "both";
   action: "block" | "redact" | "flag";
   pattern: string | null;
+  /** Pre-compiled regex from `pattern`, attached once by `loadRules` so
+   *  `checkContent` avoids recompiling per request. Null when the pattern
+   *  is missing or invalid. */
+  compiledPattern?: RegExp | null;
   enabled: boolean;
   builtIn: boolean;
 }
@@ -58,7 +62,10 @@ export async function ensureBuiltInRules(db: Db, tenantId: string | null) {
   }
 }
 
-// Load active rules for a tenant
+// Load active rules for a tenant. Regex patterns are compiled here rather
+// than inside checkContent's hot loop — one compilation per rule per load
+// instead of once per rule per request. Invalid patterns are logged
+// loudly (not silent skip) so operators can find and fix them.
 export async function loadRules(db: Db, tenantId: string | null): Promise<GuardrailRule[]> {
   const rows = await db
     .select()
@@ -71,7 +78,24 @@ export async function loadRules(db: Db, tenantId: string | null): Promise<Guardr
     )
     .all();
 
-  return rows as GuardrailRule[];
+  const rules: GuardrailRule[] = [];
+  for (const row of rows) {
+    const rule = row as GuardrailRule;
+    if (rule.pattern) {
+      try {
+        rule.compiledPattern = new RegExp(rule.pattern, "gi");
+      } catch (err) {
+        console.warn(
+          `[guardrails] rule "${rule.name}" (id=${rule.id}) has an invalid regex and was skipped: ${err instanceof Error ? err.message : err}`,
+        );
+        rule.compiledPattern = null;
+      }
+    } else {
+      rule.compiledPattern = null;
+    }
+    rules.push(rule);
+  }
+  return rules;
 }
 
 // Check content against rules
@@ -87,31 +111,31 @@ export function checkContent(
   for (const rule of rules) {
     // Skip rules that don't apply to this target
     if (rule.target !== "both" && rule.target !== target) continue;
-    if (!rule.pattern) continue;
+    const regex = rule.compiledPattern;
+    if (!regex) continue;
 
-    try {
-      const regex = new RegExp(rule.pattern, "gi");
-      const matches = content.match(regex);
+    // Reset lastIndex: global regexes retain state across .match / .replace
+    // calls, which can cause spurious misses on reuse.
+    regex.lastIndex = 0;
+    const matches = content.match(regex);
 
-      if (matches && matches.length > 0) {
-        const snippet = matches[0].slice(0, 50);
+    if (matches && matches.length > 0) {
+      const snippet = matches[0].slice(0, 50);
 
-        violations.push({
-          ruleId: rule.id,
-          ruleName: rule.name,
-          action: rule.action,
-          matchedSnippet: snippet,
-        });
+      violations.push({
+        ruleId: rule.id,
+        ruleName: rule.name,
+        action: rule.action,
+        matchedSnippet: snippet,
+      });
 
-        if (rule.action === "block") {
-          shouldBlock = true;
-        } else if (rule.action === "redact") {
-          processedContent = processedContent.replace(regex, "[REDACTED]");
-        }
-        // "flag" action: just log, don't modify content
+      if (rule.action === "block") {
+        shouldBlock = true;
+      } else if (rule.action === "redact") {
+        regex.lastIndex = 0;
+        processedContent = processedContent.replace(regex, "[REDACTED]");
       }
-    } catch {
-      // Invalid regex — skip this rule
+      // "flag" action: just log, don't modify content
     }
   }
 

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -155,6 +155,10 @@ export async function createRouter(ctx: RouterContext) {
     const body = await c.req.json<CompletionRequest & { provider?: string; cache?: boolean; complexity_hint?: "simple" | "medium" | "complex" }>();
     const { provider: providerName, routing_hint, complexity_hint, cache: cacheParam, ...rest } = body;
     const request = rest as CompletionRequest;
+    // Serialize once for all downstream DB writes (cache-hit row, streaming
+    // row, non-streaming row). Messages is otherwise stringified 2–3× per
+    // request on the hot path.
+    const promptJson = JSON.stringify(request.messages);
 
     // Input guardrails — check all message content before routing
     const tenantIdForGuardrails = getTenantId(c.req.raw);
@@ -236,7 +240,7 @@ export async function createRouter(ctx: RouterContext) {
           id: hitId,
           provider: providerForResp,
           model: modelForResp,
-          prompt: JSON.stringify(request.messages),
+          prompt: promptJson,
           response: content,
           inputTokens,
           outputTokens,
@@ -432,7 +436,7 @@ export async function createRouter(ctx: RouterContext) {
                     id: requestId,
                     provider: usedProvider,
                     model: usedModel,
-                    prompt: JSON.stringify(request.messages),
+                    prompt: promptJson,
                     response: fullContent,
                     inputTokens: usage.inputTokens,
                     outputTokens: usage.outputTokens,
@@ -585,7 +589,7 @@ export async function createRouter(ctx: RouterContext) {
         id: requestId,
         provider: usedProvider,
         model: usedModel,
-        prompt: JSON.stringify(request.messages),
+        prompt: promptJson,
         response: response.content,
         inputTokens: response.usage.inputTokens,
         outputTokens: response.usage.outputTokens,


### PR DESCRIPTION
## Summary

Two hot-path efficiency fixes from the audit (#5 and #6), both non-breaking.

## 1. Guardrail regex compilation (audit #5)

`new RegExp(rule.pattern, "gi")` was called inside `checkContent`'s per-rule loop on **every** request. Now `loadRules` compiles each rule's pattern exactly once and attaches the compiled `RegExp` (`rule.compiledPattern`). `checkContent` reuses the cache, resetting `lastIndex` between calls to avoid the stateful-global-regex-reuse pitfall.

Bonus: the silent regex-parse failure is upgraded to a `console.warn` naming the rule — bad patterns now surface instead of disabling themselves invisibly.

## 2. Prompt serialization (audit #6)

`router.ts` called `JSON.stringify(request.messages)` at **three** DB-insert sites per request (cache-hit row, streaming row, non-streaming row). Lift to one `promptJson = JSON.stringify(...)` at the top of the handler and reuse.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run` — 74/74 pass.
- [ ] No observable behavior change on Railway.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)