### PR TITLE
feat(#167): Stripe webhook handler + subscription persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,23 @@ ZAI_API_KEY=
 # PROVARA_ALLOWED_ORIGINS=https://www.provara.xyz,https://gateway.provara.xyz
 
 # ──────────────────────────────────────────────
+# Stripe (OPTIONAL — billing integration)
+# ──────────────────────────────────────────────
+# Leave all three unset to run without billing (self-host default). Set
+# all three to enable paid-tier features on Provara Cloud deployments.
+# Use test-mode keys (sk_test_*, pk_test_*) for staging and live keys
+# (sk_live_*, pk_live_*) for production — the lookup keys we use to
+# reference prices match across both environments.
+#
+# STRIPE_SECRET_KEY=<your-stripe-secret-key>
+# STRIPE_PUBLISHABLE_KEY=<your-stripe-publishable-key>
+#
+# Webhook signing secret — unique per Stripe webhook endpoint. Get it
+# from Dashboard → Developers → Webhooks → [your endpoint] → Reveal.
+# Different value per environment (test vs live) and per endpoint.
+# STRIPE_WEBHOOK_SECRET=<your-stripe-webhook-secret>
+
+# ──────────────────────────────────────────────
 # Service Ports (OPTIONAL)
 # ──────────────────────────────────────────────
 # PORT=4000           # Gateway

--- a/package-lock.json
+++ b/package-lock.json
@@ -11764,6 +11764,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.0.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.2.tgz",
+      "integrity": "sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -14002,7 +14019,8 @@
         "dotenv": "^17.4.2",
         "hono": "^4.7.0",
         "nanoid": "^5.1.0",
-        "openai": "^4.85.0"
+        "openai": "^4.85.0",
+        "stripe": "^22.0.2"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/db/drizzle/0023_clumsy_cargill.sql
+++ b/packages/db/drizzle/0023_clumsy_cargill.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `stripe_webhook_events` (
+	`event_id` text PRIMARY KEY NOT NULL,
+	`event_type` text NOT NULL,
+	`processed_at` integer NOT NULL,
+	`payload` text
+);
+--> statement-breakpoint
+CREATE TABLE `subscriptions` (
+	`stripe_subscription_id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text NOT NULL,
+	`stripe_customer_id` text NOT NULL,
+	`stripe_price_id` text NOT NULL,
+	`stripe_product_id` text NOT NULL,
+	`tier` text NOT NULL,
+	`includes_intelligence` integer DEFAULT false NOT NULL,
+	`status` text NOT NULL,
+	`current_period_start` integer NOT NULL,
+	`current_period_end` integer NOT NULL,
+	`cancel_at_period_end` integer DEFAULT false NOT NULL,
+	`trial_end` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `subscriptions_tenant_idx` ON `subscriptions` (`tenant_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `subscriptions_customer_idx` ON `subscriptions` (`stripe_customer_id`);

--- a/packages/db/drizzle/meta/0023_snapshot.json
+++ b/packages/db/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,2441 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7fec15b5-7602-44a8-92ca-a4129a7e2750",
+  "prevId": "a1354096-9ff3-4104-b47e-27076a850cc2",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1776455946736,
       "tag": "0022_wealthy_squadron_supreme",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1776468029477,
+      "tag": "0023_clumsy_cargill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -447,6 +447,60 @@ export const costMigrations = sqliteTable("cost_migrations", {
 });
 
 /**
+ * Subscription state mirror for Stripe (#167). The `subscriptions` table
+ * is not a source of truth — Stripe is. This table caches enough state
+ * for the gateway's feature-gate middleware to answer "what tier is this
+ * tenant on?" without hitting the Stripe API on every request.
+ *
+ * Rows are upserted by the webhook handler when Stripe fires lifecycle
+ * events. `tier` and `includes_intelligence` are denormalized from the
+ * Stripe Product's metadata at write time so feature-gate reads are one
+ * row away from a decision.
+ */
+export const subscriptions = sqliteTable("subscriptions", {
+  stripeSubscriptionId: text("stripe_subscription_id").primaryKey(),
+  tenantId: text("tenant_id").notNull(),
+  stripeCustomerId: text("stripe_customer_id").notNull(),
+  stripePriceId: text("stripe_price_id").notNull(),
+  stripeProductId: text("stripe_product_id").notNull(),
+  /** Denormalized from product.metadata.tier for fast feature-gate reads. */
+  tier: text("tier").notNull(),
+  includesIntelligence: integer("includes_intelligence", { mode: "boolean" }).notNull().default(false),
+  status: text("status", {
+    enum: ["active", "past_due", "canceled", "trialing", "unpaid", "incomplete", "incomplete_expired", "paused"],
+  }).notNull(),
+  currentPeriodStart: integer("current_period_start", { mode: "timestamp" }).notNull(),
+  currentPeriodEnd: integer("current_period_end", { mode: "timestamp" }).notNull(),
+  cancelAtPeriodEnd: integer("cancel_at_period_end", { mode: "boolean" }).notNull().default(false),
+  trialEnd: integer("trial_end", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  uniqueIndex("subscriptions_tenant_idx").on(table.tenantId),
+  uniqueIndex("subscriptions_customer_idx").on(table.stripeCustomerId),
+]);
+
+/**
+ * Stripe webhook event dedupe table. Stripe can retry any event up to
+ * 3 days on 2xx-non-response; the handler needs to dedupe by event.id
+ * to avoid double-processing. Row is written with processedAt only
+ * after the handler succeeds; on retry we see the row and skip.
+ */
+export const stripeWebhookEvents = sqliteTable("stripe_webhook_events", {
+  eventId: text("event_id").primaryKey(),
+  eventType: text("event_type").notNull(),
+  processedAt: integer("processed_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  /** Raw JSON payload kept for debugging; dropped on a regular schedule. */
+  payload: text("payload"),
+});
+
+/**
  * Persistent state for the in-process scheduler. One row per named job.
  * Survives restart so re-scheduled jobs can resume their cadence and the
  * UI can surface last-run telemetry. The scheduler itself still lives

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -18,7 +18,8 @@
     "dotenv": "^17.4.2",
     "hono": "^4.7.0",
     "nanoid": "^5.1.0",
-    "openai": "^4.85.0"
+    "openai": "^4.85.0",
+    "stripe": "^22.0.2"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -36,6 +36,7 @@ import type { Scheduler } from "./scheduler/index.js";
 import { getActiveAutoAbCells } from "./routing/adaptive/auto-ab.js";
 import { createRegressionRoutes } from "./routes/regression.js";
 import { createMigrationRoutes } from "./routes/migrations.js";
+import { createWebhookRoutes } from "./routes/webhooks.js";
 
 interface RouterContext {
   registry: ProviderRegistry;
@@ -100,6 +101,11 @@ export async function createRouter(ctx: RouterContext) {
   // accidentally gate it. Admin create/revoke operations use /v1/shares/*.
   const shareHandlers = createShareHandlers(ctx.db);
   app.get("/v1/shared/:token", shareHandlers.getPublic);
+
+  // Stripe webhooks mount BEFORE auth middleware — they come from Stripe,
+  // not an authenticated user, and are authenticated via HMAC signature
+  // against STRIPE_WEBHOOK_SECRET instead of a session/bearer.
+  app.route("/v1/webhooks", createWebhookRoutes(ctx.db));
 
   // Auth middleware — checks Bearer token on /v1/chat/completions
   app.use("/v1/*", createAuthMiddleware(ctx.db));

--- a/packages/gateway/src/routes/webhooks.ts
+++ b/packages/gateway/src/routes/webhooks.ts
@@ -1,0 +1,79 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { getStripe } from "../stripe/index.js";
+import { dispatchStripeEvent } from "../stripe/events.js";
+import {
+  claimWebhookEvent,
+  isDuplicateWebhookEvent,
+  releaseWebhookEventOnFailure,
+} from "../stripe/subscriptions.js";
+
+/**
+ * Stripe webhook handler. Must run OUTSIDE of JSON body parsing — Stripe
+ * signature verification requires the exact raw bytes Stripe POSTed,
+ * byte-for-byte. Hono doesn't auto-parse unless the handler asks for
+ * JSON, so reading `c.req.raw.text()` before any JSON call gets us the
+ * unmodified body.
+ *
+ * Idempotency is a two-step claim/release: write the event row first,
+ * process, and delete the row on handler failure so a retry can
+ * re-attempt. A stale row from a crashed process would permanently
+ * dedupe a retry that should have run — that's an acceptable trade-off
+ * for simplicity; operator can manually delete if it happens.
+ */
+export function createWebhookRoutes(db: Db) {
+  const app = new Hono();
+
+  app.post("/stripe", async (c) => {
+    const stripe = getStripe();
+    if (!stripe) {
+      // No Stripe SDK configured. Self-hosters without billing return 404
+      // so accidental public exposure doesn't 200 to nothing.
+      return c.json({ error: { message: "stripe integration not configured", type: "not_configured" } }, 404);
+    }
+
+    const secret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!secret) {
+      console.error("[stripe] webhook received but STRIPE_WEBHOOK_SECRET is unset");
+      return c.json({ error: { message: "webhook secret not configured", type: "misconfigured" } }, 500);
+    }
+
+    const signature = c.req.header("stripe-signature");
+    if (!signature) {
+      return c.json({ error: { message: "missing stripe-signature header", type: "invalid_request" } }, 400);
+    }
+
+    const rawBody = await c.req.raw.text();
+
+    let event;
+    try {
+      event = await stripe.webhooks.constructEventAsync(rawBody, signature, secret);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[stripe] webhook signature verification failed: ${msg}`);
+      return c.json({ error: { message: "invalid signature", type: "invalid_signature" } }, 400);
+    }
+
+    if (await isDuplicateWebhookEvent(db, event.id)) {
+      // Stripe retried a previously-handled event. 200 so it stops retrying.
+      return c.json({ received: true, deduped: true });
+    }
+
+    await claimWebhookEvent(db, event.id, event.type, rawBody);
+
+    try {
+      await dispatchStripeEvent(db, stripe, event);
+    } catch (err) {
+      // Release the claim so Stripe's retry can re-attempt. Logged at
+      // error level since unhandled handler exceptions are a real bug.
+      await releaseWebhookEventOnFailure(db, event.id);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[stripe] handler failed for event ${event.id} (${event.type}):`, msg);
+      return c.json({ error: { message: "handler failed", type: "handler_error" } }, 500);
+    }
+
+    return c.json({ received: true });
+  });
+
+  return app;
+}

