### PR TITLE
feat(#148): stale-cell detection — boost exploration on long-idle cells

### DIFF
--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -16,6 +16,13 @@ export interface AdaptiveCell {
   taskType: string;
   complexity: string;
   scores: AdaptiveScore[];
+  /** Set by the gateway when the cell's most-recent update is older than
+   *  PROVARA_STALE_AFTER_DAYS. The heatmap renders stale cells with a
+   *  distinct border to flag that routing is running with boosted
+   *  exploration until fresh signal arrives. See #148. */
+  isStale?: boolean;
+  /** ISO string — most recent updatedAt across the cell's models. */
+  lastUpdatedAt?: string | null;
 }
 
 export interface SparklinePoint {
@@ -153,11 +160,18 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
               const cell = cellMap.get(`${tt}:${cx}`);
               const scores = [...(cell?.scores ?? [])].sort((a, b) => b.qualityScore - a.qualityScore);
               const maxSamples = scores.reduce((m, s) => Math.max(m, s.sampleCount), 0);
+              const isStale = cell?.isStale === true;
+              const staleTitle = isStale && cell?.lastUpdatedAt
+                ? `Stale since ${new Date(cell.lastUpdatedAt).toLocaleDateString()} — routing explores more aggressively until fresh signal arrives.`
+                : undefined;
 
               return (
                 <div
                   key={`${tt}-${cx}`}
-                  className="border-b border-l border-zinc-800 p-1 min-h-[64px]"
+                  title={staleTitle}
+                  className={`border-b border-l p-1 min-h-[64px] ${
+                    isStale ? "border-amber-800/60 bg-amber-950/10" : "border-zinc-800"
+                  }`}
                 >
                   {scores.length === 0 ? (
                     <div className="h-full flex items-center justify-center text-xs text-zinc-600">
@@ -206,6 +220,10 @@ export function AdaptiveHeatmap({ cells, minSamples = 5, pulsedKeys, getSparklin
           <span className="flex items-center gap-1.5">
             <span className="inline-block w-4 h-3 rounded-sm border border-dashed border-zinc-500" />
             <span>Below {minSamples} samples</span>
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block w-4 h-3 rounded-sm border border-amber-800/60 bg-amber-950/10" />
+            <span>Stale</span>
           </span>
           <span>Opacity = confidence</span>
         </div>

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -737,9 +737,15 @@ export async function createRouter(ctx: RouterContext) {
     return c.json({ providers });
   });
 
-  // Adaptive routing scores (for dashboard)
+  // Adaptive routing scores (for dashboard). Annotates each cell with
+  // staleness so the heatmap can render stale cells distinctly — see #148.
   app.get("/v1/analytics/adaptive/scores", (c) => {
-    return c.json({ cells: routingEngine.adaptive.getAllScores() });
+    const cells = routingEngine.adaptive.getAllScores().map((cell) => ({
+      ...cell,
+      isStale: routingEngine.adaptive.isStale(cell.taskType, cell.complexity),
+      lastUpdatedAt: routingEngine.adaptive.lastUpdated(cell.taskType, cell.complexity),
+    }));
+    return c.json({ cells });
   });
 
   // Cache stats

--- a/packages/gateway/src/routing/adaptive/exploration.ts
+++ b/packages/gateway/src/routing/adaptive/exploration.ts
@@ -1,5 +1,11 @@
 import type { RouteTarget } from "../types.js";
 
+function numFromEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined || value === "") return fallback;
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
 /**
  * ε-greedy exploration rate (#103). With this probability, bypass the EMA
  * and pick uniformly at random from the full candidate list — including
@@ -9,20 +15,49 @@ import type { RouteTarget } from "../types.js";
  * MIN_SAMPLES before any competitor does, it wins permanently in that cell
  * because no alternative is ever eligible for the EMA comparison.
  */
-export const EXPLORATION_RATE = parseFloat(process.env.PROVARA_EXPLORATION_RATE || "0.1");
+export const EXPLORATION_RATE = numFromEnv(process.env.PROVARA_EXPLORATION_RATE, 0.1);
+
+/**
+ * Higher exploration rate used when the current cell is deemed "stale" —
+ * i.e. its most recent score update is older than `STALE_AFTER_DAYS`. A
+ * sleeping cell accumulates no fresh signal under the normal rate
+ * (10% of 0 traffic = 0), so we boost the probability of exploration
+ * when traffic DOES arrive to that cell, forcing ground-truth refresh.
+ */
+export const STALE_EXPLORATION_RATE = numFromEnv(process.env.PROVARA_STALE_EXPLORATION_RATE, 0.5);
+
+/**
+ * How long a cell can go without any score update before it's treated as
+ * stale. Default 30 days. Units: milliseconds internally; the env var is
+ * in days for human readability.
+ */
+export const STALE_AFTER_MS =
+  numFromEnv(process.env.PROVARA_STALE_AFTER_DAYS, 30) * 24 * 60 * 60 * 1000;
 
 /**
  * Returns a uniformly random eligible candidate if the ε-greedy branch
  * fires, else null. Callers fall through to the EMA-winner path on null.
  * Requires at least 2 eligible candidates — there's no meaningful choice
  * to make otherwise.
+ *
+ * When `options.stale` is true, the higher `STALE_EXPLORATION_RATE`
+ * applies instead of the normal rate. Stale detection itself lives in
+ * `adaptive/router.ts`.
  */
 export function pickExploration(
   allCandidates: RouteTarget[],
   availableProviders: Set<string>,
+  options: { stale?: boolean } = {},
 ): RouteTarget | null {
   const eligible = allCandidates.filter((c) => availableProviders.has(c.provider));
   if (eligible.length <= 1) return null;
-  if (Math.random() >= EXPLORATION_RATE) return null;
+  const rate = options.stale ? STALE_EXPLORATION_RATE : EXPLORATION_RATE;
+  if (Math.random() >= rate) return null;
   return eligible[Math.floor(Math.random() * eligible.length)];
+}
+
+/** Helper for callers: is the most-recent updatedAt past the stale threshold? */
+export function isStaleTimestamp(mostRecent: Date | null | undefined): boolean {
+  if (!mostRecent) return false;
+  return Date.now() - mostRecent.getTime() > STALE_AFTER_MS;
 }

--- a/packages/gateway/src/routing/adaptive/persistence.ts
+++ b/packages/gateway/src/routing/adaptive/persistence.ts
@@ -25,6 +25,7 @@ export async function loadScoresFromDb(db: Db, store: ScoreStore): Promise<void>
       model: modelScores.model,
       qualityScore: modelScores.qualityScore,
       sampleCount: modelScores.sampleCount,
+      updatedAt: modelScores.updatedAt,
     })
     .from(modelScores)
     .all();
@@ -38,6 +39,7 @@ export async function loadScoresFromDb(db: Db, store: ScoreStore): Promise<void>
       sampleCount: row.sampleCount,
       costPer1M: getModelCost(row.model),
       avgLatencyMs: 0,
+      updatedAt: row.updatedAt,
     });
   }
 

