### PR TITLE
fix(#139): admin-key timing-safe compare + per-IP rate limit

### DIFF
--- a/packages/gateway/src/auth/admin.ts
+++ b/packages/gateway/src/auth/admin.ts
@@ -1,5 +1,6 @@
 import type { Context, Next } from "hono";
 import type { Db } from "@provara/db";
+import { timingSafeEqual } from "node:crypto";
 import { getMode } from "../config.js";
 import { getSessionFromCookie, validateSession } from "./session.js";
 
@@ -11,9 +12,73 @@ export function getAuthUser(req: Request) {
 }
 
 /**
+ * Constant-time string compare. `crypto.timingSafeEqual` requires equal-
+ * length buffers, so we length-check first and return false on mismatch —
+ * leaking the length is fine (the admin secret should be 32+ random
+ * bytes; its length is not the secret). Only once lengths match do we
+ * compare bytewise without short-circuiting on the first mismatch.
+ */
+function safeStringEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+/**
+ * Per-client failed-attempt counter for the X-Admin-Key path. Stores a
+ * failure count and lockout timestamp per client-ip-ish key. Not shared
+ * across processes — single-replica self-hosted only, which is where
+ * this matters (multi_tenant uses session cookies, not admin keys). A
+ * Redis-backed store would be the upgrade path if we ever scale
+ * horizontally.
+ */
+const ADMIN_MAX_FAILURES = 5;
+const ADMIN_LOCKOUT_MS = 60_000;
+interface AttemptRecord {
+  failures: number;
+  lockedUntil: number;
+}
+const adminAttempts = new Map<string, AttemptRecord>();
+
+function clientKey(c: Context): string {
+  const fwd = c.req.header("x-forwarded-for") || c.req.header("cf-connecting-ip") || "";
+  return fwd.split(",")[0]?.trim() || "unknown";
+}
+
+function isLocked(key: string): number {
+  const rec = adminAttempts.get(key);
+  if (!rec) return 0;
+  const remaining = rec.lockedUntil - Date.now();
+  return remaining > 0 ? remaining : 0;
+}
+
+function recordFailure(key: string): void {
+  const rec = adminAttempts.get(key) || { failures: 0, lockedUntil: 0 };
+  rec.failures += 1;
+  if (rec.failures >= ADMIN_MAX_FAILURES) {
+    rec.lockedUntil = Date.now() + ADMIN_LOCKOUT_MS;
+    console.warn(
+      `[admin-auth] rate-limiting client ${key} for ${ADMIN_LOCKOUT_MS}ms after ${rec.failures} consecutive failures`,
+    );
+  }
+  adminAttempts.set(key, rec);
+}
+
+function clearFailures(key: string): void {
+  adminAttempts.delete(key);
+}
+
+/** Testing helpers — exported for unit tests; not for general use. */
+export const __adminAuthInternals = {
+  reset: () => adminAttempts.clear(),
+  get: (key: string) => adminAttempts.get(key),
+  MAX_FAILURES: ADMIN_MAX_FAILURES,
+};
+
+/**
  * Admin middleware for dashboard routes.
- * - self_hosted: checks X-Admin-Key header
- * - multi_tenant: checks session cookie, attaches user to request
+ * - self_hosted: checks X-Admin-Key header with constant-time compare +
+ *   per-IP rate limit on repeated failures.
+ * - multi_tenant: checks session cookie, attaches user to request.
  */
 export function createAdminMiddleware(db?: Db) {
   return async (c: Context, next: Next) => {
@@ -40,20 +105,37 @@ export function createAdminMiddleware(db?: Db) {
       return next();
     }
 
-    // self_hosted mode: existing X-Admin-Key logic
+    // self_hosted mode: X-Admin-Key with timing-safe compare + rate limit
     const secret = process.env.PROVARA_ADMIN_SECRET;
     if (!secret) {
       return next();
     }
 
+    const cKey = clientKey(c);
+    const lockRemainingMs = isLocked(cKey);
+    if (lockRemainingMs > 0) {
+      c.header("Retry-After", String(Math.ceil(lockRemainingMs / 1000)));
+      return c.json(
+        {
+          error: {
+            message: "Too many failed auth attempts. Try again later.",
+            type: "rate_limited",
+          },
+        },
+        429
+      );
+    }
+
     const provided = c.req.header("X-Admin-Key");
-    if (provided !== secret) {
+    if (!provided || !safeStringEqual(provided, secret)) {
+      recordFailure(cKey);
       return c.json(
         { error: { message: "Unauthorized. Invalid or missing admin key.", type: "auth_error" } },
         401
       );
     }
 
+    clearFailures(cKey);
     return next();
   };
 }

--- a/packages/gateway/tests/admin-auth.test.ts
+++ b/packages/gateway/tests/admin-auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+import { createAdminMiddleware, __adminAuthInternals } from "../src/auth/admin.js";
+
+async function buildApp(secret: string | undefined) {
+  if (secret === undefined) delete process.env.PROVARA_ADMIN_SECRET;
+  else process.env.PROVARA_ADMIN_SECRET = secret;
+  process.env.PROVARA_MODE = "self_hosted";
+
+  const app = new Hono();
+  app.use("/admin/*", createAdminMiddleware());
+  app.get("/admin/ok", (c) => c.json({ ok: true }));
+  return app;
+}
+
+function req(app: Hono, path: string, headers: Record<string, string> = {}) {
+  return app.request(path, { headers });
+}
+
+describe("admin-auth", () => {
+  const originalEnv = { ...process.env };
+  beforeEach(() => {
+    __adminAuthInternals.reset();
+  });
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("no secret configured → open mode (no auth required)", async () => {
+    const app = await buildApp(undefined);
+    const res = await req(app, "/admin/ok");
+    expect(res.status).toBe(200);
+  });
+
+  it("correct key passes", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const res = await req(app, "/admin/ok", { "X-Admin-Key": "s3cretKEY12345" });
+    expect(res.status).toBe(200);
+  });
+
+  it("wrong key returns 401", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const res = await req(app, "/admin/ok", { "X-Admin-Key": "wrong-key-xxxxx" });
+    expect(res.status).toBe(401);
+  });
+
+  it("wrong-length key returns 401 (timing-safe path rejects length mismatch)", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const res = await req(app, "/admin/ok", { "X-Admin-Key": "short" });
+    expect(res.status).toBe(401);
+  });
+
+  it("missing key returns 401", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const res = await req(app, "/admin/ok");
+    expect(res.status).toBe(401);
+  });
+
+  it("locks out after MAX_FAILURES consecutive wrong keys (returns 429)", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const ip = { "X-Forwarded-For": "10.0.0.5" };
+    for (let i = 0; i < __adminAuthInternals.MAX_FAILURES; i++) {
+      const res = await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+      expect(res.status).toBe(401);
+    }
+    const res = await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBeTruthy();
+  });
+
+  it("locked client is rejected even with correct key (lockout trumps credential)", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const ip = { "X-Forwarded-For": "10.0.0.6" };
+    for (let i = 0; i < __adminAuthInternals.MAX_FAILURES; i++) {
+      await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+    }
+    const res = await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "s3cretKEY12345" });
+    expect(res.status).toBe(429);
+  });
+
+  it("lockout is per-IP (different IP not affected)", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    for (let i = 0; i < __adminAuthInternals.MAX_FAILURES; i++) {
+      await req(app, "/admin/ok", { "X-Forwarded-For": "10.0.0.7", "X-Admin-Key": "wrong-key-xxxxx" });
+    }
+    const res = await req(app, "/admin/ok", { "X-Forwarded-For": "10.0.0.8", "X-Admin-Key": "s3cretKEY12345" });
+    expect(res.status).toBe(200);
+  });
+
+  it("successful auth clears the failure counter", async () => {
+    const app = await buildApp("s3cretKEY12345");
+    const ip = { "X-Forwarded-For": "10.0.0.9" };
+    // 4 failures, then 1 success
+    for (let i = 0; i < 4; i++) {
+      await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+    }
+    await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "s3cretKEY12345" });
+    // Now 5 more failures should lock after the 5th, not the 1st.
+    for (let i = 0; i < 4; i++) {
+      const res = await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+      expect(res.status).toBe(401);
+    }
+    const res = await req(app, "/admin/ok", { ...ip, "X-Admin-Key": "wrong-key-xxxxx" });
+    expect(res.status).toBe(401); // 5th failure — lock starts AT the threshold, not before
+  });
+});


### PR DESCRIPTION
Closes #139. timingSafeEqual on admin key compare + 5-strike per-IP lockout (60s, returns 429 with Retry-After). 9 new tests. No breaking change.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)