### PR TITLE
fix(#157): Active Providers count from registry, not request history

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -135,7 +135,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
 
   // Mount analytics routes
-  app.route("/v1/analytics", createAnalyticsRoutes(ctx.db));
+  app.route("/v1/analytics", createAnalyticsRoutes(ctx.db, ctx.registry));
 
   // Mount API key management routes
   app.route("/v1/api-keys", createApiKeyRoutes(ctx.db));

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -4,6 +4,19 @@ import { requests, costLogs, abTests, feedback } from "@provara/db";
 import { desc, asc, sql, eq, and, gte } from "drizzle-orm";
 import type { SQLWrapper } from "drizzle-orm";
 import { getTenantId } from "../auth/tenant.js";
+import type { ProviderRegistry } from "../providers/index.js";
+
+/**
+ * Count providers that are currently ready to accept a routing decision.
+ * The registry registers a provider unconditionally when its module loads
+ * (Ollama in particular always registers even when the server is
+ * unreachable), so we require `models.length > 0` as a liveness proxy —
+ * reachable providers always resolve at least one model, unreachable
+ * ones come back empty after the startup discovery pass.
+ */
+function countLiveProviders(registry: ProviderRegistry): number {
+  return registry.list().filter((p) => p.models.length > 0).length;
+}
 
 // Whitelist of columns exposed to client-driven sort on /requests. Never map
 // raw user input into a SQL expression — anything not in this table silently
@@ -21,7 +34,7 @@ const REQUESTS_SORT_COLUMNS: Record<string, SQLWrapper> = {
   cost: costLogs.cost,
 };
 
-export function createAnalyticsRoutes(db: Db) {
+export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
   const app = new Hono();
 
   // List recent requests with pagination
@@ -238,17 +251,16 @@ export function createAnalyticsRoutes(db: Db) {
     const totalCost = await db.select({ total: sql<number>`sum(${costLogs.cost})` }).from(costLogs).where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined).get();
     const avgLatency = await db.select({ avg: sql<number>`avg(${requests.latencyMs})` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
 
-    const providerCount = await db
-      .select({ count: sql<number>`count(distinct ${requests.provider})` })
-      .from(requests)
-      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
-      .get();
+    // Authoritative source for "active providers" is the registry, not the
+    // requests table — historical distinct-count conflated "ever routed
+    // through" with "ready to route," see #157.
+    const providerCount = registry ? countLiveProviders(registry) : 0;
 
     return c.json({
       totalRequests: totalRequests?.count || 0,
       totalCost: totalCost?.total || 0,
       avgLatency: avgLatency?.avg || 0,
-      providerCount: providerCount?.count || 0,
+      providerCount,
     });
   });
 
@@ -359,12 +371,8 @@ export function createAnalyticsRoutes(db: Db) {
       .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
       .get();
 
-    // Provider count
-    const providerCount = await db
-      .select({ count: sql<number>`count(distinct ${requests.provider})` })
-      .from(requests)
-      .where(tenantFilter)
-      .get();
+    // Active provider count — registry is authoritative (see #157).
+    const providerCount = registry ? countLiveProviders(registry) : 0;
 
     // Total requests
     const totalRequests = await db
@@ -426,7 +434,7 @@ export function createAnalyticsRoutes(db: Db) {
         providers: {
           count: totalRequests?.count || 0,
           active: true,
-          providerCount: providerCount?.count || 0,
+          providerCount,
         },
       },
     });

--- a/packages/gateway/tests/overview-provider-count.test.ts
+++ b/packages/gateway/tests/overview-provider-count.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { Hono } from "hono";
+import { requests } from "@provara/db";
+import { nanoid } from "nanoid";
+import { createAnalyticsRoutes } from "../src/routes/analytics.js";
+import { makeTestDb } from "./_setup/db.js";
+import type { Provider, ProviderRegistry } from "../src/providers/index.js";
+
+function mockRegistry(providers: Array<{ name: string; models: string[] }>): ProviderRegistry {
+  const mapped: Provider[] = providers.map((p) => ({
+    name: p.name,
+    models: p.models,
+    async complete() {
+      throw new Error("mock");
+    },
+    async *stream() {},
+  }));
+  return {
+    get: (name: string) => mapped.find((p) => p.name === name),
+    list: () => mapped,
+    refreshModels: async () => [],
+  } as unknown as ProviderRegistry;
+}
+
+async function buildApp(registry?: ProviderRegistry) {
+  const db = await makeTestDb();
+  const app = new Hono();
+  app.route("/v1/analytics", createAnalyticsRoutes(db, registry));
+  return { db, app };
+}
+
+describe("overview providerCount uses the registry, not request history (#157)", () => {
+  it("counts providers whose models list is non-empty", async () => {
+    const registry = mockRegistry([
+      { name: "openai", models: ["gpt-4o", "gpt-4o-mini"] },
+      { name: "anthropic", models: ["claude-sonnet-4-6"] },
+      { name: "google", models: ["gemini-2.5-pro"] },
+      { name: "mistral", models: ["mistral-large-latest"] },
+      { name: "xai", models: ["grok-2"] },
+      { name: "zai", models: ["glm-4"] },
+      { name: "openrouter", models: ["openrouter/mixture"] },
+      { name: "together", models: ["llama-3"] },
+    ]);
+    const { app } = await buildApp(registry);
+    const res = await app.request("/v1/analytics/overview");
+    const body = await res.json();
+    expect(body.providerCount).toBe(8);
+  });
+
+  it("excludes providers with no discovered models (unreachable Ollama case)", async () => {
+    const registry = mockRegistry([
+      { name: "openai", models: ["gpt-4o"] },
+      { name: "anthropic", models: ["claude-sonnet-4-6"] },
+      { name: "ollama", models: [] }, // registered but unreachable
+    ]);
+    const { app } = await buildApp(registry);
+    const res = await app.request("/v1/analytics/overview");
+    const body = await res.json();
+    expect(body.providerCount).toBe(2);
+  });
+
+  it("ignores historical request rows — count comes from the live registry only", async () => {
+    const registry = mockRegistry([
+      { name: "openai", models: ["gpt-4o"] },
+      { name: "anthropic", models: ["claude-sonnet-4-6"] },
+    ]);
+    const { db, app } = await buildApp(registry);
+
+    // Seed requests for a provider that is no longer registered
+    await db.insert(requests).values({
+      id: nanoid(),
+      provider: "legacy-provider",
+      model: "retired-model",
+      prompt: "x",
+      response: "y",
+    }).run();
+
+    const res = await app.request("/v1/analytics/overview");
+    const body = await res.json();
+    // Old reporting would have said 1 (legacy-provider). Registry-backed is 2.
+    expect(body.providerCount).toBe(2);
+  });
+
+  it("returns 0 when no registry is wired (backward-compat)", async () => {
+    const { app } = await buildApp();
+    const res = await app.request("/v1/analytics/overview");
+    const body = await res.json();
+    expect(body.providerCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #157. Fixes the misleading "Active Providers" stat on the dashboard Overview — it was reading historical traffic, showing 3 on a Railway instance that had 8 providers configured and ready to route.

## What changed

- `packages/gateway/src/routes/analytics.ts` — overview endpoint now takes an optional `ProviderRegistry` and returns `registry.list().filter(p => p.models.length > 0).length`. Same swap in the routing-pipeline endpoint's `providers` block.
- `packages/gateway/src/router.ts` — threads `ctx.registry` into `createAnalyticsRoutes`.
- Four new tests (see issue T3).

**Why models-length as the liveness proxy:** Ollama registers unconditionally (it's always in the registry even when the server is unreachable). Reachable providers come back with at least one model after the startup discovery pass; unreachable ones end up with an empty list. Using `models.length > 0` means Ollama only counts when it's actually reachable.

## Notes on the provider on/off UI question

Recommend skipping. The existing flow (delete the API key on `/dashboard/api-keys`) already produces the exact same result — the registry drops the provider on refresh. Adding a separate toggle would just create a second form of state ("disabled-but-keyed") that diverges from the behavioral truth. If we ever want a softer action than full deletion, a "soft-disable without deleting the encrypted key" toggle could land as its own issue, but it's not worth coupling to this bug fix.

## Test plan

- [x] `npx vitest run` — 150/150 pass (4 new)
- [x] `tsc --noEmit` clean for gateway
- [ ] Manual smoke on Railway: card should now read 8 with Ollama excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