--- a/packages/gateway/src/routing/adaptive/router.ts
+++ b/packages/gateway/src/routing/adaptive/router.ts
@@ -3,7 +3,7 @@ import type { TaskType, Complexity } from "../../classifier/types.js";
 import type { RouteTarget } from "../types.js";
 import { EMA_ALPHA, ema, getQualityAlpha } from "./ema.js";
 import { MIN_SAMPLES, computeRouteScore, getModelCost, resolveWeights } from "./scoring.js";
-import { pickExploration } from "./exploration.js";
+import { isStaleTimestamp, pickExploration } from "./exploration.js";
 import { createScoreStore, type ScoreStore } from "./score-store.js";
 import { loadScoresFromDb, persistScore } from "./persistence.js";
 import type { FeedbackSource, ModelScore, RoutingProfile, RoutingWeights } from "./types.js";
@@ -29,12 +29,14 @@ export async function createAdaptiveRouter(db: Db) {
   ): Promise<void> {
     const alpha = getQualityAlpha(source);
     const existing = store.get(taskType, complexity, provider, model);
+    const now = new Date();
 
     let qualityScore: number;
     let sampleCount: number;
     if (existing) {
       existing.qualityScore = ema(existing.qualityScore, newScore, alpha);
       existing.sampleCount++;
+      existing.updatedAt = now;
       qualityScore = existing.qualityScore;
       sampleCount = existing.sampleCount;
     } else {
@@ -47,6 +49,7 @@ export async function createAdaptiveRouter(db: Db) {
         sampleCount,
         costPer1M: getModelCost(model),
         avgLatencyMs: 0,
+        updatedAt: now,
       });
     }
 
