### PR TITLE
fix: null-safe Intelligence panels when tier gate returns 402

### DIFF
--- a/apps/web/src/components/gated-panel.tsx
+++ b/apps/web/src/components/gated-panel.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Shared empty-state for Intelligence-tier panels (#173 hotfix) when the
+ * backend tier gate returns 402. Keeps the UX honest for two distinct
+ * audiences:
+ *
+ *   - Self-hosters (reason="not_cloud"): they already have the code,
+ *     they just need to enable PROVARA_CLOUD. Link to docs, no
+ *     "Upgrade" button because that implies payment.
+ *
+ *   - Cloud customers on Free / no sub / inactive sub: render an Upgrade
+ *     CTA that points at the billing dashboard or pricing page.
+ *
+ * Replaced by the richer <UpgradeCta /> system landing in #169 — this
+ * is deliberately minimal so it can ship as a crash hotfix without
+ * blocking on full billing UX work.
+ */
+
+interface GatedPanelProps {
+  reason: string;
+  currentTier: string;
+  upgradeUrl?: string;
+  feature: string;
+}
+
+export function GatedPanel({ reason, currentTier, upgradeUrl, feature }: GatedPanelProps) {
+  const isSelfHost = reason === "not_cloud";
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+      <h3 className="text-sm font-semibold">{feature}</h3>
+      {isSelfHost ? (
+        <>
+          <p className="text-xs text-zinc-500 mt-2">
+            Intelligence-tier features are gated on self-hosted deployments. Set{" "}
+            <code className="px-1 py-0.5 rounded bg-zinc-800 text-zinc-300 text-[11px]">PROVARA_CLOUD=true</code>{" "}
+            on your gateway to enable.
+          </p>
+          <a
+            href="https://github.com/syndicalt/provara#silent-regression-detection"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block mt-3 text-xs text-blue-400 hover:text-blue-300"
+          >
+            Read the docs →
+          </a>
+        </>
+      ) : (
+        <>
+          <p className="text-xs text-zinc-500 mt-2">
+            {reason === "inactive_status"
+              ? `Your subscription needs attention before ${feature.toLowerCase()} can resume.`
+              : reason === "insufficient_tier"
+              ? `${feature} is available on Pro and higher plans. Your current plan: ${currentTier}.`
+              : `Upgrade to Pro to enable ${feature.toLowerCase()}.`}
+          </p>
+          {upgradeUrl && (
+            <a
+              href={upgradeUrl}
+              className="inline-block mt-3 px-3 py-1.5 rounded text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+            >
+              {reason === "inactive_status" ? "Manage billing" : "Upgrade"}
+            </a>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/migrations-panel.tsx
+++ b/apps/web/src/components/migrations-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { gatewayFetchRaw } from "../lib/gateway-client";
+import { GatedPanel } from "./gated-panel";
 
 interface MigrationRow {
   id: string;
@@ -37,20 +38,46 @@ function shortDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
+interface GatedState {
+  reason: string;
+  currentTier: string;
+  upgradeUrl?: string;
+}
+
 export function MigrationsPanel() {
   const [status, setStatus] = useState<Status | null>(null);
   const [migrations, setMigrations] = useState<MigrationRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
+  const [gated, setGated] = useState<GatedState | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const [statusRes, listRes] = await Promise.all([
-        gatewayFetchRaw("/v1/cost-migrations/status").then((r) => r.json()),
-        gatewayFetchRaw("/v1/cost-migrations").then((r) => r.json()),
-      ]);
-      setStatus(statusRes);
+      const statusRes = await gatewayFetchRaw("/v1/cost-migrations/status");
+      // Tier gate from #168 returns 402 when the deployment isn't Cloud or
+      // the caller's subscription doesn't include Intelligence. Render a
+      // dedicated empty state instead of crashing on status.savingsThisMonth
+      // being undefined. Full Upgrade CTA UX lands in #169.
+      if (statusRes.status === 402) {
+        const body = await statusRes.json().catch(() => ({}));
+        setGated({
+          reason: body?.gate?.reason ?? "not_available",
+          currentTier: body?.gate?.currentTier ?? "free",
+          upgradeUrl: body?.gate?.upgradeUrl,
+        });
+        setStatus(null);
+        setMigrations([]);
+        return;
+      }
+      if (!statusRes.ok) {
+        setStatus(null);
+        return;
+      }
+      const parsedStatus: Status = await statusRes.json();
+      const listRes = await gatewayFetchRaw("/v1/cost-migrations").then((r) => r.json());
+      setStatus(parsedStatus);
       setMigrations(listRes.migrations || []);
+      setGated(null);
     } catch (err) {
       console.error("migrations panel fetch failed:", err);
     } finally {
@@ -85,6 +112,7 @@ export function MigrationsPanel() {
   }
 
   if (loading) return <p className="text-sm text-zinc-500">Loading cost migrations...</p>;
+  if (gated) return <GatedPanel reason={gated.reason} currentTier={gated.currentTier} upgradeUrl={gated.upgradeUrl} feature="Automated cost migrations" />;
   if (!status) return null;
 
   const activeRows = migrations.filter((m) => !m.rolledBackAt);

--- a/apps/web/src/components/regression-panel.tsx
+++ b/apps/web/src/components/regression-panel.tsx
@@ -2,12 +2,19 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { gatewayFetchRaw } from "../lib/gateway-client";
+import { GatedPanel } from "./gated-panel";
 
 interface RegressionStatus {
   enabled: boolean;
   budget: { used: number; limit: number; remaining: number };
   bankSize: number;
   defaultWeeklyBudgetUsd: number;
+}
+
+interface GatedState {
+  reason: string;
+  currentTier: string;
+  upgradeUrl?: string;
 }
 
 interface RegressionEvent {
@@ -36,15 +43,35 @@ export function RegressionPanel() {
   const [events, setEvents] = useState<RegressionEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [toggling, setToggling] = useState(false);
+  const [gated, setGated] = useState<GatedState | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const [statusRes, eventsRes] = await Promise.all([
-        gatewayFetchRaw("/v1/regression/status").then((r) => r.json()),
-        gatewayFetchRaw("/v1/regression/events").then((r) => r.json()),
-      ]);
-      setStatus(statusRes);
+      const statusResponse = await gatewayFetchRaw("/v1/regression/status");
+      // Tier gate (#168) returns 402 when deployment isn't Cloud or the
+      // caller's subscription doesn't include Intelligence. Render a
+      // dedicated empty state instead of crashing on status.budget being
+      // undefined. Full Upgrade CTA UX lands in #169.
+      if (statusResponse.status === 402) {
+        const body = await statusResponse.json().catch(() => ({}));
+        setGated({
+          reason: body?.gate?.reason ?? "not_available",
+          currentTier: body?.gate?.currentTier ?? "free",
+          upgradeUrl: body?.gate?.upgradeUrl,
+        });
+        setStatus(null);
+        setEvents([]);
+        return;
+      }
+      if (!statusResponse.ok) {
+        setStatus(null);
+        return;
+      }
+      const parsedStatus: RegressionStatus = await statusResponse.json();
+      const eventsRes = await gatewayFetchRaw("/v1/regression/events").then((r) => r.json());
+      setStatus(parsedStatus);
       setEvents(eventsRes.events || []);
+      setGated(null);
     } catch (err) {
       console.error("regression panel fetch failed:", err);
     } finally {
@@ -81,6 +108,8 @@ export function RegressionPanel() {
   if (loading) {
     return <p className="text-sm text-zinc-500">Loading regression detection...</p>;
   }
+
+  if (gated) return <GatedPanel reason={gated.reason} currentTier={gated.currentTier} upgradeUrl={gated.upgradeUrl} feature="Silent-regression detection" />;
 
   if (!status) return null;
 


### PR DESCRIPTION
## Summary

Hotfix for the white-screen crash on `/dashboard/quality` and `/dashboard/routing` that started after #172 merged. The tier-gate middleware returns 402 when `PROVARA_CLOUD` is unset or the tenant lacks an Intelligence subscription, but `RegressionPanel` and `MigrationsPanel` were parsing those responses as success payloads and calling `.toFixed()` on undefined fields.

## What changed

Both panels now:
- Check `response.status === 402` before parsing
- Set a new `gated` state with the structured payload from the backend
- Render a shared `<GatedPanel />` empty-state component instead of the normal UI

The new `<GatedPanel />` component speaks honestly to two audiences:

**Self-hosters** (reason `not_cloud`)  
Message: "Intelligence-tier features are gated on self-hosted deployments. Set `PROVARA_CLOUD=true` on your gateway to enable."  
Link: Read the docs →  
No Upgrade button — they already have the code; pushing them to pay would be wrong.

**Cloud customers** (reason `no_subscription` / `insufficient_tier` / `inactive_status`)  
Message varies by reason.  
Link: Upgrade (or Manage billing for inactive status).

## Scope note

This is deliberately minimal — crash hotfix only. #169 replaces `<GatedPanel />` with a richer `<UpgradeCta />` + `useGatedFetch` hook that handles the full billing UX. The component boundary here makes the swap clean later.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: deploy to Railway, no env var change, hit `/dashboard/routing` — should render the "set PROVARA_CLOUD=true" message instead of crashing
- [ ] Manual: same for `/dashboard/quality`

## Next steps after this merges

You can then set `PROVARA_CLOUD=true` on Railway + seed the bootstrap subscription row at your leisure. The panels now degrade gracefully in either state instead of hard-crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
