### PR TITLE
fix(#138): CORS env-driven allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,15 @@ ZAI_API_KEY=
 # DATABASE_AUTH_TOKEN=your-turso-auth-token
 
 # ──────────────────────────────────────────────
+# CORS (RECOMMENDED for production)
+# ──────────────────────────────────────────────
+# Comma-separated list of origins allowed to make authenticated cross-origin
+# requests against the gateway. When unset, the gateway runs in permissive
+# mode (any origin with credentials). Always set this on prod deploys.
+# Example:
+# PROVARA_ALLOWED_ORIGINS=https://www.provara.xyz,https://gateway.provara.xyz
+
+# ──────────────────────────────────────────────
 # Service Ports (OPTIONAL)
 # ──────────────────────────────────────────────
 # PORT=4000           # Gateway

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -54,9 +54,31 @@ export async function createRouter(ctx: RouterContext) {
     ? await createSemanticCache(ctx.db, embeddings)
     : null;
 
-  // Enable CORS for web dashboard and browser-based API clients
+  // CORS: env-driven allowlist. `PROVARA_ALLOWED_ORIGINS` is a
+  // comma-separated list of exact origin strings (e.g.
+  // "https://www.provara.xyz,https://gateway.provara.xyz"). When unset we
+  // fall back to allowing any origin for non-credentialed requests and
+  // reflecting the request origin for credentialed ones — a warning is
+  // logged once at startup so operators know they're in permissive
+  // mode. Setting the allowlist on Railway / self-host Docker env
+  // upgrades to strict.
+  const allowedOrigins = (process.env.PROVARA_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (allowedOrigins.length === 0) {
+    console.warn(
+      "[cors] PROVARA_ALLOWED_ORIGINS is not set — running in permissive mode (any origin allowed with credentials). Set this env var on prod to lock down.",
+    );
+  }
+  const corsOrigin = (origin: string | undefined): string | null => {
+    if (!origin) return null;
+    if (allowedOrigins.length === 0) return origin;
+    return allowedOrigins.includes(origin) ? origin : null;
+  };
+
   app.use("/*", cors({
-    origin: (origin) => origin || "*",
+    origin: corsOrigin,
     credentials: true,
     allowHeaders: ["Content-Type", "Authorization", "X-Admin-Key", "X-Stainless-OS", "X-Stainless-Arch", "X-Stainless-Lang", "X-Stainless-Runtime", "X-Stainless-Runtime-Version", "X-Stainless-Package-Version", "X-Stainless-Retry-Count"],
     allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],


### PR DESCRIPTION
Closes #138.

## Summary

Replaces the wildcard+credentials CORS config with an env-driven allowlist.

- Set `PROVARA_ALLOWED_ORIGINS` (comma-separated) to lock down.
- Unset = permissive fallback + startup warning — so existing deploys don't 500 on redeploy before the env is set.

## Railway action required after merge

Set the env var in the gateway service:
\`\`\`
PROVARA_ALLOWED_ORIGINS=https://www.provara.xyz,https://gateway.provara.xyz
\`\`\`
(Adjust for your real public domains.) Until set, the startup log will show the warning and permissive mode stays active.

## Test plan

- [x] \`tsc --noEmit\` clean.
- [x] 74/74 gateway tests pass.
- [ ] Manual: without the env var, dashboard keeps working (permissive + warning).
- [ ] Manual: with the env var set, a request from an unlisted origin gets blocked by the browser.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)