@@ -72,6 +75,10 @@ export async function createAdaptiveRouter(db: Db) {
    * and `via: "adaptive"` when the EMA-scoring branch picked the winner.
    * Returns null when no adaptive candidate qualifies and exploration
    * didn't fire — caller falls through to cheapest-first.
+   *
+   * Cells whose most-recent update is older than the stale threshold get
+   * a boosted exploration rate so their stored EMA doesn't drift further
+   * from current truth. See #148.
    */
   function getBestModel(
     taskType: TaskType,
@@ -81,12 +88,13 @@ export async function createAdaptiveRouter(db: Db) {
     allCandidates: RouteTarget[],
     customWeights?: RoutingWeights,
   ): { target: RouteTarget; via: "adaptive" | "exploration" } | null {
-    const exploration = pickExploration(allCandidates, availableProviders);
+    const cellMap = store.getCellMap(taskType, complexity);
+    const stale = isCellStale(cellMap);
+    const exploration = pickExploration(allCandidates, availableProviders, { stale });
     if (exploration) {
       return { target: exploration, via: "exploration" };
     }
 
-    const cellMap = store.getCellMap(taskType, complexity);
     if (!cellMap || cellMap.size === 0) return null;
 
     const candidates = Array.from(cellMap.values()).filter(
@@ -120,6 +128,37 @@ export async function createAdaptiveRouter(db: Db) {
     return store.getAllScores();
   }
 
+  /**
+   * Most-recent `updatedAt` across all models in a cell, or null if the
+   * cell has no timestamps (e.g. feedback-seeded, never updated through
+   * `updateScore`). `isCellStale` builds on this.
+   */
+  function cellLastUpdated(cellMap: Map<string, ModelScore> | undefined): Date | null {
+    if (!cellMap || cellMap.size === 0) return null;
+    let mostRecent: Date | null = null;
+    for (const s of cellMap.values()) {
+      if (!s.updatedAt) continue;
+      if (!mostRecent || s.updatedAt.getTime() > mostRecent.getTime()) {
+        mostRecent = s.updatedAt;
+      }
+    }
+    return mostRecent;
+  }
+
+  function isCellStale(cellMap: Map<string, ModelScore> | undefined): boolean {
+    return isStaleTimestamp(cellLastUpdated(cellMap));
+  }
+
+  /** Public read for analytics/UI: is this cell past the stale threshold? */
+  function isStale(taskType: string, complexity: string): boolean {
+    return isCellStale(store.getCellMap(taskType, complexity));
+  }
+
+  /** Public read for analytics/UI: the cell's most-recent updatedAt. */
+  function lastUpdated(taskType: string, complexity: string): Date | null {
+    return cellLastUpdated(store.getCellMap(taskType, complexity));
+  }
+
   await loadScoresFromDb(db, store);
 
   return {
@@ -128,6 +167,8 @@ export async function createAdaptiveRouter(db: Db) {
     getBestModel,
     getCellScores,
     getAllScores,
+    isStale,
+    lastUpdated,
     loadScoresFromDb: () => loadScoresFromDb(db, store),
   };
 }

--- a/packages/gateway/src/routing/adaptive/types.ts
+++ b/packages/gateway/src/routing/adaptive/types.ts
@@ -18,4 +18,8 @@ export interface ModelScore {
   costPer1M: number;
   /** EMA of observed latency in ms. */
   avgLatencyMs: number;
+  /** Last time this score was updated. Null for rows seeded purely from
+   *  pre-EMA feedback aggregation. Used to detect stale cells and force
+   *  exploration on them. */
+  updatedAt?: Date | null;
 }

--- a/packages/gateway/tests/adaptive-modules.test.ts
+++ b/packages/gateway/tests/adaptive-modules.test.ts
@@ -5,7 +5,7 @@ import {
   computeRouteScore,
   resolveWeights,
 } from "../src/routing/adaptive/scoring.js";
-import { pickExploration } from "../src/routing/adaptive/exploration.js";
+import { pickExploration, isStaleTimestamp, STALE_AFTER_MS } from "../src/routing/adaptive/exploration.js";
 import type { RouteTarget } from "../src/routing/types.js";
 
 describe("ema math", () => {
@@ -148,5 +148,36 @@ describe("pickExploration", () => {
     const onlyOpenAI = new Set(["openai"]);
     // 3 candidates but only 1 available → not eligible for exploration
     expect(pickExploration(candidates, onlyOpenAI)).toBeNull();
+  });
+
+  it("stale cells use the boosted exploration rate (default 0.5)", () => {
+    // Draw 0.3 — above the normal 0.1 (would miss) but under the stale 0.5
+    // (should hit). Second draw picks the index.
+    vi.spyOn(Math, "random").mockReturnValueOnce(0.3).mockReturnValueOnce(0.0);
+    const normal = pickExploration(candidates, available, { stale: false });
+    expect(normal).toBeNull();
+
+    vi.spyOn(Math, "random").mockReturnValueOnce(0.3).mockReturnValueOnce(0.0);
+    const stale = pickExploration(candidates, available, { stale: true });
+    expect(stale).not.toBeNull();
+  });
+});
+
+describe("isStaleTimestamp", () => {
+  it("returns false for null/undefined", () => {
+    expect(isStaleTimestamp(null)).toBe(false);
+    expect(isStaleTimestamp(undefined)).toBe(false);
+  });
+
+  it("returns false for a recent timestamp", () => {
+    expect(isStaleTimestamp(new Date(Date.now() - 60_000))).toBe(false);
+  });
+
+  it("returns true for a timestamp older than the threshold", () => {
+    expect(isStaleTimestamp(new Date(Date.now() - STALE_AFTER_MS - 1000))).toBe(true);
+  });
+
+  it("returns false right at the boundary", () => {
+    expect(isStaleTimestamp(new Date(Date.now() - STALE_AFTER_MS + 1000))).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #148. The third approach from #51 — staleness flag + boosted exploration — chosen over time-weighted EMA and periodic cron.

## Mechanism

- Each ModelScore tracks \`updatedAt\` (in-memory + hydrated from DB).
- A cell is \"stale\" when the max \`updatedAt\` across its models exceeds \`PROVARA_STALE_AFTER_DAYS\` (default 30).
- \`pickExploration\` gains \`{ stale }\` option — uses \`PROVARA_STALE_EXPLORATION_RATE\` (default 0.5) vs normal 0.1.
- \`/v1/analytics/adaptive/scores\` response annotates each cell with \`isStale\` + \`lastUpdatedAt\`.
- Heatmap renders stale cells with amber border + wash, tooltip, legend entry.

## Why not the other options

- **Time-weighted EMA** — fiddly two-parameter math, risk of regressing #49.
- **Periodic cron nudge** — couples to scheduler infra we don't have.
- **Dual EMA (long + short)** — doubles state per cell for marginal gain.

## Test plan

- [x] \`tsc --noEmit\` clean on gateway + web.
- [x] 92/92 gateway tests pass (+5 new: boundary conditions + rate boost).
- [ ] Manual: set \`PROVARA_STALE_AFTER_DAYS=0\` locally, send a request to a cell, observe the heatmap render that cell in amber.

Last-code-by: Opus 4.7 (1M context)/claude-opus-4-7 (Claude Code)