### PR TITLE
feat(#153): quality-gated cost migration with grace-boost window

### DIFF
--- a/apps/web/src/app/dashboard/routing/page.tsx
+++ b/apps/web/src/app/dashboard/routing/page.tsx
@@ -8,6 +8,7 @@ import { gatewayFetchRaw } from "../../../lib/gateway-client";
 import { PipelineVisualization } from "../../../components/pipeline-viz";
 import type { AdaptiveCell } from "../../../components/adaptive-heatmap";
 import { useAdaptiveScoreBuffer } from "../../../hooks/use-adaptive-score-buffer";
+import { MigrationsPanel } from "../../../components/migrations-panel";
 
 interface RoutingStat {
   taskType: string | null;
@@ -270,6 +271,12 @@ export default function RoutingPage() {
           Based on historical request count. See <a href="/dashboard/quality" className="text-blue-400 hover:text-blue-300 underline">Quality → Adaptive Routing</a> for quality-based routing decisions.
         </p>
         <RoutingMatrix stats={stats} />
+      </section>
+
+      {/* Cost migrations */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Cost Migrations</h2>
+        <MigrationsPanel />
       </section>
 
       {/* Detailed Stats */}

--- a/apps/web/src/components/migrations-panel.tsx
+++ b/apps/web/src/components/migrations-panel.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { gatewayFetchRaw } from "../lib/gateway-client";
+
+interface MigrationRow {
+  id: string;
+  taskType: string;
+  complexity: string;
+  fromProvider: string;
+  fromModel: string;
+  fromCostPer1M: number;
+  fromQualityScore: number;
+  toProvider: string;
+  toModel: string;
+  toCostPer1M: number;
+  toQualityScore: number;
+  projectedMonthlySavingsUsd: number;
+  graceEndsAt: string;
+  executedAt: string;
+  rolledBackAt: string | null;
+  rollbackReason: string | null;
+}
+
+interface Status {
+  enabled: boolean;
+  savingsThisMonth: number;
+}
+
+function usd(v: number): string {
+  if (v === 0) return "$0";
+  if (v < 1) return `$${v.toFixed(2)}`;
+  return `$${v.toFixed(0)}`;
+}
+
+function shortDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function MigrationsPanel() {
+  const [status, setStatus] = useState<Status | null>(null);
+  const [migrations, setMigrations] = useState<MigrationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [statusRes, listRes] = await Promise.all([
+        gatewayFetchRaw("/v1/cost-migrations/status").then((r) => r.json()),
+        gatewayFetchRaw("/v1/cost-migrations").then((r) => r.json()),
+      ]);
+      setStatus(statusRes);
+      setMigrations(listRes.migrations || []);
+    } catch (err) {
+      console.error("migrations panel fetch failed:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function toggle() {
+    if (!status) return;
+    setBusy(true);
+    try {
+      await gatewayFetchRaw("/v1/cost-migrations/opt-in", {
+        method: "POST",
+        body: JSON.stringify({ enabled: !status.enabled }),
+      });
+      await load();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function rollback(id: string) {
+    await gatewayFetchRaw(`/v1/cost-migrations/${id}/rollback`, {
+      method: "POST",
+      body: JSON.stringify({ reason: "manual rollback from dashboard" }),
+    });
+    await load();
+  }
+
+  if (loading) return <p className="text-sm text-zinc-500">Loading cost migrations...</p>;
+  if (!status) return null;
+
+  const activeRows = migrations.filter((m) => !m.rolledBackAt);
+  const rolledBackRows = migrations.filter((m) => m.rolledBackAt);
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-semibold">Quality-gated cost migrations</h3>
+            <p className="text-xs text-zinc-500 mt-1">
+              Nightly sweep: when a cheaper model holds its quality within
+              tolerance, the router migrates the cell automatically and reports
+              the projected savings.
+            </p>
+          </div>
+          <button
+            onClick={toggle}
+            disabled={busy}
+            className={`px-3 py-1.5 rounded text-xs font-medium transition-colors ${
+              status.enabled
+                ? "bg-emerald-700 hover:bg-emerald-600 text-white"
+                : "bg-zinc-800 hover:bg-zinc-700 text-zinc-200 border border-zinc-700"
+            } disabled:opacity-50`}
+          >
+            {status.enabled ? "Enabled" : "Enable"}
+          </button>
+        </div>
+        <div className="mt-3 grid grid-cols-3 gap-3 text-xs">
+          <div className="bg-zinc-800/40 rounded p-2">
+            <div className="text-zinc-500">Projected savings this month</div>
+            <div className="text-emerald-400 font-semibold mt-1 text-base">
+              {usd(status.savingsThisMonth)}
+            </div>
+          </div>
+          <div className="bg-zinc-800/40 rounded p-2">
+            <div className="text-zinc-500">Active migrations</div>
+            <div className="text-zinc-200 font-medium mt-1">{activeRows.length}</div>
+          </div>
+          <div className="bg-zinc-800/40 rounded p-2">
+            <div className="text-zinc-500">Rolled back</div>
+            <div className="text-zinc-200 font-medium mt-1">{rolledBackRows.length}</div>
+          </div>
+        </div>
+      </div>
+
+      {activeRows.length > 0 && (
+        <div className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden">
+          <div className="px-4 py-3 border-b border-zinc-800">
+            <h4 className="text-sm font-semibold text-zinc-200">Active migrations</h4>
+          </div>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-zinc-400 text-xs">
+                <th className="text-left px-4 py-2">Cell</th>
+                <th className="text-left px-4 py-2">From</th>
+                <th className="text-left px-4 py-2">To</th>
+                <th className="text-right px-4 py-2">Savings/mo</th>
+                <th className="text-right px-4 py-2">Grace ends</th>
+                <th className="px-4 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {activeRows.map((m) => (
+                <tr key={m.id} className="border-t border-zinc-800/50">
+                  <td className="px-4 py-2 text-xs text-zinc-300 capitalize">
+                    {m.taskType}+{m.complexity}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-zinc-400">
+                    {m.fromProvider}/{m.fromModel}
+                    <div className="text-[10px] text-zinc-500">
+                      q{m.fromQualityScore.toFixed(2)} · ${m.fromCostPer1M.toFixed(2)}/1M
+                    </div>
+                  </td>
+                  <td className="px-4 py-2 font-mono text-xs text-emerald-300">
+                    {m.toProvider}/{m.toModel}
+                    <div className="text-[10px] text-zinc-500">
+                      q{m.toQualityScore.toFixed(2)} · ${m.toCostPer1M.toFixed(2)}/1M
+                    </div>
+                  </td>
+                  <td className="px-4 py-2 text-right text-xs text-emerald-400 font-medium">
+                    {usd(m.projectedMonthlySavingsUsd)}
+                  </td>
+                  <td className="px-4 py-2 text-right text-xs text-zinc-500">
+                    {shortDate(m.graceEndsAt)}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <button
+                      onClick={() => rollback(m.id)}
+                      className="text-xs text-zinc-400 hover:text-red-400"
+                    >
+                      Roll back
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {rolledBackRows.length > 0 && (
+        <details className="bg-zinc-900 border border-zinc-800 rounded-lg">
+          <summary className="px-4 py-2 cursor-pointer text-xs text-zinc-400 hover:text-zinc-200">
+            Rolled-back history ({rolledBackRows.length})
+          </summary>
+          <div className="divide-y divide-zinc-800/50">
+            {rolledBackRows.slice(0, 20).map((m) => (
+              <div key={m.id} className="px-4 py-2 text-xs text-zinc-500 flex justify-between">
+                <span>
+                  {m.taskType}+{m.complexity} —{" "}
+                  <span className="font-mono text-zinc-400">
+                    {m.fromProvider}/{m.fromModel} → {m.toProvider}/{m.toModel}
+                  </span>
+                </span>
+                <span>{m.rolledBackAt ? shortDate(m.rolledBackAt) : ""}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/packages/db/drizzle/0022_wealthy_squadron_supreme.sql
+++ b/packages/db/drizzle/0022_wealthy_squadron_supreme.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `cost_migrations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`task_type` text NOT NULL,
+	`complexity` text NOT NULL,
+	`from_provider` text NOT NULL,
+	`from_model` text NOT NULL,
+	`from_cost_per_1m` real NOT NULL,
+	`from_quality_score` real NOT NULL,
+	`to_provider` text NOT NULL,
+	`to_model` text NOT NULL,
+	`to_cost_per_1m` real NOT NULL,
+	`to_quality_score` real NOT NULL,
+	`projected_monthly_savings_usd` real DEFAULT 0 NOT NULL,
+	`grace_ends_at` integer NOT NULL,
+	`executed_at` integer NOT NULL,
+	`rolled_back_at` integer,
+	`rollback_reason` text
+);

--- a/packages/db/drizzle/meta/0022_snapshot.json
+++ b/packages/db/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2278 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a1354096-9ff3-4104-b47e-27076a850cc2",
+  "prevId": "ff256b68-a122-456b-b610-849bca0fa7cd",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1776455101820,
       "tag": "0021_tranquil_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1776455946736,
+      "tag": "0022_wealthy_squadron_supreme",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -414,6 +414,39 @@ export const regressionEvents = sqliteTable("regression_events", {
 });
 
 /**
+ * Automated cell-level cost migrations (#153). One row per executed
+ * migration — the adaptive router consults this table for a
+ * `graceBoost` during the grace window so the newly-selected cheaper
+ * model gets time to prove itself under live traffic. `rolledBackAt`
+ * stays null unless regression detection (#152) or an operator flips
+ * it — we preserve history regardless of outcome so savings claims are
+ * auditable.
+ */
+export const costMigrations = sqliteTable("cost_migrations", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  taskType: text("task_type").notNull(),
+  complexity: text("complexity").notNull(),
+  fromProvider: text("from_provider").notNull(),
+  fromModel: text("from_model").notNull(),
+  fromCostPer1M: real("from_cost_per_1m").notNull(),
+  fromQualityScore: real("from_quality_score").notNull(),
+  toProvider: text("to_provider").notNull(),
+  toModel: text("to_model").notNull(),
+  toCostPer1M: real("to_cost_per_1m").notNull(),
+  toQualityScore: real("to_quality_score").notNull(),
+  /** Savings floor — projected monthly USD based on traffic pattern at execute time. */
+  projectedMonthlySavingsUsd: real("projected_monthly_savings_usd").notNull().default(0),
+  /** Grace-period end. Router ends the boost at this timestamp. */
+  graceEndsAt: integer("grace_ends_at", { mode: "timestamp" }).notNull(),
+  executedAt: integer("executed_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  rolledBackAt: integer("rolled_back_at", { mode: "timestamp" }),
+  rollbackReason: text("rollback_reason"),
+});
+
+/**
  * Persistent state for the in-process scheduler. One row per named job.
  * Survives restart so re-scheduled jobs can resume their cadence and the
  * UI can surface last-run telemetry. The scheduler itself still lives

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -16,6 +16,7 @@ import { hydrateRoutingConfig } from "./routing/config.js";
 import { createScheduler } from "./scheduler/index.js";
 import { runAutoAbCycle } from "./routing/adaptive/auto-ab.js";
 import { runBankPopulationCycle, runReplayCycle } from "./routing/adaptive/regression.js";
+import { runCostMigrationCycle } from "./routing/adaptive/migrations.js";
 import { createEmbeddingProvider } from "./embeddings/index.js";
 import { getJudgeConfig } from "./routing/judge.js";
 
@@ -85,9 +86,30 @@ await scheduler.schedule({
     }
   },
 });
-scheduler.start();
-
 const app = await createRouter({ registry, db, dbKeys, scheduler });
+
+const COST_MIGRATION_INTERVAL_MS = parseInt(
+  process.env.PROVARA_COST_MIGRATION_INTERVAL_MS || `${24 * 60 * 60 * 1000}`,
+  10,
+);
+await scheduler.schedule({
+  name: "cost-migration",
+  intervalMs: COST_MIGRATION_INTERVAL_MS,
+  initialDelayMs: 90_000,
+  handler: async () => {
+    const stats = await runCostMigrationCycle(db);
+    if (stats.executed.length > 0) {
+      console.log(
+        `[cost-migration] executed ${stats.executed.length} migration(s), projected $${stats.executed.reduce((s, m) => s + m.projectedMonthlySavingsUsd, 0).toFixed(2)}/mo saved`,
+      );
+      // Refresh the boost table so the router picks up the new migration
+      // without a restart — boost applies on the very next routing decision.
+      await app.routingEngine.boostTable.refresh();
+    }
+  },
+});
+
+scheduler.start();
 
 // Discover available models from each provider's API at startup
 registry.refreshModels().then((results) => {

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -35,6 +35,7 @@ import { getMode } from "./config.js";
 import type { Scheduler } from "./scheduler/index.js";
 import { getActiveAutoAbCells } from "./routing/adaptive/auto-ab.js";
 import { createRegressionRoutes } from "./routes/regression.js";
+import { createMigrationRoutes } from "./routes/migrations.js";
 
 interface RouterContext {
   registry: ProviderRegistry;
@@ -131,6 +132,7 @@ export async function createRouter(ctx: RouterContext) {
   // Mount A/B test CRUD routes
   app.route("/v1/ab-tests", createAbTestRoutes(ctx.db));
   app.route("/v1/regression", createRegressionRoutes(ctx.db));
+  app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
 
   // Mount analytics routes
   app.route("/v1/analytics", createAnalyticsRoutes(ctx.db));
@@ -783,5 +785,5 @@ export async function createRouter(ctx: RouterContext) {
   // Health check + config
   app.get("/health", (c) => c.json({ status: "ok", mode: getMode() }));
 
-  return app;
+  return Object.assign(app, { routingEngine });
 }

--- a/packages/gateway/src/routes/migrations.ts
+++ b/packages/gateway/src/routes/migrations.ts
@@ -1,0 +1,55 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { getTenantId } from "../auth/tenant.js";
+import {
+  isCostMigrationEnabled,
+  listMigrations,
+  rollbackMigration,
+  runCostMigrationCycle,
+  setCostMigrationOptIn,
+  totalSavingsThisMonth,
+} from "../routing/adaptive/migrations.js";
+import type { BoostTable } from "../routing/adaptive/migrations.js";
+
+export function createMigrationRoutes(db: Db, boostTable: BoostTable) {
+  const app = new Hono();
+
+  app.get("/status", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const enabled = await isCostMigrationEnabled(db, tenantId);
+    const savingsThisMonth = await totalSavingsThisMonth(db, tenantId);
+    return c.json({ enabled, savingsThisMonth });
+  });
+
+  app.post("/opt-in", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{ enabled: boolean }>();
+    await setCostMigrationOptIn(db, tenantId, Boolean(body.enabled));
+    return c.json({ enabled: Boolean(body.enabled) });
+  });
+
+  app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const migrations = await listMigrations(db, tenantId);
+    return c.json({ migrations });
+  });
+
+  app.post("/run", async (c) => {
+    const stats = await runCostMigrationCycle(db);
+    if (stats.executed.length > 0) {
+      await boostTable.refresh();
+    }
+    return c.json(stats);
+  });
+
+  app.post("/:id/rollback", async (c) => {
+    const { id } = c.req.param();
+    const body = await c.req.json<{ reason?: string }>().catch(() => ({} as { reason?: string }));
+    const ok = await rollbackMigration(db, id, body.reason ?? "manual rollback");
+    if (!ok) return c.json({ error: { message: "migration not found or already rolled back", type: "not_found" } }, 404);
+    await boostTable.refresh();
+    return c.json({ rolledBack: true });
+  });
+
+  return app;
+}

--- a/packages/gateway/src/routing/adaptive/migrations.ts
+++ b/packages/gateway/src/routing/adaptive/migrations.ts
@@ -1,0 +1,389 @@
+import type { Db } from "@provara/db";
+import { costMigrations, modelScores, requests, appConfig } from "@provara/db";
+import { and, eq, sql, desc, isNull, gt } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { MIN_SAMPLES, getModelCost } from "./scoring.js";
+
+function numEnv(v: string | undefined, fallback: number): number {
+  if (v === undefined || v === "") return fallback;
+  const parsed = parseFloat(v);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function intEnv(v: string | undefined, fallback: number): number {
+  if (v === undefined || v === "") return fallback;
+  const parsed = parseInt(v, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** Quality tolerance — a competitor within this margin of the winner is eligible. 1-5 scale. */
+export const EPSILON_QUALITY = numEnv(process.env.PROVARA_COST_MIGRATION_EPSILON, 0.2);
+
+/** Cheapest candidate must beat the incumbent by this multiplier — e.g. 0.8 = at most 80% of incumbent cost. */
+export const COST_RATIO_THRESHOLD = numEnv(process.env.PROVARA_COST_MIGRATION_RATIO, 0.8);
+
+/** Sample floor: migrations require double-confidence vs. normal routing. */
+export const MIGRATION_MIN_SAMPLES = Math.max(MIN_SAMPLES * 2, intEnv(process.env.PROVARA_COST_MIGRATION_MIN_SAMPLES, MIN_SAMPLES * 2));
+
+/** Hard cap on migrations per scheduler cycle — guards against mass reshuffle. */
+export const MAX_MIGRATIONS_PER_CYCLE = intEnv(process.env.PROVARA_COST_MIGRATION_MAX_PER_CYCLE, 3);
+
+/** Temporary boost added to the target's EMA during the grace window. */
+export const GRACE_BOOST = numEnv(process.env.PROVARA_COST_MIGRATION_GRACE_BOOST, 0.3);
+
+/** Grace window length in days — boost tapers off to zero after this. */
+export const GRACE_DAYS = intEnv(process.env.PROVARA_COST_MIGRATION_GRACE_DAYS, 30);
+
+/** Cooldown before the same cell can be re-migrated, in days. */
+export const COOLDOWN_DAYS = intEnv(process.env.PROVARA_COST_MIGRATION_COOLDOWN_DAYS, 30);
+
+const OPT_IN_CONFIG_PREFIX = "cost_migration_opt_in:";
+
+function optInKey(tenantId: string | null): string {
+  return `${OPT_IN_CONFIG_PREFIX}${tenantId ?? "_global"}`;
+}
+
+export async function isCostMigrationEnabled(db: Db, tenantId: string | null): Promise<boolean> {
+  const row = await db.select().from(appConfig).where(eq(appConfig.key, optInKey(tenantId))).get();
+  return row?.value === "true";
+}
+
+export async function setCostMigrationOptIn(db: Db, tenantId: string | null, enabled: boolean): Promise<void> {
+  const now = new Date();
+  const value = enabled ? "true" : "false";
+  await db
+    .insert(appConfig)
+    .values({ key: optInKey(tenantId), value, updatedAt: now })
+    .onConflictDoUpdate({ target: appConfig.key, set: { value, updatedAt: now } })
+    .run();
+}
+
+interface CellRow {
+  taskType: string;
+  complexity: string;
+  provider: string;
+  model: string;
+  qualityScore: number;
+  sampleCount: number;
+  updatedAt: Date | null;
+}
+
+export interface MigrationCandidate {
+  taskType: string;
+  complexity: string;
+  from: { provider: string; model: string; qualityScore: number; costPer1M: number };
+  to: { provider: string; model: string; qualityScore: number; costPer1M: number };
+  projectedMonthlySavingsUsd: number;
+}
+
+async function recentCellAvgTokens(db: Db, cell: { taskType: string; complexity: string; provider: string; model: string }) {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const row = await db
+    .select({
+      count: sql<number>`count(*)`,
+      avgInput: sql<number>`avg(${requests.inputTokens})`,
+      avgOutput: sql<number>`avg(${requests.outputTokens})`,
+    })
+    .from(requests)
+    .where(
+      and(
+        eq(requests.taskType, cell.taskType),
+        eq(requests.complexity, cell.complexity),
+        eq(requests.provider, cell.provider),
+        eq(requests.model, cell.model),
+        sql`${requests.createdAt} > ${Math.floor(thirtyDaysAgo.getTime() / 1000)}`,
+      ),
+    )
+    .get();
+  return {
+    count: row?.count ?? 0,
+    avgInput: row?.avgInput ?? 0,
+    avgOutput: row?.avgOutput ?? 0,
+  };
+}
+
+/**
+ * Project monthly USD savings from swapping `from` to `to` at the cell's
+ * current 30-day traffic pattern. Returns 0 when no traffic data is
+ * available — migration still fires in that case (cell must have picked
+ * up a winner somehow), but UI shows "$0 projected" rather than garbage.
+ */
+async function projectSavings(
+  db: Db,
+  cell: { taskType: string; complexity: string; provider: string; model: string },
+  from: { costPer1M: number },
+  to: { costPer1M: number },
+): Promise<number> {
+  const traffic = await recentCellAvgTokens(db, cell);
+  if (traffic.count === 0) return 0;
+  const monthlyRate = traffic.count; // requests in last 30 days ≈ current monthly rate
+  const tokensPerReq = (traffic.avgInput + traffic.avgOutput);
+  const costBefore = (tokensPerReq * monthlyRate / 1_000_000) * from.costPer1M;
+  const costAfter = (tokensPerReq * monthlyRate / 1_000_000) * to.costPer1M;
+  return Math.max(0, costBefore - costAfter);
+}
+
+/**
+ * Scan model_scores for cells where a cheaper competitor is at-or-above
+ * (winner - epsilon) quality with enough samples and fresh signal. Returns
+ * ranked candidates for the current cycle; caller enforces the per-run
+ * cap and cooldown.
+ */
+export async function findMigrationCandidates(db: Db): Promise<MigrationCandidate[]> {
+  const rows = await db.select().from(modelScores).all();
+  const cells = new Map<string, CellRow[]>();
+  const now = Date.now();
+  const staleCutoff = now - 30 * 24 * 60 * 60 * 1000;
+
+  for (const row of rows) {
+    if (row.sampleCount < MIGRATION_MIN_SAMPLES) continue;
+    if (!row.updatedAt || row.updatedAt.getTime() < staleCutoff) continue;
+    const key = `${row.taskType}::${row.complexity}`;
+    const existing = cells.get(key) ?? [];
+    existing.push({
+      taskType: row.taskType,
+      complexity: row.complexity,
+      provider: row.provider,
+      model: row.model,
+      qualityScore: row.qualityScore,
+      sampleCount: row.sampleCount,
+      updatedAt: row.updatedAt,
+    });
+    cells.set(key, existing);
+  }
+
+  const candidates: MigrationCandidate[] = [];
+  for (const group of cells.values()) {
+    if (group.length < 2) continue;
+    const sorted = [...group].sort((a, b) => b.qualityScore - a.qualityScore);
+    const winner = sorted[0];
+    const winnerCost = getModelCost(winner.model);
+    if (winnerCost <= 0) continue;
+
+    let best: { row: CellRow; cost: number } | null = null;
+    for (const alt of sorted.slice(1)) {
+      const altCost = getModelCost(alt.model);
+      if (altCost <= 0) continue;
+      if (altCost >= winnerCost * COST_RATIO_THRESHOLD) continue;
+      if (winner.qualityScore - alt.qualityScore > EPSILON_QUALITY) continue;
+      if (!best || altCost < best.cost) {
+        best = { row: alt, cost: altCost };
+      }
+    }
+
+    if (!best) continue;
+
+    const savings = await projectSavings(
+      db,
+      { taskType: winner.taskType, complexity: winner.complexity, provider: winner.provider, model: winner.model },
+      { costPer1M: winnerCost },
+      { costPer1M: best.cost },
+    );
+
+    candidates.push({
+      taskType: winner.taskType,
+      complexity: winner.complexity,
+      from: {
+        provider: winner.provider,
+        model: winner.model,
+        qualityScore: winner.qualityScore,
+        costPer1M: winnerCost,
+      },
+      to: {
+        provider: best.row.provider,
+        model: best.row.model,
+        qualityScore: best.row.qualityScore,
+        costPer1M: best.cost,
+      },
+      projectedMonthlySavingsUsd: savings,
+    });
+  }
+
+  // Biggest savings first — we'll cap at MAX_MIGRATIONS_PER_CYCLE
+  return candidates.sort((a, b) => b.projectedMonthlySavingsUsd - a.projectedMonthlySavingsUsd);
+}
+
+async function wasCellRecentlyMigrated(db: Db, tenantId: string | null, taskType: string, complexity: string): Promise<boolean> {
+  const cutoff = new Date(Date.now() - COOLDOWN_DAYS * 24 * 60 * 60 * 1000);
+  const row = await db
+    .select({ id: costMigrations.id })
+    .from(costMigrations)
+    .where(
+      and(
+        tenantId ? eq(costMigrations.tenantId, tenantId) : isNull(costMigrations.tenantId),
+        eq(costMigrations.taskType, taskType),
+        eq(costMigrations.complexity, complexity),
+        sql`${costMigrations.executedAt} > ${Math.floor(cutoff.getTime() / 1000)}`,
+      ),
+    )
+    .get();
+  return Boolean(row);
+}
+
+export interface ExecutedMigration {
+  id: string;
+  taskType: string;
+  complexity: string;
+  from: { provider: string; model: string };
+  to: { provider: string; model: string };
+  projectedMonthlySavingsUsd: number;
+}
+
+export async function executeMigration(
+  db: Db,
+  tenantId: string | null,
+  candidate: MigrationCandidate,
+): Promise<ExecutedMigration | null> {
+  if (await wasCellRecentlyMigrated(db, tenantId, candidate.taskType, candidate.complexity)) {
+    return null;
+  }
+
+  const id = nanoid();
+  const graceEndsAt = new Date(Date.now() + GRACE_DAYS * 24 * 60 * 60 * 1000);
+  await db
+    .insert(costMigrations)
+    .values({
+      id,
+      tenantId,
+      taskType: candidate.taskType,
+      complexity: candidate.complexity,
+      fromProvider: candidate.from.provider,
+      fromModel: candidate.from.model,
+      fromCostPer1M: candidate.from.costPer1M,
+      fromQualityScore: candidate.from.qualityScore,
+      toProvider: candidate.to.provider,
+      toModel: candidate.to.model,
+      toCostPer1M: candidate.to.costPer1M,
+      toQualityScore: candidate.to.qualityScore,
+      projectedMonthlySavingsUsd: candidate.projectedMonthlySavingsUsd,
+      graceEndsAt,
+    })
+    .run();
+
+  console.log(
+    `[cost-migration] ${candidate.taskType}+${candidate.complexity}: ${candidate.from.provider}/${candidate.from.model} → ${candidate.to.provider}/${candidate.to.model} (save $${candidate.projectedMonthlySavingsUsd.toFixed(2)}/mo)`,
+  );
+
+  return {
+    id,
+    taskType: candidate.taskType,
+    complexity: candidate.complexity,
+    from: { provider: candidate.from.provider, model: candidate.from.model },
+    to: { provider: candidate.to.provider, model: candidate.to.model },
+    projectedMonthlySavingsUsd: candidate.projectedMonthlySavingsUsd,
+  };
+}
+
+export interface MigrationCycleStats {
+  evaluated: number;
+  executed: ExecutedMigration[];
+  skippedCooldown: number;
+}
+
+export async function runCostMigrationCycle(db: Db): Promise<MigrationCycleStats> {
+  const enabled = await isCostMigrationEnabled(db, null);
+  if (!enabled) {
+    return { evaluated: 0, executed: [], skippedCooldown: 0 };
+  }
+
+  const candidates = await findMigrationCandidates(db);
+  const executed: ExecutedMigration[] = [];
+  let skipped = 0;
+
+  for (const candidate of candidates) {
+    if (executed.length >= MAX_MIGRATIONS_PER_CYCLE) break;
+    const result = await executeMigration(db, null, candidate);
+    if (result) executed.push(result);
+    else skipped++;
+  }
+
+  return { evaluated: candidates.length, executed, skippedCooldown: skipped };
+}
+
+/**
+ * In-memory grace-boost table. The adaptive router consults this on every
+ * routing decision to give migration targets a temporary EMA nudge during
+ * the grace window. Loaded from DB at boot; callers must `refresh()` after
+ * a new migration fires to pick it up without a restart.
+ */
+export interface BoostTable {
+  getBoost(taskType: string, complexity: string, provider: string, model: string): number;
+  refresh(): Promise<void>;
+}
+
+export function createBoostTable(db: Db): BoostTable {
+  const boosts = new Map<string, number>();
+
+  function key(taskType: string, complexity: string, provider: string, model: string): string {
+    return `${taskType}::${complexity}::${provider}::${model}`;
+  }
+
+  async function refresh(): Promise<void> {
+    boosts.clear();
+    const now = new Date();
+    const active = await db
+      .select()
+      .from(costMigrations)
+      .where(
+        and(
+          isNull(costMigrations.rolledBackAt),
+          gt(costMigrations.graceEndsAt, now),
+        ),
+      )
+      .all();
+    for (const row of active) {
+      boosts.set(key(row.taskType, row.complexity, row.toProvider, row.toModel), GRACE_BOOST);
+    }
+  }
+
+  function getBoost(taskType: string, complexity: string, provider: string, model: string): number {
+    return boosts.get(key(taskType, complexity, provider, model)) ?? 0;
+  }
+
+  return { getBoost, refresh };
+}
+
+export async function listMigrations(db: Db, tenantId: string | null, limit = 100) {
+  const where = tenantId ? eq(costMigrations.tenantId, tenantId) : isNull(costMigrations.tenantId);
+  return db
+    .select()
+    .from(costMigrations)
+    .where(where)
+    .orderBy(desc(costMigrations.executedAt))
+    .limit(limit)
+    .all();
+}
+
+export async function rollbackMigration(
+  db: Db,
+  id: string,
+  reason: string,
+): Promise<boolean> {
+  const row = await db.select().from(costMigrations).where(eq(costMigrations.id, id)).get();
+  if (!row || row.rolledBackAt) return false;
+  await db
+    .update(costMigrations)
+    .set({ rolledBackAt: new Date(), rollbackReason: reason })
+    .where(eq(costMigrations.id, id))
+    .run();
+  return true;
+}
+
+export async function totalSavingsThisMonth(db: Db, tenantId: string | null): Promise<number> {
+  const monthStart = new Date();
+  monthStart.setUTCDate(1);
+  monthStart.setUTCHours(0, 0, 0, 0);
+
+  const rows = await db
+    .select({ projected: costMigrations.projectedMonthlySavingsUsd })
+    .from(costMigrations)
+    .where(
+      and(
+        tenantId ? eq(costMigrations.tenantId, tenantId) : isNull(costMigrations.tenantId),
+        isNull(costMigrations.rolledBackAt),
+        sql`${costMigrations.executedAt} >= ${Math.floor(monthStart.getTime() / 1000)}`,
+      ),
+    )
+    .all();
+  return rows.reduce((s, r) => s + r.projected, 0);
+}

--- a/packages/gateway/src/routing/adaptive/router.ts
+++ b/packages/gateway/src/routing/adaptive/router.ts
@@ -11,13 +11,24 @@ import type { FeedbackSource, ModelScore, RoutingProfile, RoutingWeights } from 
 export type AdaptiveRouter = Awaited<ReturnType<typeof createAdaptiveRouter>>;
 
 /**
+ * Optional quality-score boost lookup, e.g. the grace boost added by
+ * #153 cost migrations. When unset, no boost is applied. Kept as a
+ * callback so the router doesn't need to know about migration state
+ * directly — whoever constructs the router wires this in.
+ */
+export interface AdaptiveRouterOptions {
+  getScoreBoost?: (taskType: string, complexity: string, provider: string, model: string) => number;
+}
+
+/**
  * Build an adaptive router wired to `db` as the durable source of truth.
  * The in-memory score store is hydrated at construction time and stays in
  * sync via `updateScore` / `updateLatency`. Single-process constraints
  * apply — see `score-store.ts` for the horizontal-scaling note.
  */
-export async function createAdaptiveRouter(db: Db) {
+export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOptions = {}) {
   const store: ScoreStore = createScoreStore();
+  const getScoreBoost = options.getScoreBoost ?? (() => 0);
 
   async function updateScore(
     taskType: string,
@@ -106,8 +117,12 @@ export async function createAdaptiveRouter(db: Db) {
     let best: { target: RouteTarget; score: number } | null = null;
 
     for (const candidate of candidates) {
+      // Grace boost (#153) nudges migration targets up during their window
+      // without mutating the underlying EMA — normal routing wins back if
+      // the migration picked wrong once the boost expires.
+      const boost = getScoreBoost(taskType, complexity, candidate.provider, candidate.model);
       const score = computeRouteScore(
-        candidate.qualityScore,
+        candidate.qualityScore + boost,
         candidate.costPer1M,
         candidate.avgLatencyMs,
         weights,

--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -8,6 +8,7 @@ import type { RoutingResult, RouteTarget } from "./types.js";
 import { classifyRequest } from "../classifier/index.js";
 import { selectVariant } from "../ab/index.js";
 import { createAdaptiveRouter, type RoutingProfile, type RoutingWeights } from "./adaptive/index.js";
+import { createBoostTable } from "./adaptive/migrations.js";
 import { getPricing } from "../cost/index.js";
 import { getRoutingConfig } from "./config.js";
 
@@ -30,7 +31,11 @@ export interface RoutingRequest {
 }
 
 export async function createRoutingEngine(config: RoutingEngineConfig) {
-  const adaptive = await createAdaptiveRouter(config.db);
+  const boostTable = createBoostTable(config.db);
+  await boostTable.refresh();
+  const adaptive = await createAdaptiveRouter(config.db, {
+    getScoreBoost: boostTable.getBoost,
+  });
 
   // Build dynamic fallback chain from all registered providers, sorted by cost (cheapest first)
   function buildDynamicFallbacks(registry: ProviderRegistry): RouteTarget[] {
@@ -242,5 +247,5 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
   }
 
   // Expose adaptive router for feedback updates and dashboard queries
-  return { route, adaptive };
+  return { route, adaptive, boostTable };
 }

--- a/packages/gateway/tests/cost-migrations.test.ts
+++ b/packages/gateway/tests/cost-migrations.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { modelScores, requests, costMigrations } from "@provara/db";
+import type { Db } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import {
+  EPSILON_QUALITY,
+  GRACE_BOOST,
+  MIGRATION_MIN_SAMPLES,
+  createBoostTable,
+  executeMigration,
+  findMigrationCandidates,
+  isCostMigrationEnabled,
+  listMigrations,
+  rollbackMigration,
+  runCostMigrationCycle,
+  setCostMigrationOptIn,
+  totalSavingsThisMonth,
+} from "../src/routing/adaptive/migrations.js";
+
+async function seedScore(
+  db: Db,
+  taskType: string,
+  complexity: string,
+  provider: string,
+  model: string,
+  qualityScore: number,
+  sampleCount = MIGRATION_MIN_SAMPLES,
+  updatedAt: Date = new Date(),
+) {
+  await db
+    .insert(modelScores)
+    .values({ taskType, complexity, provider, model, qualityScore, sampleCount, updatedAt })
+    .run();
+}
+
+async function seedRequests(db: Db, params: { provider: string; model: string; taskType: string; complexity: string; count: number; avgInputTokens?: number; avgOutputTokens?: number }) {
+  for (let i = 0; i < params.count; i++) {
+    await db.insert(requests).values({
+      id: `r-${params.provider}-${params.model}-${params.taskType}-${params.complexity}-${i}`,
+      provider: params.provider,
+      model: params.model,
+      prompt: "test",
+      taskType: params.taskType,
+      complexity: params.complexity,
+      inputTokens: params.avgInputTokens ?? 1000,
+      outputTokens: params.avgOutputTokens ?? 500,
+      createdAt: new Date(),
+    }).run();
+  }
+}
+
+describe("findMigrationCandidates", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("flags cells where a cheaper model holds quality within epsilon", async () => {
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4);
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].from.model).toBe("gpt-4o");
+    expect(candidates[0].to.model).toBe("gpt-4o-mini");
+  });
+
+  it("skips cells where cheaper model's quality drops beyond epsilon", async () => {
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.5 - EPSILON_QUALITY - 0.1);
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("skips cells where cheaper model isn't cheap enough", async () => {
+    // Both gpt-4o at same quality — no cost advantage
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "anthropic", "claude-sonnet-4-6", 4.4);
+    // gpt-4o=12.5, sonnet=18 — not cheaper
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("requires MIGRATION_MIN_SAMPLES samples (stricter than routing)", async () => {
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5, MIGRATION_MIN_SAMPLES);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4, MIGRATION_MIN_SAMPLES - 1);
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("skips stale cells (updatedAt older than 30 days)", async () => {
+    const staleDate = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5, MIGRATION_MIN_SAMPLES, staleDate);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4, MIGRATION_MIN_SAMPLES, staleDate);
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(0);
+  });
+
+  it("sorts by projected savings descending", async () => {
+    // Cell A: heavy traffic, modest cost diff
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4);
+    await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "complex", count: 100 });
+
+    // Cell B: light traffic, similar cost diff
+    await seedScore(db, "qa", "simple", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "qa", "simple", "openai", "gpt-4o-mini", 4.4);
+    await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "qa", complexity: "simple", count: 10 });
+
+    const candidates = await findMigrationCandidates(db);
+    expect(candidates).toHaveLength(2);
+    // Coding+complex should outrank qa+simple (more traffic)
+    expect(candidates[0].taskType).toBe("coding");
+    expect(candidates[0].projectedMonthlySavingsUsd).toBeGreaterThan(candidates[1].projectedMonthlySavingsUsd);
+  });
+});
+
+describe("executeMigration / cooldown", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  const candidate = {
+    taskType: "coding",
+    complexity: "complex",
+    from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+    to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+    projectedMonthlySavingsUsd: 42,
+  };
+
+  it("creates a cost_migrations row with grace window", async () => {
+    const result = await executeMigration(db, null, candidate);
+    expect(result).not.toBeNull();
+    const row = await db.select().from(costMigrations).where(eq(costMigrations.id, result!.id)).get();
+    expect(row?.fromModel).toBe("gpt-4o");
+    expect(row?.toModel).toBe("gpt-4o-mini");
+    expect(row?.graceEndsAt).toBeTruthy();
+    expect(row?.graceEndsAt!.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("returns null when the same cell was migrated recently", async () => {
+    const first = await executeMigration(db, null, candidate);
+    expect(first).not.toBeNull();
+    const second = await executeMigration(db, null, candidate);
+    expect(second).toBeNull();
+  });
+
+  it("allows re-migration after cooldown elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = new Date("2026-01-01T00:00:00Z");
+      vi.setSystemTime(start);
+      await executeMigration(db, null, candidate);
+
+      vi.setSystemTime(new Date(start.getTime() + 31 * 24 * 60 * 60 * 1000));
+      const again = await executeMigration(db, null, candidate);
+      expect(again).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("createBoostTable", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("returns 0 boost when no active migrations exist", async () => {
+    const bt = createBoostTable(db);
+    await bt.refresh();
+    expect(bt.getBoost("coding", "complex", "openai", "gpt-4o-mini")).toBe(0);
+  });
+
+  it("returns GRACE_BOOST for the target of an active migration", async () => {
+    await executeMigration(db, null, {
+      taskType: "coding",
+      complexity: "complex",
+      from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+      to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+      projectedMonthlySavingsUsd: 10,
+    });
+
+    const bt = createBoostTable(db);
+    await bt.refresh();
+    expect(bt.getBoost("coding", "complex", "openai", "gpt-4o-mini")).toBe(GRACE_BOOST);
+    expect(bt.getBoost("coding", "complex", "openai", "gpt-4o")).toBe(0);
+  });
+
+  it("drops the boost after rollback", async () => {
+    const result = await executeMigration(db, null, {
+      taskType: "coding",
+      complexity: "complex",
+      from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+      to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+      projectedMonthlySavingsUsd: 10,
+    });
+
+    const bt = createBoostTable(db);
+    await bt.refresh();
+    expect(bt.getBoost("coding", "complex", "openai", "gpt-4o-mini")).toBe(GRACE_BOOST);
+
+    await rollbackMigration(db, result!.id, "test");
+    await bt.refresh();
+    expect(bt.getBoost("coding", "complex", "openai", "gpt-4o-mini")).toBe(0);
+  });
+});
+
+describe("runCostMigrationCycle", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("no-ops when global opt-in is disabled", async () => {
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4);
+
+    const stats = await runCostMigrationCycle(db);
+    expect(stats.executed).toHaveLength(0);
+  });
+
+  it("executes eligible migrations once opted in", async () => {
+    await setCostMigrationOptIn(db, null, true);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o", 4.5);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4o-mini", 4.4);
+    await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "complex", count: 50 });
+
+    const stats = await runCostMigrationCycle(db);
+    expect(stats.executed).toHaveLength(1);
+  });
+
+  it("respects the per-cycle cap", async () => {
+    await setCostMigrationOptIn(db, null, true);
+    for (let i = 0; i < 5; i++) {
+      const tt = `task-${i}`;
+      await seedScore(db, tt, "complex", "openai", "gpt-4o", 4.5);
+      await seedScore(db, tt, "complex", "openai", "gpt-4o-mini", 4.4);
+    }
+    const stats = await runCostMigrationCycle(db);
+    expect(stats.executed.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("listMigrations + savings", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("totalSavingsThisMonth sums non-rolled-back migrations", async () => {
+    await executeMigration(db, null, {
+      taskType: "coding",
+      complexity: "complex",
+      from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+      to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+      projectedMonthlySavingsUsd: 42,
+    });
+    await executeMigration(db, null, {
+      taskType: "qa",
+      complexity: "simple",
+      from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+      to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+      projectedMonthlySavingsUsd: 20,
+    });
+
+    const total = await totalSavingsThisMonth(db, null);
+    expect(total).toBe(62);
+
+    const migrations = await listMigrations(db, null);
+    expect(migrations).toHaveLength(2);
+  });
+
+  it("excludes rolled-back migrations from savings", async () => {
+    const result = await executeMigration(db, null, {
+      taskType: "coding",
+      complexity: "complex",
+      from: { provider: "openai", model: "gpt-4o", qualityScore: 4.5, costPer1M: 12.5 },
+      to: { provider: "openai", model: "gpt-4o-mini", qualityScore: 4.4, costPer1M: 0.75 },
+      projectedMonthlySavingsUsd: 42,
+    });
+    await rollbackMigration(db, result!.id, "test");
+    const total = await totalSavingsThisMonth(db, null);
+    expect(total).toBe(0);
+  });
+});
+
+describe("opt-in roundtrip", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("defaults to disabled", async () => {
+    expect(await isCostMigrationEnabled(db, null)).toBe(false);
+    expect(await isCostMigrationEnabled(db, "t")).toBe(false);
+  });
+
+  it("toggles per tenant", async () => {
+    await setCostMigrationOptIn(db, "t-a", true);
+    expect(await isCostMigrationEnabled(db, "t-a")).toBe(true);
+    expect(await isCostMigrationEnabled(db, "t-b")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #153. Feature 3 of the scheduling-infra roadmap (#150) — completes the "must-do" trio with #151 and #152.

**What it does:** a nightly job scans the adaptive routing matrix for cells where a cheaper competitor holds quality within tolerance of the current winner. When it finds one, it records a migration and nudges the router to actually pick the cheaper model via a temporary EMA boost. The dashboard shows "projected monthly savings" for the operator, so the value prop is visible and quantifiable.

## What changed

**Schema** (migration 0022): new `cost_migrations` table — full audit trail with from/to cost, quality scores at migration time, projected savings, grace window, and rollback metadata.

**Gateway** (`routing/adaptive/migrations.ts`)
- `findMigrationCandidates` — cost ratio ≤ 0.8, quality gap ≤ 0.2 (env-configurable), `sampleCount ≥ MIN_SAMPLES × 2`, `updatedAt` within 30d
- `executeMigration` — idempotent w/ per-cell cooldown (default 30d)
- `createBoostTable` — in-memory grace-boost overlay the adaptive router consults on every routing decision; reloads from DB at boot and after every migration
- `runCostMigrationCycle` — full scheduler tick, respects per-run cap (default 3)
- `totalSavingsThisMonth`, `listMigrations`, `rollbackMigration`

**Adaptive router** — new optional `getScoreBoost` callback. Non-invasive: boosts are applied at scoring time without mutating the underlying EMA, so normal signal recovery happens automatically if the migration picked wrong once the grace window closes.

**Routes** (`/v1/cost-migrations/*`)
- `GET /status` — opt-in state, savings this month
- `POST /opt-in` — tenant toggle
- `GET /` — list migrations (active + rolled back)
- `POST /run` — trigger a cycle manually
- `POST /:id/rollback` — rollback with reason, refreshes boost table

**UI** — new `MigrationsPanel` on `/dashboard/routing`
- Opt-in toggle, three-tile header (projected savings / active / rolled back)
- Active migrations table with per-row "from → to" with quality + $/1M metadata and grace-end date, rollback action
- Rolled-back history in collapsible `<details>`

**Env knobs**
- `PROVARA_COST_MIGRATION_EPSILON` (0.2 quality tolerance)
- `PROVARA_COST_MIGRATION_RATIO` (0.8 cost-ratio ceiling)
- `PROVARA_COST_MIGRATION_GRACE_BOOST` (0.3 EMA boost), `PROVARA_COST_MIGRATION_GRACE_DAYS` (30d)
- `PROVARA_COST_MIGRATION_COOLDOWN_DAYS` (30d per cell)
- `PROVARA_COST_MIGRATION_MAX_PER_CYCLE` (3), `PROVARA_COST_MIGRATION_INTERVAL_MS` (24h)

## Test plan

- [x] `npx vitest run` — 146/146 pass (19 new)
- [x] `tsc --noEmit` clean for gateway, db, web
- [ ] Manual smoke: opt in, seed scores with a cheap competitor, `POST /v1/cost-migrations/run`, verify the migration fires, refresh heatmap — cheaper model should now win on that cell
- [ ] Manual smoke: rollback via dashboard, confirm grace boost is cleared and router reverts

## Notes

- Works alongside #152: a regression detected on a migration target is signal to roll back — future wiring can automate this, v1 leaves it manual
- Shares the scheduler primitive from #151, zero new infrastructure — three features, one scheduler
- Boost table hot-reloads after every migration; no restart required

With this PR, the three flagship features from #150 ship together. Backlog items 4 (prompt template drift) and 5 (federated intelligence) remain in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
