### PR TITLE
feat(#173): operator email allowlist for Intelligence tier bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,19 @@ ZAI_API_KEY=
 # PROVARA_CLOUD=true
 
 # ──────────────────────────────────────────────
+# Operator email allowlist (OPTIONAL — Provara Cloud only)
+# ──────────────────────────────────────────────
+# Comma-separated list of emails for CoreLumen employees / contractors
+# who should bypass subscription checks. Any tenant containing a user
+# whose email is on this list gets Intelligence-tier access without
+# needing a paid Stripe subscription. Operator access is a billing
+# bypass only — does NOT grant cross-tenant privilege, admin keys, or
+# the ability to view other customers' data.
+#
+# This is operator-only. Never put customer emails here.
+# PROVARA_OPERATOR_EMAILS=operator@corelumen.com,second@corelumen.com
+
+# ──────────────────────────────────────────────
 # Stripe (OPTIONAL — billing integration)
 # ──────────────────────────────────────────────
 # Leave all three unset to run without billing (self-host default). Set

--- a/packages/gateway/src/auth/tier.ts
+++ b/packages/gateway/src/auth/tier.ts
@@ -1,8 +1,42 @@
 import type { Context, Next } from "hono";
 import type { Db } from "@provara/db";
-import { isCloudDeployment } from "../config.js";
+import { users } from "@provara/db";
+import { eq, and, sql } from "drizzle-orm";
+import { getOperatorEmails, isCloudDeployment } from "../config.js";
 import { getTenantId } from "./tenant.js";
 import { getSubscriptionForTenant } from "../stripe/subscriptions.js";
+
+/**
+ * Operator bypass lookup (#173). A tenant is an "operator tenant" if any
+ * of its users has an email on the PROVARA_OPERATOR_EMAILS allowlist.
+ * Returns true → the tenant bypasses subscription checks at both the
+ * HTTP middleware and the scheduler cycle layer. Tiny DB hit per gate
+ * check; acceptable because Intelligence routes are not on the hot path
+ * for chat completions.
+ */
+async function isOperatorTenant(db: Db, tenantId: string | null | undefined): Promise<boolean> {
+  if (!tenantId) return false;
+  const allowlist = getOperatorEmails();
+  if (allowlist.length === 0) return false;
+  // Case-insensitive comparison — OAuth providers return inconsistent
+  // casings (Google preserves the user's preferred casing, GitHub
+  // lowercases), so we compare on LOWER(email). The allowlist is
+  // already lowercased by getOperatorEmails.
+  const row = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(
+      and(
+        eq(users.tenantId, tenantId),
+        sql`LOWER(${users.email}) IN (${sql.join(
+          allowlist.map((e) => sql`${e}`),
+          sql`, `,
+        )})`,
+      ),
+    )
+    .get();
+  return Boolean(row);
+}
 
 /**
  * Subscription statuses that grant feature access to the tenant's tier.
@@ -43,6 +77,16 @@ export interface TierGateFailure {
  */
 export function requireIntelligenceTier(db: Db) {
   return async (c: Context, next: Next) => {
+    const tenantId = getTenantId(c.req.raw);
+
+    // Operator bypass (#173) runs before any other gate so CoreLumen's own
+    // team can use Intelligence features in all environments — including
+    // self-host preview deploys — without needing a Stripe subscription
+    // seeded for their tenant.
+    if (tenantId && (await isOperatorTenant(db, tenantId))) {
+      return next();
+    }
+
     if (!isCloudDeployment()) {
       return c.json(
         {
@@ -60,7 +104,6 @@ export function requireIntelligenceTier(db: Db) {
       );
     }
 
-    const tenantId = getTenantId(c.req.raw);
     if (!tenantId) {
       // Multi_tenant mode without a tenant means unauthenticated — the
       // admin/auth middleware upstream should have caught this. Belt-and-
@@ -133,14 +176,18 @@ export function requireIntelligenceTier(db: Db) {
 /**
  * Non-middleware variant for server-side callers (scheduler cycles) that
  * need to decide per-tenant whether to process. Mirrors the middleware
- * logic exactly so the gates are consistent.
+ * logic exactly so the gates are consistent, including the operator
+ * allowlist bypass (#173).
  */
 export async function tenantHasIntelligenceAccess(
   db: Db,
   tenantId: string | null,
 ): Promise<boolean> {
-  if (!isCloudDeployment()) return false;
   if (!tenantId) return false;
+  // Operator bypass takes precedence so CoreLumen's own scheduler cycles
+  // process operator tenants even in self-host preview environments.
+  if (await isOperatorTenant(db, tenantId)) return true;
+  if (!isCloudDeployment()) return false;
   const sub = await getSubscriptionForTenant(db, tenantId);
   if (!sub) return false;
   if (!ACTIVE_STATUSES.has(sub.status)) return false;

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -18,3 +18,27 @@ export function getMode(): ProvaraMode {
 export function isCloudDeployment(): boolean {
   return process.env.PROVARA_CLOUD === "true";
 }
+
+/**
+ * Operator email allowlist (#173). CoreLumen employees / contractors with
+ * production access whose tenants should bypass subscription checks so
+ * they can use Intelligence features without a paying Stripe subscription.
+ *
+ * Failure mode is bounded: a misconfigured env var locks operators out
+ * briefly until it's fixed. Customer access is unaffected — the bypass
+ * only *grants*, never *revokes*.
+ */
+export function getOperatorEmails(): string[] {
+  const raw = process.env.PROVARA_OPERATOR_EMAILS || "";
+  return raw
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isOperatorEmail(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) return false;
+  return getOperatorEmails().includes(normalized);
+}

--- a/packages/gateway/tests/_setup/tier.ts
+++ b/packages/gateway/tests/_setup/tier.ts
@@ -1,5 +1,6 @@
 import type { Db } from "@provara/db";
-import { subscriptions } from "@provara/db";
+import { subscriptions, users } from "@provara/db";
+import { nanoid } from "nanoid";
 
 /**
  * Seed an Intelligence-tier subscription for a test tenant so code paths
@@ -42,4 +43,36 @@ export async function grantIntelligenceAccess(
 /** Reset env vars between tests to avoid leaking PROVARA_CLOUD. */
 export function resetTierEnv(): void {
   delete process.env.PROVARA_CLOUD;
+  delete process.env.PROVARA_OPERATOR_EMAILS;
+}
+
+/**
+ * Seed an operator user on the given tenant (#173). Does NOT set
+ * PROVARA_CLOUD — operator bypass works regardless of deployment flag,
+ * which is by design (operators can test self-host preview deploys).
+ * Caller sets PROVARA_OPERATOR_EMAILS separately or via this helper's
+ * `registerInAllowlist` option.
+ */
+export async function seedOperatorUser(
+  db: Db,
+  tenantId: string,
+  email: string,
+  options: { registerInAllowlist?: boolean } = {},
+): Promise<void> {
+  await db
+    .insert(users)
+    .values({
+      id: nanoid(),
+      email,
+      tenantId,
+      role: "owner",
+      createdAt: new Date(),
+    })
+    .run();
+  if (options.registerInAllowlist ?? true) {
+    const existing = process.env.PROVARA_OPERATOR_EMAILS || "";
+    const set = new Set(existing.split(",").map((e) => e.trim()).filter(Boolean));
+    set.add(email);
+    process.env.PROVARA_OPERATOR_EMAILS = Array.from(set).join(",");
+  }
 }

--- a/packages/gateway/tests/tier-gate.test.ts
+++ b/packages/gateway/tests/tier-gate.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { subscriptions } from "@provara/db";
 import type { Db } from "@provara/db";
 import { makeTestDb } from "./_setup/db.js";
-import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+import { grantIntelligenceAccess, resetTierEnv, seedOperatorUser } from "./_setup/tier.js";
 
 // Mock the tenant module so our unit test can control tenant resolution
 // via a test header rather than wiring up full session/bearer auth.
@@ -167,5 +167,76 @@ describe("tenantHasIntelligenceAccess", () => {
     await grantIntelligenceAccess(db, "tenant-1");
     await db.update(subscriptions).set({ status: "canceled" }).run();
     expect(await tenantHasIntelligenceAccess(db, "tenant-1")).toBe(false);
+  });
+});
+
+describe("operator allowlist bypass (#173)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+    resetTierEnv();
+  });
+  afterEach(() => resetTierEnv());
+
+  it("HTTP middleware returns 200 for operator tenant even without PROVARA_CLOUD", async () => {
+    await seedOperatorUser(db, "op-tenant", "ops@corelumen.com");
+    // Note: PROVARA_CLOUD is NOT set — operator bypass takes precedence
+    const app = buildApp(db);
+    const res = await app.request("/gated", { headers: { "x-test-tenant": "op-tenant" } });
+    expect(res.status).toBe(200);
+  });
+
+  it("HTTP middleware returns 200 for operator tenant even without a subscription", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await seedOperatorUser(db, "op-tenant", "ops@corelumen.com");
+    const app = buildApp(db);
+    const res = await app.request("/gated", { headers: { "x-test-tenant": "op-tenant" } });
+    expect(res.status).toBe(200);
+  });
+
+  it("email comparison is case-insensitive", async () => {
+    await seedOperatorUser(db, "op-tenant", "Ops@CoreLumen.com", { registerInAllowlist: false });
+    process.env.PROVARA_OPERATOR_EMAILS = "ops@corelumen.com";
+    const app = buildApp(db);
+    const res = await app.request("/gated", { headers: { "x-test-tenant": "op-tenant" } });
+    expect(res.status).toBe(200);
+  });
+
+  it("non-operator users on the same tenant flow don't accidentally bypass", async () => {
+    // Seed an operator email that's NOT on tenant-customer, so the allowlist
+    // exists but doesn't cover this tenant.
+    process.env.PROVARA_OPERATOR_EMAILS = "ops@corelumen.com";
+    process.env.PROVARA_CLOUD = "true";
+    const app = buildApp(db);
+    const res = await app.request("/gated", { headers: { "x-test-tenant": "tenant-customer" } });
+    expect(res.status).toBe(402);
+    const body = await res.json();
+    expect(body.gate.reason).toBe("no_subscription");
+  });
+
+  it("empty PROVARA_OPERATOR_EMAILS env var is treated as no allowlist", async () => {
+    process.env.PROVARA_OPERATOR_EMAILS = "";
+    process.env.PROVARA_CLOUD = "true";
+    const app = buildApp(db);
+    const res = await app.request("/gated", { headers: { "x-test-tenant": "tenant-1" } });
+    expect(res.status).toBe(402);
+  });
+
+  it("tenantHasIntelligenceAccess returns true for operator tenant on non-cloud deployment", async () => {
+    await seedOperatorUser(db, "op-tenant", "ops@corelumen.com");
+    expect(await tenantHasIntelligenceAccess(db, "op-tenant")).toBe(true);
+  });
+
+  it("tenantHasIntelligenceAccess returns true for operator tenant even without subscription", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await seedOperatorUser(db, "op-tenant", "ops@corelumen.com");
+    expect(await tenantHasIntelligenceAccess(db, "op-tenant")).toBe(true);
+  });
+
+  it("tenantHasIntelligenceAccess returns false for non-operator tenant without sub, regardless of other operators existing", async () => {
+    await seedOperatorUser(db, "other-tenant", "ops@corelumen.com");
+    process.env.PROVARA_CLOUD = "true";
+    // Another tenant exists but this one is a customer without a sub
+    expect(await tenantHasIntelligenceAccess(db, "customer-tenant")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Closes #173. Operator email allowlist — replaces the "insert a fake enterprise subscription for every CoreLumen employee" workaround with an env-driven bypass.

`PROVARA_OPERATOR_EMAILS=ops@corelumen.com,second@corelumen.com`

Any tenant containing a user whose email is on the list bypasses subscription checks at both the HTTP middleware layer (`requireIntelligenceTier`) and the scheduler cycle layer (`tenantHasIntelligenceAccess`).

## What's not

Operator bypass is a **billing-gate bypass only** — no cross-tenant privilege, no admin-key shortcut, no ability to view other tenants' data. Multi-tenant isolation is untouched.

## Test plan

- [x] `npx vitest run` — 203/203 (8 new)
- [x] `tsc --noEmit` clean
- [ ] Manual on Railway: add `PROVARA_OPERATOR_EMAILS=cheapseatsecon@gmail.com` env var, remove the bootstrap subscription row, confirm /v1/regression/status still returns 200 and the dashboards work

## Next step after merge

Once merged, you can delete the bootstrap subscription row from Railway:
```sql
DELETE FROM subscriptions WHERE stripe_subscription_id = 'sub_bootstrap_dev';
```

Then set `PROVARA_OPERATOR_EMAILS=cheapseatsecon@gmail.com` on Railway's gateway env and redeploy. Your Intelligence panels keep working, without the fake subscription polluting analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