--- a/packages/gateway/src/stripe/events.ts
+++ b/packages/gateway/src/stripe/events.ts
@@ -1,0 +1,159 @@
+import type { Db } from "@provara/db";
+import type Stripe from "stripe";
+import {
+  getTenantForSubscription,
+  markSubscriptionCanceled,
+  setSubscriptionStatus,
+  upsertSubscription,
+} from "./subscriptions.js";
+
+/**
+ * Resolve the Product a Subscription's first item points to, expanding
+ * if the server only sent an ID. The subscription upsert needs the
+ * product's metadata (tier, includes_intelligence) to denormalize.
+ */
+async function resolveProductForSubscription(
+  stripe: Stripe,
+  subscription: Stripe.Subscription,
+): Promise<Stripe.Product> {
+  const item = subscription.items.data[0];
+  if (!item) throw new Error(`subscription ${subscription.id} has no items`);
+  const product = item.price.product;
+  if (typeof product === "string") {
+    return stripe.products.retrieve(product);
+  }
+  if (product.deleted) {
+    throw new Error(`subscription ${subscription.id} points at a deleted product`);
+  }
+  return product;
+}
+
+/**
+ * `checkout.session.completed` — the first time we see a customer for
+ * this subscription. The session carries `metadata.tenantId` (written
+ * at Checkout Session creation time by the dashboard) and a pointer to
+ * the resulting subscription. We resolve the subscription + its product
+ * and upsert the first row linking tenant → Stripe.
+ */
+export async function handleCheckoutSessionCompleted(
+  db: Db,
+  stripe: Stripe,
+  session: Stripe.Checkout.Session,
+): Promise<void> {
+  // Only subscription-mode checkouts produce subscriptions. Payment-mode
+  // (one-off) and setup-mode (saved payment method only) are ignored.
+  if (session.mode !== "subscription" || !session.subscription) return;
+
+  const tenantId = session.metadata?.tenantId;
+  if (!tenantId) {
+    console.warn(`[stripe] checkout.session.completed ${session.id} missing tenantId metadata — ignoring`);
+    return;
+  }
+
+  const subscriptionId = typeof session.subscription === "string" ? session.subscription : session.subscription.id;
+  const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+  const product = await resolveProductForSubscription(stripe, subscription);
+
+  await upsertSubscription(db, subscription, tenantId, product);
+  console.log(`[stripe] subscription ${subscription.id} linked to tenant ${tenantId} (${product.name})`);
+}
+
+/**
+ * `customer.subscription.updated` — plan changes (monthly→annual, tier
+ * upgrades), renewals, and status flips. The tenantId is already in our
+ * row from the initial checkout, so we read it out and reuse it.
+ */
+export async function handleSubscriptionUpdated(
+  db: Db,
+  stripe: Stripe,
+  subscription: Stripe.Subscription,
+): Promise<void> {
+  const tenantId = await getTenantForSubscription(db, subscription.id);
+  if (!tenantId) {
+    console.warn(`[stripe] subscription.updated for unknown subscription ${subscription.id} — ignoring`);
+    return;
+  }
+  const product = await resolveProductForSubscription(stripe, subscription);
+  await upsertSubscription(db, subscription, tenantId, product);
+}
+
+/**
+ * `customer.subscription.deleted` — subscription is gone (canceled or
+ * expired). Feature-gate code will read status === "canceled" and revoke
+ * access on the next request.
+ */
+export async function handleSubscriptionDeleted(
+  db: Db,
+  subscription: Stripe.Subscription,
+): Promise<void> {
+  await markSubscriptionCanceled(db, subscription.id);
+}
+
+/**
+ * `invoice.payment_failed` — customer's card got declined or transfer
+ * failed. Mark the subscription past_due so feature-gate UX can show a
+ * "payment issue, please update your card" banner. Stripe's own dunning
+ * (Smart Retries) will try again several times before giving up.
+ */
+export async function handleInvoicePaymentFailed(
+  db: Db,
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const subscriptionId = getSubscriptionIdFromInvoice(invoice);
+  if (!subscriptionId) return;
+  await setSubscriptionStatus(db, subscriptionId, "past_due");
+}
+
+/**
+ * `invoice.paid` — renewal or dunning recovery. Flip back to active.
+ * If the subscription was already active, this is a no-op.
+ */
+export async function handleInvoicePaid(
+  db: Db,
+  invoice: Stripe.Invoice,
+): Promise<void> {
+  const subscriptionId = getSubscriptionIdFromInvoice(invoice);
+  if (!subscriptionId) return;
+  await setSubscriptionStatus(db, subscriptionId, "active");
+}
+
+function getSubscriptionIdFromInvoice(invoice: Stripe.Invoice): string | null {
+  // In 2025-09+ API the subscription reference moved off Invoice and onto
+  // Invoice.parent when the invoice was generated from a subscription.
+  const parent = invoice.parent;
+  if (parent?.type === "subscription_details") {
+    const sub = parent.subscription_details?.subscription;
+    if (sub) return typeof sub === "string" ? sub : sub.id;
+  }
+  return null;
+}
+
+/**
+ * Top-level event dispatcher. Unknown event types are logged and no-op'd
+ * — Stripe sends lots of events our app doesn't care about (price changes
+ * on the platform dashboard, customer metadata updates, etc.), and 200-
+ * ing them is the correct response.
+ */
+export async function dispatchStripeEvent(
+  db: Db,
+  stripe: Stripe,
+  event: Stripe.Event,
+): Promise<void> {
+  switch (event.type) {
+    case "checkout.session.completed":
+      return handleCheckoutSessionCompleted(db, stripe, event.data.object);
+    case "customer.subscription.updated":
+    case "customer.subscription.created":
+      return handleSubscriptionUpdated(db, stripe, event.data.object);
+    case "customer.subscription.deleted":
+      return handleSubscriptionDeleted(db, event.data.object);
+    case "invoice.payment_failed":
+      return handleInvoicePaymentFailed(db, event.data.object);
+    case "invoice.paid":
+    case "invoice.payment_succeeded":
+      return handleInvoicePaid(db, event.data.object);
+    default:
+      // No-op; 200-ing unknown events is correct.
+      return;
+  }
+}

