### PR TITLE
fix(#160): restrict replay bank to judge-scored entries + dedupe events

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,20 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 | `GET/POST/PATCH/DELETE /v1/admin/providers` | Manage custom providers |
 | `GET/PATCH/DELETE /v1/admin/team` | Team member management |
 | `POST /v1/providers/reload` | Hot-reload providers after key changes |
+| **Regression Detection** (#152) | |
+| `GET /v1/regression/status` | Opt-in state, replay-bank size, weekly spend |
+| `POST /v1/regression/opt-in` | Toggle silent-regression detection |
+| `GET /v1/regression/events` | Tenant-scoped regression history (`?unresolvedOnly=true`) |
+| `POST /v1/regression/events/:id/resolve` | Dismiss or mark resolved with a note |
+| **Cost Migrations** (#153) | |
+| `GET /v1/cost-migrations/status` | Opt-in state, monthly projected savings |
+| `POST /v1/cost-migrations/opt-in` | Toggle auto cost migration |
+| `GET /v1/cost-migrations` | List executed migrations (active + rolled back) |
+| `POST /v1/cost-migrations/run` | Trigger a migration cycle manually |
+| `POST /v1/cost-migrations/:id/rollback` | Roll back a migration + clear grace boost |
+| **Scheduler** (owner only) | |
+| `GET /v1/admin/scheduler/jobs` | List registered jobs with last-run state |
+| `POST /v1/admin/scheduler/jobs/:name/run` | Trigger a job immediately |
 | **Auth** (multi-tenant only) | |
 | `GET /auth/login/google` | Google OAuth login |
 | `GET /auth/login/github` | GitHub OAuth login |

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -1147,6 +1147,266 @@ paths:
                         tokensSavedOutput: { type: integer }
                         hits: { type: integer }
 
+  /v1/regression/status:
+    get:
+      tags: [Regression Detection]
+      summary: Opt-in state, bank size, and weekly budget usage
+      description: |
+        Returns whether silent-regression detection is enabled for the caller's
+        tenant (#152), the number of prompts currently stored in the replay bank,
+        and the USD spent this ISO week against the replay budget.
+      operationId: regressionStatus
+      responses:
+        "200":
+          description: Status payload
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [enabled, budget, bankSize, defaultWeeklyBudgetUsd]
+                properties:
+                  enabled: { type: boolean }
+                  bankSize: { type: integer }
+                  defaultWeeklyBudgetUsd: { type: number }
+                  budget:
+                    type: object
+                    properties:
+                      used: { type: number }
+                      limit: { type: number }
+                      remaining: { type: number }
+
+  /v1/regression/opt-in:
+    post:
+      tags: [Regression Detection]
+      summary: Toggle regression detection for the caller's tenant
+      operationId: regressionOptIn
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses:
+        "200":
+          description: Updated state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled: { type: boolean }
+
+  /v1/regression/events:
+    get:
+      tags: [Regression Detection]
+      summary: List regression events
+      description: |
+        Tenant-scoped detection history. Each event captures the cell, the
+        baseline mean vs replay mean, the delta, and the judge-spend cost.
+      operationId: listRegressionEvents
+      parameters:
+        - name: unresolvedOnly
+          in: query
+          schema: { type: boolean }
+          description: When true, only return events with `resolvedAt` null.
+      responses:
+        "200":
+          description: Events
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/RegressionEvent"
+
+  /v1/regression/events/{id}/resolve:
+    post:
+      tags: [Regression Detection]
+      summary: Mark a regression event resolved
+      operationId: resolveRegressionEvent
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note: { type: string }
+      responses:
+        "200":
+          description: Resolved
+        "404":
+          description: Event not found
+
+  /v1/cost-migrations/status:
+    get:
+      tags: [Cost Migrations]
+      summary: Opt-in state and monthly projected savings
+      description: |
+        Reports whether auto cost migration (#153) is enabled for the caller's
+        tenant plus the sum of projected-monthly savings from executed, non-
+        rolled-back migrations this month.
+      operationId: costMigrationStatus
+      responses:
+        "200":
+          description: Status payload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  enabled: { type: boolean }
+                  savingsThisMonth: { type: number }
+
+  /v1/cost-migrations/opt-in:
+    post:
+      tags: [Cost Migrations]
+      summary: Toggle auto cost migration
+      operationId: costMigrationOptIn
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [enabled]
+              properties:
+                enabled: { type: boolean }
+      responses:
+        "200":
+          description: Updated state
+
+  /v1/cost-migrations:
+    get:
+      tags: [Cost Migrations]
+      summary: List executed migrations
+      description: |
+        Tenant-scoped. Includes active (within grace window or past grace but
+        not rolled back) and rolled-back entries; distinguish via `rolledBackAt`.
+      operationId: listCostMigrations
+      responses:
+        "200":
+          description: Migrations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  migrations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CostMigration"
+
+  /v1/cost-migrations/run:
+    post:
+      tags: [Cost Migrations]
+      summary: Trigger a migration cycle manually
+      description: |
+        Runs the same logic the nightly scheduler runs (candidate detection,
+        per-cycle cap, cooldown checks, grace-boost refresh) on demand. Useful
+        in demos and during incident response.
+      operationId: runCostMigrationCycle
+      responses:
+        "200":
+          description: Cycle stats
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  evaluated: { type: integer }
+                  skippedCooldown: { type: integer }
+                  executed:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        taskType: { type: string }
+                        complexity: { type: string }
+                        projectedMonthlySavingsUsd: { type: number }
+
+  /v1/cost-migrations/{id}/rollback:
+    post:
+      tags: [Cost Migrations]
+      summary: Roll back a migration
+      description: Clears the grace boost for the migration target and stamps a rollback reason for audit.
+      operationId: rollbackCostMigration
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: string }
+      responses:
+        "200":
+          description: Rolled back
+        "404":
+          description: Migration not found or already rolled back
+
+  /v1/admin/scheduler/jobs:
+    get:
+      tags: [Scheduler]
+      summary: List scheduler jobs and their last-run state
+      description: |
+        Owner-only. Returns every job registered on the in-process scheduler
+        (auto-ab, replay-bank-populate, replay-execute, cost-migration, …)
+        with its interval, enabled flag, run count, and the outcome of its
+        most recent execution.
+      operationId: listSchedulerJobs
+      responses:
+        "200":
+          description: Jobs
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jobs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SchedulerJob"
+        "401":
+          description: Not authenticated
+        "403":
+          description: Not authorized (owner role required)
+
+  /v1/admin/scheduler/jobs/{name}/run:
+    post:
+      tags: [Scheduler]
+      summary: Trigger a scheduled job immediately
+      description: Owner-only. Runs the named job synchronously, respecting the in-progress guard.
+      operationId: runSchedulerJob
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema: { type: string }
+          description: Job name, e.g. `auto-ab`, `replay-execute`, `cost-migration`.
+      responses:
+        "200":
+          description: Ran (or recorded as skipped if already running)
+        "404":
+          description: Unknown job
+        "503":
+          description: Scheduler not wired into this deployment
+
 components:
   securitySchemes:
     BearerAuth:
@@ -1482,6 +1742,63 @@ components:
           type: number
           description: ε-greedy exploration rate (only present on the `exploration` stage)
 
+    RegressionEvent:
+      type: object
+      required: [id, taskType, complexity, provider, model, replayCount, originalMean, replayMean, delta, costUsd, detectedAt]
+      properties:
+        id: { type: string }
+        tenantId: { type: string, nullable: true }
+        taskType: { type: string }
+        complexity: { type: string }
+        provider: { type: string }
+        model: { type: string }
+        replayCount: { type: integer }
+        originalMean: { type: number, description: "Mean baseline score at capture time (1–5)" }
+        replayMean: { type: number, description: "Mean judge score on re-runs (1–5)" }
+        delta: { type: number, description: "replayMean − originalMean. Negative = regression." }
+        costUsd: { type: number, description: "Total judge + replay API spend this detection cycle." }
+        detectedAt: { type: string, format: date-time }
+        resolvedAt: { type: string, format: date-time, nullable: true }
+        resolutionNote: { type: string, nullable: true }
+
+    CostMigration:
+      type: object
+      required: [id, taskType, complexity, fromProvider, fromModel, toProvider, toModel, projectedMonthlySavingsUsd, graceEndsAt, executedAt]
+      properties:
+        id: { type: string }
+        tenantId: { type: string, nullable: true }
+        taskType: { type: string }
+        complexity: { type: string }
+        fromProvider: { type: string }
+        fromModel: { type: string }
+        fromCostPer1M: { type: number }
+        fromQualityScore: { type: number }
+        toProvider: { type: string }
+        toModel: { type: string }
+        toCostPer1M: { type: number }
+        toQualityScore: { type: number }
+        projectedMonthlySavingsUsd: { type: number }
+        graceEndsAt: { type: string, format: date-time }
+        executedAt: { type: string, format: date-time }
+        rolledBackAt: { type: string, format: date-time, nullable: true }
+        rollbackReason: { type: string, nullable: true }
+
+    SchedulerJob:
+      type: object
+      required: [name, enabled, intervalMs, runCount]
+      properties:
+        name: { type: string }
+        enabled: { type: boolean }
+        intervalMs: { type: integer }
+        runCount: { type: integer }
+        lastRunAt: { type: string, format: date-time, nullable: true }
+        lastStatus:
+          type: string
+          enum: [ok, error, skipped]
+          nullable: true
+        lastError: { type: string, nullable: true }
+        lastDurationMs: { type: integer, nullable: true }
+
     PipelineStats:
       type: object
       required: [totalRequests, stages]
@@ -1531,5 +1848,11 @@ tags:
     description: Registering additional OpenAI-compatible providers.
   - name: Cache
     description: Completion cache inspection.
+  - name: Regression Detection
+    description: Prompt replay bank, regression events, and weekly replay-budget status (#152).
+  - name: Cost Migrations
+    description: Quality-gated automated cost migrations and rollback (#153).
+  - name: Scheduler
+    description: In-process background job runner — list state and trigger jobs on demand (#151–#153).
   - name: System
     description: Health and meta endpoints.

--- a/packages/gateway/src/routing/adaptive/regression.ts
+++ b/packages/gateway/src/routing/adaptive/regression.ts
@@ -128,6 +128,12 @@ async function distinctEligibleCells(db: Db): Promise<CellGroup[]> {
  * requests for the (tenant, cell, model) combo, joined with their
  * feedback score. Returns candidates sorted by recency — embedding-based
  * diversity filtering happens in `populateBankForCell`.
+ *
+ * Only judge-scored feedback qualifies (#160). User ratings are systematically
+ * more generous than the judge ("A 5 should be rare" per the judge prompt),
+ * so mixing user baselines with judge replays produced a consistent false-
+ * positive regression signal on every cell. Restricting to judge source
+ * means baseline and replay come from the same grader — apples to apples.
  */
 async function fetchCandidates(db: Db, cell: CellGroup, limit = 200) {
   const baseWhere = and(
@@ -151,6 +157,7 @@ async function fetchCandidates(db: Db, cell: CellGroup, limit = 200) {
     .where(
       and(
         baseWhere,
+        eq(feedback.source, "judge"),
         sql`${feedback.score} >= ${REPLAY_BANK_MIN_SCORE}`,
       ),
     )
@@ -461,22 +468,57 @@ export async function runReplayCycle(
       const replayMean = mean(replayScores);
       const delta = replayMean - originalMean;
       if (delta <= REGRESSION_DELTA_THRESHOLD) {
-        await db
-          .insert(regressionEvents)
-          .values({
-            id: nanoid(),
-            tenantId: cell.tenantId,
-            taskType: cell.taskType,
-            complexity: cell.complexity,
-            provider: cell.provider,
-            model: cell.model,
-            replayCount: replayScores.length,
-            originalMean,
-            replayMean,
-            delta,
-            costUsd: cellCost,
-          })
-          .run();
+        // Dedupe (#160): if an unresolved event already exists for this
+        // (tenant, cell, model), update it in place with the latest
+        // measurements and accumulate cost. Preserve `detectedAt` so the UI
+        // continues to show "this has been regressing since X". Once the
+        // operator dismisses via `resolveRegressionEvent`, new events can
+        // fire again on the next cycle.
+        const existing = await db
+          .select()
+          .from(regressionEvents)
+          .where(
+            and(
+              cell.tenantId ? eq(regressionEvents.tenantId, cell.tenantId) : isNull(regressionEvents.tenantId),
+              eq(regressionEvents.taskType, cell.taskType),
+              eq(regressionEvents.complexity, cell.complexity),
+              eq(regressionEvents.provider, cell.provider),
+              eq(regressionEvents.model, cell.model),
+              isNull(regressionEvents.resolvedAt),
+            ),
+          )
+          .get();
+
+        if (existing) {
+          await db
+            .update(regressionEvents)
+            .set({
+              replayCount: replayScores.length,
+              originalMean,
+              replayMean,
+              delta,
+              costUsd: existing.costUsd + cellCost,
+            })
+            .where(eq(regressionEvents.id, existing.id))
+            .run();
+        } else {
+          await db
+            .insert(regressionEvents)
+            .values({
+              id: nanoid(),
+              tenantId: cell.tenantId,
+              taskType: cell.taskType,
+              complexity: cell.complexity,
+              provider: cell.provider,
+              model: cell.model,
+              replayCount: replayScores.length,
+              originalMean,
+              replayMean,
+              delta,
+              costUsd: cellCost,
+            })
+            .run();
+        }
         stats.regressionsDetected++;
         console.warn(
           `[regression] detected ${cell.provider}/${cell.model} on ${cell.taskType}+${cell.complexity}: Δ=${delta.toFixed(2)}`,

--- a/packages/gateway/tests/regression.test.ts
+++ b/packages/gateway/tests/regression.test.ts
@@ -50,7 +50,7 @@ function makeRequestRow(
     .run();
 }
 
-function makeFeedbackRow(db: Db, requestId: string, score: number, source: "user" | "judge" = "user") {
+function makeFeedbackRow(db: Db, requestId: string, score: number, source: "user" | "judge" = "judge") {
   return db
     .insert(feedback)
     .values({
@@ -394,5 +394,158 @@ describe("listRegressionEvents / resolveRegressionEvent", () => {
   it("returns false when resolving a missing event", async () => {
     const ok = await resolveRegressionEvent(db, "missing", null);
     expect(ok).toBe(false);
+  });
+});
+
+describe("bank calibration: user-rated entries excluded (#160)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("user-rated prompts are NOT ingested into the bank", async () => {
+    await setRegressionOptIn(db, "t", true);
+
+    // Three judge-scored (should be banked), three user-rated (should NOT be)
+    for (let i = 0; i < 3; i++) {
+      await makeRequestRow(db, {
+        id: `j-${i}`,
+        tenantId: "t",
+        provider: "openai",
+        model: "gpt-4o",
+        taskType: "coding",
+        complexity: "complex",
+      });
+      await makeFeedbackRow(db, `j-${i}`, 5, "judge");
+    }
+    for (let i = 0; i < 3; i++) {
+      await makeRequestRow(db, {
+        id: `u-${i}`,
+        tenantId: "t",
+        provider: "openai",
+        model: "gpt-4o",
+        taskType: "coding",
+        complexity: "complex",
+      });
+      await makeFeedbackRow(db, `u-${i}`, 5, "user");
+    }
+
+    await runBankPopulationCycle(db, null);
+    const rows = await db.select().from(replayBank).all();
+    expect(rows).toHaveLength(3);
+    expect(rows.every((r) => r.originalScoreSource === "judge")).toBe(true);
+    expect(rows.map((r) => r.sourceRequestId).sort()).toEqual(["j-0", "j-1", "j-2"]);
+  });
+
+  it("a cell with only user-rated prompts produces an empty bank", async () => {
+    await setRegressionOptIn(db, "t", true);
+    for (let i = 0; i < 5; i++) {
+      await makeRequestRow(db, {
+        id: `u-${i}`,
+        tenantId: "t",
+        provider: "openai",
+        model: "gpt-4o",
+        taskType: "coding",
+        complexity: "complex",
+      });
+      await makeFeedbackRow(db, `u-${i}`, 5, "user");
+    }
+
+    const results = await runBankPopulationCycle(db, null);
+    expect(results).toHaveLength(0);
+    const rows = await db.select().from(replayBank).all();
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("regression event dedupe (#160)", () => {
+  let db: Db;
+
+  async function seedBankWithScores(tenantId: string, count: number, score = 5) {
+    for (let i = 0; i < count; i++) {
+      await db
+        .insert(replayBank)
+        .values({
+          id: `bank-${tenantId}-${i}`,
+          tenantId,
+          taskType: "coding",
+          complexity: "complex",
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: JSON.stringify([{ role: "user", content: `prompt ${i}` }]),
+          response: `orig ${i}`,
+          originalScore: score,
+          originalScoreSource: "judge",
+          sourceRequestId: `req-${i}`,
+        })
+        .run();
+      await makeRequestRow(db, {
+        id: `req-${i}-${tenantId}`,
+        tenantId,
+        provider: "openai",
+        model: "gpt-4o",
+        taskType: "coding",
+        complexity: "complex",
+      });
+    }
+  }
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("second replay cycle updates the existing unresolved event instead of duplicating", async () => {
+    await setRegressionOptIn(db, "t", true);
+    await seedBankWithScores("t", 3, 5);
+
+    const buildRegistry = () => mockRegistry(new Map([
+      ["openai::gpt-4o", [
+        { content: "weak 1" }, { content: "weak 2" }, { content: "weak 3" },
+      ]],
+      ["openai::judge", [
+        { content: '{"score": 2}' }, { content: '{"score": 2}' }, { content: '{"score": 2}' },
+      ]],
+    ]));
+
+    await runReplayCycle(db, buildRegistry(), { provider: "openai", model: "judge" });
+    const afterFirst = await db.select().from(regressionEvents).all();
+    expect(afterFirst).toHaveLength(1);
+    const firstDetectedAt = afterFirst[0].detectedAt;
+    const firstCost = afterFirst[0].costUsd;
+
+    await runReplayCycle(db, buildRegistry(), { provider: "openai", model: "judge" });
+    const afterSecond = await db.select().from(regressionEvents).all();
+    expect(afterSecond).toHaveLength(1);
+    expect(afterSecond[0].id).toBe(afterFirst[0].id);
+    expect(afterSecond[0].detectedAt.getTime()).toBe(firstDetectedAt.getTime());
+    // Cost accumulates across cycles
+    expect(afterSecond[0].costUsd).toBeGreaterThanOrEqual(firstCost);
+  });
+
+  it("a resolved event does not block a new event on the next regression", async () => {
+    await setRegressionOptIn(db, "t", true);
+    await seedBankWithScores("t", 3, 5);
+
+    const buildRegistry = () => mockRegistry(new Map([
+      ["openai::gpt-4o", [
+        { content: "weak 1" }, { content: "weak 2" }, { content: "weak 3" },
+      ]],
+      ["openai::judge", [
+        { content: '{"score": 2}' }, { content: '{"score": 2}' }, { content: '{"score": 2}' },
+      ]],
+    ]));
+
+    await runReplayCycle(db, buildRegistry(), { provider: "openai", model: "judge" });
+    const first = (await db.select().from(regressionEvents).all())[0];
+
+    // Operator dismisses
+    const { resolveRegressionEvent } = await import("../src/routing/adaptive/regression.js");
+    await resolveRegressionEvent(db, first.id, "dismissed");
+
+    // Next cycle — should now produce a NEW event since the old one is resolved
+    await runReplayCycle(db, buildRegistry(), { provider: "openai", model: "judge" });
+    const all = await db.select().from(regressionEvents).all();
+    expect(all).toHaveLength(2);
+    expect(all.filter((e) => e.resolvedAt === null)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #160. Two fixes surfaced by the live Railway deployment of the regression watch — both visible in a single screenshot that showed five simultaneous regressions, all with Δ = -0.60 across unrelated models.

**Root cause A — grader calibration gap:** bank baseline came from user ratings (generous), replay came from LLM judge (strict by prompt design). Mixing graders produced a consistent phantom ~0.6-star regression on every cell.

**Root cause B — duplicate events:** two `replay-execute` runs, two rows for the same cell.

## What changed

- `fetchCandidates` filters `source = "judge"`. Bank is judge-homogeneous; replay comparisons are apples-to-apples.
- `runReplayCycle` upserts on unresolved. Existing unresolved event → update measurements + accumulate `costUsd`, preserve `detectedAt`. Resolved event → new insert allowed (dismissal re-opens eligibility).
- 4 new tests + default source flip on the shared fixture helper.

## Test plan

- [x] `npx vitest run` — 154/154 (4 new)
- [x] `tsc --noEmit` clean
- [ ] Manual on Railway: after deploy, current 5 live regressions will resolve naturally the next time the bank rebuilds from judge-only entries. Populate job will skip user-rated rows. If the judge's strict grading consistently scores below the bank baseline, we'll see real regressions — but those baselines will now themselves be judge scores, so they're meaningful.

## Follow-up note

The judge prompt's strictness stance ("a 5 should be rare") is intentional for ranking purposes, but it means even with apples-to-apples scoring, the bank has a slight recency bias toward whatever the judge happened to grade at capture time. This is fine for regression detection (we want *directional* drift, not absolute calibration) but worth noting if we ever try to compare deltas across cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