--- a/packages/gateway/src/stripe/index.ts
+++ b/packages/gateway/src/stripe/index.ts
@@ -1,0 +1,30 @@
+import Stripe from "stripe";
+
+/**
+ * Stripe SDK singleton. Lazy-initialized so tests can run without
+ * Stripe env vars present. Returns null when `STRIPE_SECRET_KEY` is
+ * unset — callers treat null as "Stripe integration is disabled" and
+ * skip silently, same pattern as the embedding provider.
+ */
+let client: Stripe | null = null;
+let initialized = false;
+
+export function getStripe(): Stripe | null {
+  if (initialized) return client;
+  initialized = true;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) return null;
+  client = new Stripe(key, {
+    // Version pinned at build time. Update when Stripe's API shape changes
+    // in a way that affects our event handlers.
+    apiVersion: "2026-03-25.dahlia",
+    maxNetworkRetries: 2,
+  });
+  return client;
+}
+
+/** Test hook — reset the singleton so a test can swap keys. */
+export function __resetStripeForTests(): void {
+  client = null;
+  initialized = false;
+}

--- a/packages/gateway/src/stripe/subscriptions.ts
+++ b/packages/gateway/src/stripe/subscriptions.ts
@@ -1,0 +1,187 @@
+import type { Db } from "@provara/db";
+import { subscriptions, stripeWebhookEvents } from "@provara/db";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+
+/**
+ * Denormalize a Stripe Subscription into our local row shape. The
+ * `tier` and `includesIntelligence` fields come from the subscription's
+ * price → product → metadata chain; we write them flat so feature-gate
+ * reads are a single row lookup rather than a Stripe roundtrip.
+ *
+ * `tenantId` is passed separately because not every event path has it
+ * on the subscription object itself. The webhook handler resolves it
+ * (usually from checkout session metadata on first write) and passes it
+ * in.
+ */
+export interface StripeProductMetadata {
+  tier?: string;
+  includes_intelligence?: string;
+}
+
+function parseTier(metadata: StripeProductMetadata | null | undefined): {
+  tier: string;
+  includesIntelligence: boolean;
+} {
+  const tier = metadata?.tier ?? "free";
+  const includesIntelligence = metadata?.includes_intelligence === "true";
+  return { tier, includesIntelligence };
+}
+
+/**
+ * Idempotent upsert — safe to call on every webhook firing, including
+ * Stripe retries. PrimaryKey is `stripeSubscriptionId`; on conflict we
+ * update everything except `createdAt`.
+ */
+export async function upsertSubscription(
+  db: Db,
+  stripeSub: Stripe.Subscription,
+  tenantId: string,
+  product: Stripe.Product,
+): Promise<void> {
+  const { tier, includesIntelligence } = parseTier(
+    product.metadata as StripeProductMetadata,
+  );
+
+  const item = stripeSub.items.data[0];
+  if (!item) {
+    throw new Error(`subscription ${stripeSub.id} has no items`);
+  }
+  const price = item.price;
+
+  // In 2025-09 API the billing-cycle period moved from the subscription to
+  // each subscription item. For our single-item subscriptions the first
+  // item carries the canonical period.
+  const periodStart = item.current_period_start ?? Math.floor(Date.now() / 1000);
+  const periodEnd = item.current_period_end ?? Math.floor(Date.now() / 1000);
+
+  const now = new Date();
+  const values = {
+    stripeSubscriptionId: stripeSub.id,
+    tenantId,
+    stripeCustomerId: typeof stripeSub.customer === "string" ? stripeSub.customer : stripeSub.customer.id,
+    stripePriceId: price.id,
+    stripeProductId: typeof price.product === "string" ? price.product : price.product.id,
+    tier,
+    includesIntelligence,
+    status: stripeSub.status,
+    currentPeriodStart: new Date(periodStart * 1000),
+    currentPeriodEnd: new Date(periodEnd * 1000),
+    cancelAtPeriodEnd: stripeSub.cancel_at_period_end,
+    trialEnd: stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000) : null,
+    updatedAt: now,
+  };
+
+  await db
+    .insert(subscriptions)
+    .values({ ...values, createdAt: now })
+    .onConflictDoUpdate({
+      target: subscriptions.stripeSubscriptionId,
+      set: values,
+    })
+    .run();
+}
+
+/** Flip a subscription's status to canceled without touching other fields. */
+export async function markSubscriptionCanceled(
+  db: Db,
+  stripeSubscriptionId: string,
+): Promise<void> {
+  await db
+    .update(subscriptions)
+    .set({ status: "canceled", updatedAt: new Date() })
+    .where(eq(subscriptions.stripeSubscriptionId, stripeSubscriptionId))
+    .run();
+}
+
+/** Flip status to past_due (payment_failed) or active (payment recovered). */
+export async function setSubscriptionStatus(
+  db: Db,
+  stripeSubscriptionId: string,
+  status: "active" | "past_due" | "unpaid",
+): Promise<void> {
+  await db
+    .update(subscriptions)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(subscriptions.stripeSubscriptionId, stripeSubscriptionId))
+    .run();
+}
+
+/**
+ * Feature-gate query: which subscription does this tenant currently have?
+ * Returns null when the tenant has no row (= Free tier in the gated-
+ * by-tier world). Used by #168's feature-gate middleware.
+ */
+export async function getSubscriptionForTenant(
+  db: Db,
+  tenantId: string,
+): Promise<typeof subscriptions.$inferSelect | null> {
+  const row = await db
+    .select()
+    .from(subscriptions)
+    .where(eq(subscriptions.tenantId, tenantId))
+    .get();
+  return row ?? null;
+}
+
+/**
+ * Look up the tenantId associated with a Stripe subscription, for events
+ * that arrive with only the subscription in hand (updated/deleted/invoice
+ * events). Returns null if we haven't seen this subscription before —
+ * shouldn't happen in normal flow since checkout.session.completed writes
+ * the first row.
+ */
+export async function getTenantForSubscription(
+  db: Db,
+  stripeSubscriptionId: string,
+): Promise<string | null> {
+  const row = await db
+    .select({ tenantId: subscriptions.tenantId })
+    .from(subscriptions)
+    .where(eq(subscriptions.stripeSubscriptionId, stripeSubscriptionId))
+    .get();
+  return row?.tenantId ?? null;
+}
+
+/**
+ * Dedupe Stripe webhook retries. Returns true if the event has already
+ * been processed (skip); false if it's new (claim it by writing the
+ * row, then process).
+ *
+ * Ordering matters: the caller should claim BEFORE processing and roll
+ * back on handler failure. Claiming is the write; rolling back is
+ * deleting the row so the next retry picks it up.
+ */
+export async function isDuplicateWebhookEvent(
+  db: Db,
+  eventId: string,
+): Promise<boolean> {
+  const row = await db
+    .select({ eventId: stripeWebhookEvents.eventId })
+    .from(stripeWebhookEvents)
+    .where(eq(stripeWebhookEvents.eventId, eventId))
+    .get();
+  return Boolean(row);
+}
+
+export async function claimWebhookEvent(
+  db: Db,
+  eventId: string,
+  eventType: string,
+  payload: string,
+): Promise<void> {
+  await db
+    .insert(stripeWebhookEvents)
+    .values({ eventId, eventType, payload })
+    .run();
+}
+
+export async function releaseWebhookEventOnFailure(
+  db: Db,
+  eventId: string,
+): Promise<void> {
+  await db
+    .delete(stripeWebhookEvents)
+    .where(eq(stripeWebhookEvents.eventId, eventId))
+    .run();
+}

--- a/packages/gateway/tests/stripe-webhook.test.ts
+++ b/packages/gateway/tests/stripe-webhook.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { subscriptions, stripeWebhookEvents } from "@provara/db";
+import type { Db } from "@provara/db";
+import type Stripe from "stripe";
+import { makeTestDb } from "./_setup/db.js";
+import {
+  claimWebhookEvent,
+  isDuplicateWebhookEvent,
+  releaseWebhookEventOnFailure,
+  upsertSubscription,
+  getSubscriptionForTenant,
+  getTenantForSubscription,
+  markSubscriptionCanceled,
+  setSubscriptionStatus,
+} from "../src/stripe/subscriptions.js";
+import {
+  dispatchStripeEvent,
+  handleCheckoutSessionCompleted,
+  handleSubscriptionUpdated,
+  handleSubscriptionDeleted,
+  handleInvoicePaymentFailed,
+  handleInvoicePaid,
+} from "../src/stripe/events.js";
+
+// Mock the minimal Stripe surface the event handlers need.
+function mockStripe(overrides?: {
+  products?: Record<string, Stripe.Product>;
+  subscriptions?: Record<string, Stripe.Subscription>;
+}): Stripe {
+  return {
+    products: {
+      retrieve: async (id: string) => {
+        const p = overrides?.products?.[id];
+        if (!p) throw new Error(`mock product ${id} not found`);
+        return p;
+      },
+    },
+    subscriptions: {
+      retrieve: async (id: string) => {
+        const s = overrides?.subscriptions?.[id];
+        if (!s) throw new Error(`mock subscription ${id} not found`);
+        return s;
+      },
+    },
+  } as unknown as Stripe;
+}
+
+function makeProduct(overrides: Partial<Stripe.Product> = {}): Stripe.Product {
+  return {
+    id: "prod_pro",
+    object: "product",
+    active: true,
+    name: "Cloud - Pro",
+    metadata: { tier: "pro", includes_intelligence: "true" },
+    created: Math.floor(Date.now() / 1000),
+    updated: Math.floor(Date.now() / 1000),
+    ...overrides,
+  } as Stripe.Product;
+}
+
+function makeSubscription(overrides: Partial<Stripe.Subscription> = {}): Stripe.Subscription {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    id: "sub_123",
+    object: "subscription",
+    customer: "cus_abc",
+    status: "active",
+    cancel_at_period_end: false,
+    trial_end: null,
+    items: {
+      data: [
+        {
+          id: "si_1",
+          price: {
+            id: "price_pro_monthly",
+            product: "prod_pro",
+          } as Stripe.Price,
+          current_period_start: nowSec,
+          current_period_end: nowSec + 30 * 86400,
+        } as Stripe.SubscriptionItem,
+      ],
+    },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+function makeInvoice(subscriptionId: string): Stripe.Invoice {
+  return {
+    id: "in_123",
+    object: "invoice",
+    parent: {
+      type: "subscription_details",
+      subscription_details: { subscription: subscriptionId },
+    },
+  } as unknown as Stripe.Invoice;
+}
+
+describe("upsertSubscription + lookups", () => {
+  let db: Db;
+  beforeEach(async () => { db = await makeTestDb(); });
+
+  it("inserts a new subscription row with denormalized tier metadata", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    const row = await db.select().from(subscriptions).where(eq(subscriptions.stripeSubscriptionId, "sub_123")).get();
+    expect(row).toBeTruthy();
+    expect(row?.tenantId).toBe("tenant-1");
+    expect(row?.tier).toBe("pro");
+    expect(row?.includesIntelligence).toBe(true);
+    expect(row?.status).toBe("active");
+    expect(row?.stripePriceId).toBe("price_pro_monthly");
+    expect(row?.stripeProductId).toBe("prod_pro");
+  });
+
+  it("updates the existing row on conflict (idempotent)", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await upsertSubscription(
+      db,
+      makeSubscription({ status: "past_due" }),
+      "tenant-1",
+      makeProduct(),
+    );
+    const rows = await db.select().from(subscriptions).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("past_due");
+  });
+
+  it("handles tier changes (Pro → Team) by updating the denormalized metadata", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await upsertSubscription(
+      db,
+      makeSubscription({
+        items: {
+          data: [
+            {
+              id: "si_1",
+              price: {
+                id: "price_team_monthly",
+                product: "prod_team",
+              } as Stripe.Price,
+              current_period_start: Math.floor(Date.now() / 1000),
+              current_period_end: Math.floor(Date.now() / 1000) + 30 * 86400,
+            } as Stripe.SubscriptionItem,
+          ],
+        },
+      }),
+      "tenant-1",
+      makeProduct({ id: "prod_team", name: "Cloud - Team", metadata: { tier: "team", includes_intelligence: "true" } }),
+    );
+    const row = await getSubscriptionForTenant(db, "tenant-1");
+    expect(row?.tier).toBe("team");
+    expect(row?.stripeProductId).toBe("prod_team");
+  });
+
+  it("getSubscriptionForTenant returns null for unknown tenants", async () => {
+    expect(await getSubscriptionForTenant(db, "nobody")).toBeNull();
+  });
+
+  it("getTenantForSubscription returns the tenant when row exists", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    expect(await getTenantForSubscription(db, "sub_123")).toBe("tenant-1");
+  });
+
+  it("markSubscriptionCanceled flips status", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await markSubscriptionCanceled(db, "sub_123");
+    const row = await getSubscriptionForTenant(db, "tenant-1");
+    expect(row?.status).toBe("canceled");
+  });
+
+  it("setSubscriptionStatus round-trips active/past_due", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await setSubscriptionStatus(db, "sub_123", "past_due");
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.status).toBe("past_due");
+    await setSubscriptionStatus(db, "sub_123", "active");
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.status).toBe("active");
+  });
+});
+
+describe("webhook idempotency (claim/release)", () => {
+  let db: Db;
+  beforeEach(async () => { db = await makeTestDb(); });
+
+  it("new event is not a duplicate; after claim it is", async () => {
+    expect(await isDuplicateWebhookEvent(db, "evt_1")).toBe(false);
+    await claimWebhookEvent(db, "evt_1", "checkout.session.completed", "{}");
+    expect(await isDuplicateWebhookEvent(db, "evt_1")).toBe(true);
+  });
+
+  it("release-on-failure removes the claim so Stripe retry can re-attempt", async () => {
+    await claimWebhookEvent(db, "evt_1", "x", "{}");
+    expect(await isDuplicateWebhookEvent(db, "evt_1")).toBe(true);
+    await releaseWebhookEventOnFailure(db, "evt_1");
+    expect(await isDuplicateWebhookEvent(db, "evt_1")).toBe(false);
+  });
+});
+
+describe("event handlers", () => {
+  let db: Db;
+  beforeEach(async () => { db = await makeTestDb(); });
+
+  it("checkout.session.completed links tenant from session metadata", async () => {
+    const stripe = mockStripe({
+      products: { prod_pro: makeProduct() },
+      subscriptions: { sub_123: makeSubscription() },
+    });
+    await handleCheckoutSessionCompleted(db, stripe, {
+      id: "cs_test",
+      mode: "subscription",
+      subscription: "sub_123",
+      metadata: { tenantId: "tenant-42" },
+    } as unknown as Stripe.Checkout.Session);
+
+    const row = await getSubscriptionForTenant(db, "tenant-42");
+    expect(row?.tier).toBe("pro");
+    expect(row?.stripeCustomerId).toBe("cus_abc");
+  });
+
+  it("checkout.session.completed is a no-op when tenantId metadata is missing", async () => {
+    const stripe = mockStripe({ products: { prod_pro: makeProduct() } });
+    await handleCheckoutSessionCompleted(db, stripe, {
+      id: "cs_test",
+      mode: "subscription",
+      subscription: "sub_123",
+      metadata: {},
+    } as unknown as Stripe.Checkout.Session);
+    const rows = await db.select().from(subscriptions).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("checkout.session.completed is a no-op for non-subscription mode", async () => {
+    const stripe = mockStripe();
+    await handleCheckoutSessionCompleted(db, stripe, {
+      id: "cs_test",
+      mode: "payment",
+      metadata: { tenantId: "tenant-42" },
+    } as unknown as Stripe.Checkout.Session);
+    const rows = await db.select().from(subscriptions).all();
+    expect(rows).toHaveLength(0);
+  });
+
+  it("subscription.updated refreshes tier + status without losing tenant linkage", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+
+    const stripe = mockStripe({
+      products: { prod_team: makeProduct({ id: "prod_team", metadata: { tier: "team", includes_intelligence: "true" } }) },
+    });
+    await handleSubscriptionUpdated(db, stripe, makeSubscription({
+      items: {
+        data: [{
+          id: "si_1",
+          price: { id: "price_team_monthly", product: "prod_team" } as Stripe.Price,
+          current_period_start: Math.floor(Date.now() / 1000),
+          current_period_end: Math.floor(Date.now() / 1000) + 30 * 86400,
+        } as Stripe.SubscriptionItem],
+      },
+    }));
+
+    const row = await getSubscriptionForTenant(db, "tenant-1");
+    expect(row?.tier).toBe("team");
+    expect(row?.tenantId).toBe("tenant-1");
+  });
+
+  it("subscription.updated for unknown subscription is ignored", async () => {
+    const stripe = mockStripe({ products: { prod_pro: makeProduct() } });
+    await handleSubscriptionUpdated(db, stripe, makeSubscription());
+    expect(await db.select().from(subscriptions).all()).toHaveLength(0);
+  });
+
+  it("subscription.deleted marks the row canceled", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await handleSubscriptionDeleted(db, makeSubscription());
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.status).toBe("canceled");
+  });
+
+  it("invoice.payment_failed flips to past_due", async () => {
+    await upsertSubscription(db, makeSubscription(), "tenant-1", makeProduct());
+    await handleInvoicePaymentFailed(db, makeInvoice("sub_123"));
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.status).toBe("past_due");
+  });
+
+  it("invoice.paid flips back to active", async () => {
+    await upsertSubscription(db, makeSubscription({ status: "past_due" }), "tenant-1", makeProduct());
+    await handleInvoicePaid(db, makeInvoice("sub_123"));
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.status).toBe("active");
+  });
+});
+
+describe("dispatchStripeEvent", () => {
+  let db: Db;
+  beforeEach(async () => { db = await makeTestDb(); });
+
+  it("routes known events to their handlers", async () => {
+    const stripe = mockStripe({
+      products: { prod_pro: makeProduct() },
+      subscriptions: { sub_123: makeSubscription() },
+    });
+    await dispatchStripeEvent(db, stripe, {
+      id: "evt_checkout",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_1",
+          mode: "subscription",
+          subscription: "sub_123",
+          metadata: { tenantId: "tenant-1" },
+        },
+      },
+    } as unknown as Stripe.Event);
+
+    expect((await getSubscriptionForTenant(db, "tenant-1"))?.tier).toBe("pro");
+  });
+
+  it("is a silent no-op for unknown event types", async () => {
+    const stripe = mockStripe();
+    await expect(
+      dispatchStripeEvent(db, stripe, {
+        id: "evt_weird",
+        type: "some.unhandled.event",
+        data: { object: {} },
+      } as unknown as Stripe.Event),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #167. Foundation for all paid-tier integration work under #166 — the gateway now knows who has what Stripe subscription, kept in sync via webhooks.

No customer-facing behavior change yet. #168 (feature gating), #169 (billing dashboard), and #170 (usage metering) all read the `subscriptions` table this PR creates.

## What's in

**Schema (migration 0023)**
- `subscriptions` — mirror of Stripe subscription state, tenant-indexed, denormalizes `tier` and `includes_intelligence` from the product's metadata for O(1) feature-gate reads
- `stripe_webhook_events` — dedupe table for Stripe's event retries

**Gateway — `src/stripe/`**
- `index.ts` — lazy Stripe SDK singleton, returns null when `STRIPE_SECRET_KEY` is unset (self-host default, preserves the dependency-budget promise)
- `subscriptions.ts` — idempotent `upsertSubscription`, tenant ↔ subscription lookups, claim/release idempotency helpers
- `events.ts` — handlers for the 6 Stripe events the endpoint subscribes to; unknown events are silent no-ops (correct behavior per Stripe's guidance)

**Gateway — `src/routes/webhooks.ts`**
- `POST /v1/webhooks/stripe`, mounted **before** auth middleware (webhooks authenticate via HMAC signature, not session)
- Raw body captured from `c.req.raw.text()` before any parsing — required for `stripe.webhooks.constructEventAsync`
- Two-phase idempotency: claim event-row → dispatch → release on handler error. Retries land on a dedupe-hit and 200.

**`.env.example`**
- Adds three new variables with placeholder values and guidance on test-vs-live separation

## Events registered with Stripe

| Event | Handler action |
|---|---|
| `checkout.session.completed` | Link tenant to subscription via session.metadata.tenantId; first row write |
| `customer.subscription.created` | Safety net, treated same as `.updated` |
| `customer.subscription.updated` | Refresh tier + status (handles monthly→annual upgrade, plan change) |
| `customer.subscription.deleted` | Flip status to `canceled` |
| `invoice.payment_failed` | Flip status to `past_due` |
| `invoice.paid` | Flip status back to `active` |

## Test plan

- [x] `npx vitest run` — 180/180, 19 new
- [x] `tsc --noEmit` clean across gateway, db, web
- [ ] Manual: set sandbox Stripe envs on Railway, create webhook endpoint in sandbox Stripe pointing at `https://gateway.provara.xyz/v1/webhooks/stripe`, send a test event from Stripe's dashboard — event row appears in `stripe_webhook_events`
- [ ] Manual: run a sandbox Checkout with `metadata: { tenantId }`, verify the `subscriptions` row lands with the right tier

## Notes

- **Stripe API version pinned** at `2026-03-25.dahlia`. Our types will break if Stripe ships a breaking change; update the pin and adjust accordingly.
- **Subscription billing-period fields** come from the subscription *item*, not the subscription itself — Stripe moved them in 2025-09. The code reads `items.data[0].current_period_{start,end}`.
- **Tenant linkage** is established during Checkout via `session.metadata.tenantId`. The dashboard-side Checkout creation (part of #169) is responsible for setting this metadata correctly.
- **Self-host deployments** without billing leave the three env vars unset; the webhook endpoint returns 404 and no migration-schema overhead is incurred beyond two small tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
