### PR TITLE
fix(#178): close cross-tenant data leakage in multi-tenant queries

### DIFF
--- a/packages/gateway/src/auth/tenant.ts
+++ b/packages/gateway/src/auth/tenant.ts
@@ -1,5 +1,7 @@
 import type { Context, Next } from "hono";
 import type { Db } from "@provara/db";
+import { SQL, sql, eq } from "drizzle-orm";
+import type { Column } from "drizzle-orm";
 import { getMode } from "../config.js";
 import { getSessionFromCookie, validateSession } from "./session.js";
 import { getTokenInfo } from "./middleware.js";
@@ -9,6 +11,62 @@ const tenantMap = new WeakMap<Request, string>();
 
 export function getTenantId(req: Request): string | null {
   return tenantMap.get(req) || null;
+}
+
+/** Testing-only helper — sets the tenant on a Request for unit tests that
+ *  don't want to wire up the full session/bearer auth chain. Never call
+ *  from production code. */
+export function __testSetTenant(req: Request, tenantId: string): void {
+  tenantMap.set(req, tenantId);
+}
+
+/**
+ * Fail-safe tenant filter for database queries (#178). Replaces the
+ * previous `tenantId ? eq(col, tenantId) : undefined` pattern which
+ * was unsafe in multi-tenant mode — `undefined` where clause = "return
+ * everything" which is a cross-tenant leak waiting to happen.
+ *
+ * Behavior:
+ *   - tenantId is set        → `eq(col, tenantId)` (filter to that tenant)
+ *   - tenantId null/undefined in multi-tenant mode → `sql\`0 = 1\`` (zero rows,
+ *                              never leak cross-tenant)
+ *   - tenantId null/undefined in self_hosted mode  → undefined (no filter,
+ *                              legacy single-tenant behavior)
+ *
+ * Why the mode split: self_hosted has no tenant concept and existing data
+ * may have `tenantId = NULL` that we still want to return. Multi-tenant
+ * requires a tenant — the tenant middleware already enforces this at the
+ * HTTP layer, but queries should be safe if the middleware is ever bypassed.
+ */
+export function tenantFilter(
+  column: Column,
+  tenantId: string | null | undefined,
+): SQL | undefined {
+  if (tenantId) return eq(column, tenantId);
+  if (getMode() === "multi_tenant") {
+    return sql`0 = 1`;
+  }
+  return undefined;
+}
+
+/**
+ * Variant that combines the tenant check with an additional scope — e.g.
+ * "this row AND owned by this tenant". Same mode-aware semantics as
+ * `tenantFilter`. Useful for `WHERE id = ? AND tenant_id = ?` patterns.
+ */
+export function tenantScoped(
+  column: Column,
+  tenantId: string | null | undefined,
+  additional: SQL,
+): SQL | undefined {
+  if (tenantId) {
+    const filter = eq(column, tenantId);
+    return sql`${additional} AND ${filter}`;
+  }
+  if (getMode() === "multi_tenant") {
+    return sql`0 = 1`;
+  }
+  return additional;
 }
 
 /**

--- a/packages/gateway/src/routes/ab-tests.ts
+++ b/packages/gateway/src/routes/ab-tests.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { abTests, abTestVariants, requests, feedback, costLogs } from "@provara/db";
 import { eq, and, sql, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 export function createAbTestRoutes(db: Db) {
   const app = new Hono();
@@ -11,7 +11,7 @@ export function createAbTestRoutes(db: Db) {
   // List all A/B tests
   app.get("/", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const tests = await db.select().from(abTests).where(tenantId ? eq(abTests.tenantId, tenantId) : undefined).all();
+    const tests = await db.select().from(abTests).where(tenantFilter(abTests.tenantId, tenantId)).all();
     return c.json({ tests });
   });
 
@@ -20,7 +20,7 @@ export function createAbTestRoutes(db: Db) {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
@@ -182,7 +182,7 @@ export function createAbTestRoutes(db: Db) {
       description?: string;
     }>();
 
-    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
@@ -193,10 +193,10 @@ export function createAbTestRoutes(db: Db) {
     if (body.description !== undefined) updates.description = body.description;
 
     if (Object.keys(updates).length > 0) {
-      await db.update(abTests).set(updates).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).run();
+      await db.update(abTests).set(updates).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).run();
     }
 
-    const updated = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
+    const updated = await db.select().from(abTests).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).get();
     return c.json({ test: updated });
   });
 
@@ -205,13 +205,13 @@ export function createAbTestRoutes(db: Db) {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const test = await db.select().from(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).get();
+    const test = await db.select().from(abTests).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).get();
     if (!test) {
       return c.json({ error: { message: "A/B test not found", type: "not_found" } }, 404);
     }
 
     await db.delete(abTestVariants).where(eq(abTestVariants.abTestId, id)).run();
-    await db.delete(abTests).where(tenantId ? and(eq(abTests.id, id), eq(abTests.tenantId, tenantId)) : eq(abTests.id, id)).run();
+    await db.delete(abTests).where((() => { const tc = tenantFilter(abTests.tenantId, tenantId); return tc ? and(eq(abTests.id, id), tc) : eq(abTests.id, id); })()).run();
 
     return c.json({ deleted: true });
   });

--- a/packages/gateway/src/routes/alerts.ts
+++ b/packages/gateway/src/routes/alerts.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { alertRules, alertLogs, requests, costLogs } from "@provara/db";
 import { eq, and, sql, gte, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 /**
  * Validate a webhook URL before storing/invoking it. Guards against SSRF:
@@ -72,7 +72,7 @@ export function createAlertRoutes(db: Db) {
     const rules = await db
       .select()
       .from(alertRules)
-      .where(tenantId ? eq(alertRules.tenantId, tenantId) : undefined)
+      .where(tenantFilter(alertRules.tenantId, tenantId))
       .all();
     return c.json({ rules });
   });
@@ -128,7 +128,8 @@ export function createAlertRoutes(db: Db) {
       enabled?: boolean;
     }>();
 
-    const ruleWhere = tenantId ? and(eq(alertRules.id, id), eq(alertRules.tenantId, tenantId)) : eq(alertRules.id, id);
+    const ruleTenantClause = tenantFilter(alertRules.tenantId, tenantId);
+    const ruleWhere = ruleTenantClause ? and(eq(alertRules.id, id), ruleTenantClause) : eq(alertRules.id, id);
     const rule = await db.select().from(alertRules).where(ruleWhere).get();
     if (!rule) {
       return c.json({ error: { message: "Rule not found", type: "not_found" } }, 404);
@@ -158,7 +159,8 @@ export function createAlertRoutes(db: Db) {
   app.delete("/rules/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const ruleWhere = tenantId ? and(eq(alertRules.id, id), eq(alertRules.tenantId, tenantId)) : eq(alertRules.id, id);
+    const ruleTenantClause = tenantFilter(alertRules.tenantId, tenantId);
+    const ruleWhere = ruleTenantClause ? and(eq(alertRules.id, id), ruleTenantClause) : eq(alertRules.id, id);
     const rule = await db.select().from(alertRules).where(ruleWhere).get();
     if (!rule) {
       return c.json({ error: { message: "Rule not found", type: "not_found" } }, 404);
@@ -186,7 +188,7 @@ export function createAlertRoutes(db: Db) {
       })
       .from(alertLogs)
       .leftJoin(alertRules, eq(alertLogs.ruleId, alertRules.id))
-      .where(tenantId ? eq(alertRules.tenantId, tenantId) : undefined)
+      .where(tenantFilter(alertRules.tenantId, tenantId))
       .orderBy(desc(alertLogs.createdAt))
       .limit(limit)
       .all();
@@ -200,7 +202,10 @@ export function createAlertRoutes(db: Db) {
     const rules = await db
       .select()
       .from(alertRules)
-      .where(and(eq(alertRules.enabled, true), tenantId ? eq(alertRules.tenantId, tenantId) : undefined))
+      .where((() => {
+        const tc = tenantFilter(alertRules.tenantId, tenantId);
+        return tc ? and(eq(alertRules.enabled, true), tc) : eq(alertRules.enabled, true);
+      })())
       .all();
 
     const fired: string[] = [];
@@ -283,8 +288,8 @@ function checkCondition(value: number, condition: string, threshold: number): bo
 
 async function evaluateMetric(db: Db, metric: string, window: string, tenantId: string | null): Promise<number | null> {
   const since = new Date(Date.now() - parseWindow(window));
-  const tenantCondition = tenantId ? eq(requests.tenantId, tenantId) : undefined;
-  const costTenantCondition = tenantId ? eq(costLogs.tenantId, tenantId) : undefined;
+  const tenantCondition = tenantFilter(requests.tenantId, tenantId);
+  const costTenantCondition = tenantFilter(costLogs.tenantId, tenantId);
 
   switch (metric) {
     case "spend": {

--- a/packages/gateway/src/routes/analytics.ts
+++ b/packages/gateway/src/routes/analytics.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { requests, costLogs, abTests, feedback } from "@provara/db";
 import { desc, asc, sql, eq, and, gte } from "drizzle-orm";
 import type { SQLWrapper } from "drizzle-orm";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import type { ProviderRegistry } from "../providers/index.js";
 
 /**
@@ -59,7 +59,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
     // sliced window happen to match. The old behavior also meant `total`
     // didn't reflect the filtered count, so page navigation was wrong.
     const conditions = [
-      tenantId ? eq(requests.tenantId, tenantId) : undefined,
+      tenantFilter(requests.tenantId, tenantId),
       provider ? eq(requests.provider, provider) : undefined,
       model ? eq(requests.model, model) : undefined,
       taskType ? eq(requests.taskType, taskType) : undefined,
@@ -132,7 +132,10 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
       })
       .from(requests)
       .leftJoin(costLogs, eq(requests.id, costLogs.requestId))
-      .where(tenantId ? and(eq(requests.id, id), eq(requests.tenantId, tenantId)) : eq(requests.id, id))
+      .where((() => {
+        const tc = tenantFilter(requests.tenantId, tenantId);
+        return tc ? and(eq(requests.id, id), tc) : eq(requests.id, id);
+      })())
       .get();
 
     if (!row) {
@@ -169,7 +172,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         requestCount: sql<number>`count(*)`,
       })
       .from(costLogs)
-      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
+      .where(tenantFilter(costLogs.tenantId, tenantId))
       .groupBy(costLogs.provider)
       .all();
 
@@ -190,7 +193,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         avgCost: sql<number>`avg(${costLogs.cost})`,
       })
       .from(costLogs)
-      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
+      .where(tenantFilter(costLogs.tenantId, tenantId))
       .groupBy(costLogs.provider, costLogs.model)
       .all();
 
@@ -211,7 +214,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         avgLatency: sql<number>`avg(${requests.latencyMs})`,
       })
       .from(requests)
-      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
+      .where(tenantFilter(requests.tenantId, tenantId))
       .groupBy(requests.taskType, requests.complexity, requests.routedBy, requests.provider, requests.model)
       .all();
 
@@ -227,7 +230,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         count: sql<number>`count(*)`,
       })
       .from(requests)
-      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
+      .where(tenantFilter(requests.tenantId, tenantId))
       .groupBy(requests.taskType)
       .all();
 
@@ -237,7 +240,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         count: sql<number>`count(*)`,
       })
       .from(requests)
-      .where(tenantId ? eq(requests.tenantId, tenantId) : undefined)
+      .where(tenantFilter(requests.tenantId, tenantId))
       .groupBy(requests.complexity)
       .all();
 
@@ -247,9 +250,9 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
   // Overview stats
   app.get("/overview", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const totalRequests = await db.select({ count: sql<number>`count(*)` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
-    const totalCost = await db.select({ total: sql<number>`sum(${costLogs.cost})` }).from(costLogs).where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined).get();
-    const avgLatency = await db.select({ avg: sql<number>`avg(${requests.latencyMs})` }).from(requests).where(tenantId ? eq(requests.tenantId, tenantId) : undefined).get();
+    const totalRequests = await db.select({ count: sql<number>`count(*)` }).from(requests).where(tenantFilter(requests.tenantId, tenantId)).get();
+    const totalCost = await db.select({ total: sql<number>`sum(${costLogs.cost})` }).from(costLogs).where(tenantFilter(costLogs.tenantId, tenantId)).get();
+    const avgLatency = await db.select({ avg: sql<number>`avg(${requests.latencyMs})` }).from(requests).where(tenantFilter(requests.tenantId, tenantId)).get();
 
     // Authoritative source for "active providers" is the registry, not the
     // requests table — historical distinct-count conflated "ever routed
@@ -268,7 +271,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
   // of cache hits (exact + semantic). This is the advertisable number.
   app.get("/cache/savings", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const tenantFilter = tenantId ? eq(requests.tenantId, tenantId) : undefined;
+    const tenantWhere = tenantFilter(requests.tenantId, tenantId);
 
     const totals = await db
       .select({
@@ -277,7 +280,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         totalRequests: sql<number>`count(*)`,
       })
       .from(requests)
-      .where(tenantFilter)
+      .where(tenantWhere)
       .get();
 
     const hitCounts = await db
@@ -287,8 +290,8 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
       })
       .from(requests)
       .where(
-        tenantFilter
-          ? and(tenantFilter, eq(requests.cached, true))
+        tenantWhere
+          ? and(tenantWhere, eq(requests.cached, true))
           : eq(requests.cached, true),
       )
       .groupBy(requests.cacheSource)
@@ -304,8 +307,8 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
       })
       .from(requests)
       .where(
-        tenantFilter
-          ? and(tenantFilter, eq(requests.cached, true))
+        tenantWhere
+          ? and(tenantWhere, eq(requests.cached, true))
           : eq(requests.cached, true),
       )
       .groupBy(requests.provider, requests.model)
@@ -329,7 +332,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
   // Pipeline stage stats — per-stage request counts and latency
   app.get("/pipeline", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const tenantFilter = tenantId ? eq(requests.tenantId, tenantId) : undefined;
+    const tenantWhere = tenantFilter(requests.tenantId, tenantId);
 
     // Requests by routing method
     const byRoutedBy = await db
@@ -339,7 +342,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
         avgLatency: sql<number>`avg(${requests.latencyMs})`,
       })
       .from(requests)
-      .where(tenantFilter)
+      .where(tenantWhere)
       .groupBy(requests.routedBy)
       .all();
 
@@ -351,8 +354,8 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
       })
       .from(requests)
       .where(
-        tenantFilter
-          ? and(tenantFilter, eq(requests.usedFallback, true))
+        tenantWhere
+          ? and(tenantWhere, eq(requests.usedFallback, true))
           : eq(requests.usedFallback, true)
       )
       .get();
@@ -361,14 +364,17 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
     const activeAbTests = await db
       .select({ count: sql<number>`count(*)` })
       .from(abTests)
-      .where(tenantId ? and(eq(abTests.status, "active"), eq(abTests.tenantId, tenantId)) : eq(abTests.status, "active"))
+      .where((() => {
+        const tc = tenantFilter(abTests.tenantId, tenantId);
+        return tc ? and(eq(abTests.status, "active"), tc) : eq(abTests.status, "active");
+      })())
       .get();
 
     // Total feedback count
     const feedbackCount = await db
       .select({ count: sql<number>`count(*)` })
       .from(feedback)
-      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
+      .where(tenantFilter(feedback.tenantId, tenantId))
       .get();
 
     // Active provider count — registry is authoritative (see #157).
@@ -378,7 +384,7 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
     const totalRequests = await db
       .select({ count: sql<number>`count(*)` })
       .from(requests)
-      .where(tenantFilter)
+      .where(tenantWhere)
       .get();
 
     const routedByMap: Record<string, { count: number; avgLatency: number }> = {};
@@ -596,7 +602,13 @@ export function createAnalyticsRoutes(db: Db, registry?: ProviderRegistry) {
       })
       .from(feedback)
       .innerJoin(requests, eq(feedback.requestId, requests.id))
-      .where(and(...[gte(feedback.createdAt, since), ...(tenantId ? [eq(feedback.tenantId, tenantId)] : [])]))
+      .where(and(
+        gte(feedback.createdAt, since),
+        ...(() => {
+          const tc = tenantFilter(feedback.tenantId, tenantId);
+          return tc ? [tc] : [];
+        })(),
+      ))
       .groupBy(requests.provider, requests.model)
       .all();
 

--- a/packages/gateway/src/routes/api-keys.ts
+++ b/packages/gateway/src/routes/api-keys.ts
@@ -4,7 +4,7 @@ import { apiKeys } from "@provara/db";
 import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { encrypt, decrypt, maskKey, hasMasterKey } from "../crypto/index.js";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 export function createApiKeyRoutes(db: Db) {
   const app = new Hono();
@@ -21,7 +21,7 @@ export function createApiKeyRoutes(db: Db) {
     }
 
     const tenantId = getTenantId(c.req.raw);
-    const keys = await db.select().from(apiKeys).where(tenantId ? eq(apiKeys.tenantId, tenantId) : undefined).all();
+    const keys = await db.select().from(apiKeys).where(tenantFilter(apiKeys.tenantId, tenantId)).all();
     return c.json({
       keys: keys.map((k) => {
         let maskedValue: string;
@@ -73,7 +73,10 @@ export function createApiKeyRoutes(db: Db) {
     const existing = await db
       .select()
       .from(apiKeys)
-      .where(tenantId ? and(eq(apiKeys.name, body.name), eq(apiKeys.tenantId, tenantId)) : eq(apiKeys.name, body.name))
+      .where((() => {
+        const tc = tenantFilter(apiKeys.tenantId, tenantId);
+        return tc ? and(eq(apiKeys.name, body.name), tc) : eq(apiKeys.name, body.name);
+      })())
       .get();
 
     if (existing) {
@@ -131,7 +134,8 @@ export function createApiKeyRoutes(db: Db) {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
-    const whereClause = tenantId ? and(eq(apiKeys.id, id), eq(apiKeys.tenantId, tenantId)) : eq(apiKeys.id, id);
+    const tenantClause = tenantFilter(apiKeys.tenantId, tenantId);
+    const whereClause = tenantClause ? and(eq(apiKeys.id, id), tenantClause) : eq(apiKeys.id, id);
     const key = await db.select().from(apiKeys).where(whereClause).get();
     if (!key) {
       return c.json({ error: { message: "API key not found", type: "not_found" } }, 404);

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -205,7 +205,17 @@ async function upsertUser(
     .get();
 
   if (existingUser) {
-    // Link new OAuth provider to existing user
+    // Link new OAuth provider to existing user (#178). This merges two
+    // different OAuth accounts (different providerAccountId, same email)
+    // under the same user row → same tenantId. Intentional for
+    // "link my Google and GitHub" flows but risky when two people
+    // legitimately share an email. Logging every merge so operators
+    // can audit if cross-account data unexpectedly appears.
+    console.warn(
+      `[auth] OAuth merge: ${provider} account ${profile.id} linked to existing user ${existingUser.id} ` +
+      `(email=${profile.email}, tenant=${existingUser.tenantId}). If this user did not explicitly intend to ` +
+      `link accounts, investigate.`,
+    );
     await db.insert(oauthAccounts).values({
       id: nanoid(),
       userId: existingUser.id,

--- a/packages/gateway/src/routes/conversations.ts
+++ b/packages/gateway/src/routes/conversations.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { conversations } from "@provara/db";
 import { and, desc, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 const DEFAULT_LIMIT = 50;
 const MAX_TITLE_LENGTH = 60;
@@ -30,7 +30,6 @@ export function createConversationRoutes(db: Db) {
   app.get("/", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const limit = Math.min(parseInt(c.req.query("limit") || String(DEFAULT_LIMIT)), 200);
-    const where = tenantId ? eq(conversations.tenantId, tenantId) : undefined;
     const rows = await db
       .select({
         id: conversations.id,
@@ -39,7 +38,7 @@ export function createConversationRoutes(db: Db) {
         updatedAt: conversations.updatedAt,
       })
       .from(conversations)
-      .where(where)
+      .where(tenantFilter(conversations.tenantId, tenantId))
       .orderBy(desc(conversations.updatedAt))
       .limit(limit)
       .all();
@@ -69,9 +68,8 @@ export function createConversationRoutes(db: Db) {
   app.get("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const id = c.req.param("id");
-    const where = tenantId
-      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
-      : eq(conversations.id, id);
+    const tenantClause = tenantFilter(conversations.tenantId, tenantId);
+    const where = tenantClause ? and(eq(conversations.id, id), tenantClause) : eq(conversations.id, id);
     const row = await db.select().from(conversations).where(where).get();
     if (!row) return c.json({ error: { message: "Not found", type: "not_found" } }, 404);
     let messages: unknown = [];
@@ -90,9 +88,8 @@ export function createConversationRoutes(db: Db) {
   app.patch("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const id = c.req.param("id");
-    const where = tenantId
-      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
-      : eq(conversations.id, id);
+    const tenantClause = tenantFilter(conversations.tenantId, tenantId);
+    const where = tenantClause ? and(eq(conversations.id, id), tenantClause) : eq(conversations.id, id);
 
     const existing = await db.select().from(conversations).where(where).get();
     if (!existing) return c.json({ error: { message: "Not found", type: "not_found" } }, 404);
@@ -109,9 +106,8 @@ export function createConversationRoutes(db: Db) {
   app.delete("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const id = c.req.param("id");
-    const where = tenantId
-      ? and(eq(conversations.id, id), eq(conversations.tenantId, tenantId))
-      : eq(conversations.id, id);
+    const tenantClause = tenantFilter(conversations.tenantId, tenantId);
+    const where = tenantClause ? and(eq(conversations.id, id), tenantClause) : eq(conversations.id, id);
     await db.delete(conversations).where(where).run();
     return c.json({ deleted: true });
   });

--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -4,7 +4,7 @@ import { feedback, requests } from "@provara/db";
 import { eq, desc, sql, and, gte } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getTokenInfo } from "../auth/middleware.js";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import { getJudgeConfig, setJudgeConfig } from "../routing/judge.js";
 import type { AdaptiveRouter } from "../routing/adaptive/index.js";
 
@@ -35,7 +35,11 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
     }
 
     // Verify request exists (scoped to tenant)
-    const request = await db.select().from(requests).where(tenantId ? and(eq(requests.id, body.requestId), eq(requests.tenantId, tenantId)) : eq(requests.id, body.requestId)).get();
+    const tenantClause = tenantFilter(requests.tenantId, tenantId);
+    const requestWhere = tenantClause
+      ? and(eq(requests.id, body.requestId), tenantClause)
+      : eq(requests.id, body.requestId);
+    const request = await db.select().from(requests).where(requestWhere).get();
     if (!request) {
       return c.json(
         { error: { message: "Request not found", type: "not_found" } },
@@ -118,7 +122,7 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
       })
       .from(feedback)
       .leftJoin(requests, eq(feedback.requestId, requests.id))
-      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
+      .where(tenantFilter(feedback.tenantId, tenantId))
       .orderBy(desc(feedback.createdAt))
       .limit(limit)
       .all();
@@ -140,7 +144,7 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
       })
       .from(feedback)
       .innerJoin(requests, eq(feedback.requestId, requests.id))
-      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
+      .where(tenantFilter(feedback.tenantId, tenantId))
       .groupBy(requests.provider, requests.model, requests.taskType, requests.complexity)
       .all();
 
@@ -161,7 +165,7 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
       })
       .from(feedback)
       .innerJoin(requests, eq(feedback.requestId, requests.id))
-      .where(tenantId ? eq(feedback.tenantId, tenantId) : undefined)
+      .where(tenantFilter(feedback.tenantId, tenantId))
       .groupBy(requests.provider, requests.model)
       .all();
 
@@ -176,8 +180,9 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
     const since = new Date(Date.now() - rangeMs);
     const fmt = range === "24h" ? "%Y-%m-%d %H:00" : "%Y-%m-%d";
 
+    const tenantClauseTrend = tenantFilter(feedback.tenantId, tenantId);
     const conditions = [gte(feedback.createdAt, since)];
-    if (tenantId) conditions.push(eq(feedback.tenantId, tenantId));
+    if (tenantClauseTrend) conditions.push(tenantClauseTrend);
 
     const rows = await db
       .select({

--- a/packages/gateway/src/routes/guardrails.ts
+++ b/packages/gateway/src/routes/guardrails.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { guardrailRules, guardrailLogs } from "@provara/db";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import { ensureBuiltInRules } from "../guardrails/engine.js";
 
 export function createGuardrailRoutes(db: Db) {
@@ -17,7 +17,7 @@ export function createGuardrailRoutes(db: Db) {
     const rules = await db
       .select()
       .from(guardrailRules)
-      .where(tenantId ? eq(guardrailRules.tenantId, tenantId) : undefined)
+      .where(tenantFilter(guardrailRules.tenantId, tenantId))
       .all();
 
     return c.json({ rules });
@@ -68,8 +68,9 @@ export function createGuardrailRoutes(db: Db) {
     const { id } = c.req.param();
     const body = await c.req.json<{ enabled?: boolean; action?: string }>();
 
+    const tenantClausePatch = tenantFilter(guardrailRules.tenantId, tenantId);
     const rule = await db.select().from(guardrailRules).where(
-      tenantId ? and(eq(guardrailRules.id, id), eq(guardrailRules.tenantId, tenantId)) : eq(guardrailRules.id, id)
+      tenantClausePatch ? and(eq(guardrailRules.id, id), tenantClausePatch) : eq(guardrailRules.id, id)
     ).get();
 
     if (!rule) {
@@ -91,8 +92,9 @@ export function createGuardrailRoutes(db: Db) {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
 
+    const tenantClauseDelete = tenantFilter(guardrailRules.tenantId, tenantId);
     const rule = await db.select().from(guardrailRules).where(
-      tenantId ? and(eq(guardrailRules.id, id), eq(guardrailRules.tenantId, tenantId)) : eq(guardrailRules.id, id)
+      tenantClauseDelete ? and(eq(guardrailRules.id, id), tenantClauseDelete) : eq(guardrailRules.id, id)
     ).get();
 
     if (!rule) {
@@ -115,7 +117,7 @@ export function createGuardrailRoutes(db: Db) {
     const logs = await db
       .select()
       .from(guardrailLogs)
-      .where(tenantId ? eq(guardrailLogs.tenantId, tenantId) : undefined)
+      .where(tenantFilter(guardrailLogs.tenantId, tenantId))
       .orderBy(desc(guardrailLogs.createdAt))
       .limit(limit)
       .all();

--- a/packages/gateway/src/routes/prompts.ts
+++ b/packages/gateway/src/routes/prompts.ts
@@ -3,7 +3,7 @@ import type { Db } from "@provara/db";
 import { promptTemplates, promptVersions } from "@provara/db";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 export function createPromptRoutes(db: Db) {
   const app = new Hono();
@@ -14,7 +14,7 @@ export function createPromptRoutes(db: Db) {
     const templates = await db
       .select()
       .from(promptTemplates)
-      .where(tenantId ? eq(promptTemplates.tenantId, tenantId) : undefined)
+      .where(tenantFilter(promptTemplates.tenantId, tenantId))
       .orderBy(desc(promptTemplates.updatedAt))
       .all();
 
@@ -44,7 +44,8 @@ export function createPromptRoutes(db: Db) {
   app.get("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const where = tenantId ? and(eq(promptTemplates.id, id), eq(promptTemplates.tenantId, tenantId)) : eq(promptTemplates.id, id);
+    const tenantClause = tenantFilter(promptTemplates.tenantId, tenantId);
+    const where = tenantClause ? and(eq(promptTemplates.id, id), tenantClause) : eq(promptTemplates.id, id);
     const template = await db.select().from(promptTemplates).where(where).get();
     if (!template) {
       return c.json({ error: { message: "Template not found", type: "not_found" } }, 404);
@@ -103,7 +104,8 @@ export function createPromptRoutes(db: Db) {
   app.post("/:id/versions", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const where = tenantId ? and(eq(promptTemplates.id, id), eq(promptTemplates.tenantId, tenantId)) : eq(promptTemplates.id, id);
+    const tenantClause = tenantFilter(promptTemplates.tenantId, tenantId);
+    const where = tenantClause ? and(eq(promptTemplates.id, id), tenantClause) : eq(promptTemplates.id, id);
     const template = await db.select().from(promptTemplates).where(where).get();
     if (!template) {
       return c.json({ error: { message: "Template not found", type: "not_found" } }, 404);
@@ -154,7 +156,8 @@ export function createPromptRoutes(db: Db) {
   app.post("/:id/publish/:versionId", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id, versionId } = c.req.param();
-    const where = tenantId ? and(eq(promptTemplates.id, id), eq(promptTemplates.tenantId, tenantId)) : eq(promptTemplates.id, id);
+    const tenantClause = tenantFilter(promptTemplates.tenantId, tenantId);
+    const where = tenantClause ? and(eq(promptTemplates.id, id), tenantClause) : eq(promptTemplates.id, id);
 
     const version = await db.select().from(promptVersions)
       .where(and(eq(promptVersions.id, versionId), eq(promptVersions.templateId, id)))
@@ -175,7 +178,8 @@ export function createPromptRoutes(db: Db) {
   app.delete("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const where = tenantId ? and(eq(promptTemplates.id, id), eq(promptTemplates.tenantId, tenantId)) : eq(promptTemplates.id, id);
+    const tenantClause = tenantFilter(promptTemplates.tenantId, tenantId);
+    const where = tenantClause ? and(eq(promptTemplates.id, id), tenantClause) : eq(promptTemplates.id, id);
     const template = await db.select().from(promptTemplates).where(where).get();
     if (!template) {
       return c.json({ error: { message: "Template not found", type: "not_found" } }, 404);

--- a/packages/gateway/src/routes/providers.ts
+++ b/packages/gateway/src/routes/providers.ts
@@ -5,7 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { discoverModels, validateCompatibility } from "../providers/openai-compatible.js";
 import { getDecryptedKeys } from "./api-keys.js";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 
 export function createProviderCrudRoutes(db: Db) {
   const app = new Hono();
@@ -13,7 +13,7 @@ export function createProviderCrudRoutes(db: Db) {
   // List custom providers
   app.get("/", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const providers = await db.select().from(customProviders).where(tenantId ? eq(customProviders.tenantId, tenantId) : undefined).all();
+    const providers = await db.select().from(customProviders).where(tenantFilter(customProviders.tenantId, tenantId)).all();
     return c.json({
       providers: providers.map((p) => ({
         ...p,
@@ -26,7 +26,7 @@ export function createProviderCrudRoutes(db: Db) {
   app.get("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const provider = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id)).get();
+    const provider = await db.select().from(customProviders).where((() => { const tc = tenantFilter(customProviders.tenantId, tenantId); return tc ? and(eq(customProviders.id, id), tc) : eq(customProviders.id, id); })()).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }
@@ -52,7 +52,10 @@ export function createProviderCrudRoutes(db: Db) {
     }
 
     // Check for duplicate name (scoped to tenant)
-    const existing = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.name, body.name), eq(customProviders.tenantId, tenantId)) : eq(customProviders.name, body.name)).get();
+    const existing = await db.select().from(customProviders).where((() => {
+      const tc = tenantFilter(customProviders.tenantId, tenantId);
+      return tc ? and(eq(customProviders.name, body.name), tc) : eq(customProviders.name, body.name);
+    })()).get();
     if (existing) {
       return c.json(
         { error: { message: `Provider "${body.name}" already exists`, type: "validation_error" } },
@@ -137,7 +140,7 @@ export function createProviderCrudRoutes(db: Db) {
       enabled?: boolean;
     }>();
 
-    const whereClause = tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id);
+    const whereClause = (() => { const tc = tenantFilter(customProviders.tenantId, tenantId); return tc ? and(eq(customProviders.id, id), tc) : eq(customProviders.id, id); })();
     const provider = await db.select().from(customProviders).where(whereClause).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
@@ -162,7 +165,7 @@ export function createProviderCrudRoutes(db: Db) {
   app.delete("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const whereClause = tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id);
+    const whereClause = (() => { const tc = tenantFilter(customProviders.tenantId, tenantId); return tc ? and(eq(customProviders.id, id), tc) : eq(customProviders.id, id); })();
     const provider = await db.select().from(customProviders).where(whereClause).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
@@ -176,7 +179,7 @@ export function createProviderCrudRoutes(db: Db) {
   app.post("/:id/discover", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const provider = await db.select().from(customProviders).where(tenantId ? and(eq(customProviders.id, id), eq(customProviders.tenantId, tenantId)) : eq(customProviders.id, id)).get();
+    const provider = await db.select().from(customProviders).where((() => { const tc = tenantFilter(customProviders.tenantId, tenantId); return tc ? and(eq(customProviders.id, id), tc) : eq(customProviders.id, id); })()).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
     }

--- a/packages/gateway/src/routes/regression.ts
+++ b/packages/gateway/src/routes/regression.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import { replayBank } from "@provara/db";
 import { and, eq, isNull, sql } from "drizzle-orm";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import {
   REPLAY_WEEKLY_BUDGET_USD,
   getBudgetStatus,
@@ -23,7 +23,7 @@ export function createRegressionRoutes(db: Db, regressionCellTable?: RegressionC
     const bankCount = await db
       .select({ count: sql<number>`count(*)` })
       .from(replayBank)
-      .where(tenantId ? eq(replayBank.tenantId, tenantId) : isNull(replayBank.tenantId))
+      .where(tenantFilter(replayBank.tenantId, tenantId) ?? isNull(replayBank.tenantId))
       .get();
     return c.json({
       enabled,

--- a/packages/gateway/src/routes/tokens.ts
+++ b/packages/gateway/src/routes/tokens.ts
@@ -4,7 +4,7 @@ import { apiTokens, costLogs, requests } from "@provara/db";
 import { eq, and, gte, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { generateToken, hashToken, maskToken } from "../auth/tokens.js";
-import { getTenantId } from "../auth/tenant.js";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import { getAuthUser } from "../auth/admin.js";
 import { invalidateAuthCache } from "./../auth/middleware.js";
 
@@ -14,7 +14,7 @@ export function createTokenRoutes(db: Db) {
   // List all tokens (masked)
   app.get("/", async (c) => {
     const tenantId = getTenantId(c.req.raw);
-    const tokens = await db.select().from(apiTokens).where(tenantId ? eq(apiTokens.tenant, tenantId) : undefined).all();
+    const tokens = await db.select().from(apiTokens).where(tenantFilter(apiTokens.tenant, tenantId)).all();
     return c.json({
       tokens: tokens.map((t) => ({
         id: t.id,
@@ -36,7 +36,9 @@ export function createTokenRoutes(db: Db) {
   app.get("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const token = await db.select().from(apiTokens).where(tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id)).get();
+    const tenantClause = tenantFilter(apiTokens.tenant, tenantId);
+    const tokenWhere = tenantClause ? and(eq(apiTokens.id, id), tenantClause) : eq(apiTokens.id, id);
+    const token = await db.select().from(apiTokens).where(tokenWhere).get();
 
     if (!token) {
       return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
@@ -176,7 +178,8 @@ export function createTokenRoutes(db: Db) {
       expiresAt?: string | null;
     }>();
 
-    const tokenWhere = tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id);
+    const tenantClause = tenantFilter(apiTokens.tenant, tenantId);
+    const tokenWhere = tenantClause ? and(eq(apiTokens.id, id), tenantClause) : eq(apiTokens.id, id);
     const token = await db.select().from(apiTokens).where(tokenWhere).get();
     if (!token) {
       return c.json({ error: { message: "Token not found", type: "not_found" } }, 404);
@@ -209,7 +212,8 @@ export function createTokenRoutes(db: Db) {
   app.delete("/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();
-    const tokenWhere = tenantId ? and(eq(apiTokens.id, id), eq(apiTokens.tenant, tenantId)) : eq(apiTokens.id, id);
+    const tenantClause = tenantFilter(apiTokens.tenant, tenantId);
+    const tokenWhere = tenantClause ? and(eq(apiTokens.id, id), tenantClause) : eq(apiTokens.id, id);
     const token = await db.select().from(apiTokens).where(tokenWhere).get();
 
     if (!token) {
@@ -231,7 +235,7 @@ export function createTokenRoutes(db: Db) {
         requestCount: sql<number>`count(*)`,
       })
       .from(costLogs)
-      .where(tenantId ? eq(costLogs.tenantId, tenantId) : undefined)
+      .where(tenantFilter(costLogs.tenantId, tenantId))
       .groupBy(costLogs.tenantId)
       .all();
 

--- a/packages/gateway/tests/conversations.test.ts
+++ b/packages/gateway/tests/conversations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { Hono } from "hono";
 import { createConversationRoutes } from "../src/routes/conversations.js";
 import { makeTestDb } from "./_setup/db.js";
@@ -128,5 +128,100 @@ describe("conversations routes", () => {
     await req(app, `/v1/conversations/${created.id}`, { method: "DELETE" });
     const res = await req(app, `/v1/conversations/${created.id}`);
     expect(res.status).toBe(404);
+  });
+});
+
+describe("cross-tenant isolation (#178)", () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  async function buildMultiTenantApp() {
+    process.env.PROVARA_MODE = "multi_tenant";
+    const db = await makeTestDb();
+    const app = new Hono();
+
+    // Swap tenant resolution to read from a header so we can simulate
+    // different tenants per request without full auth plumbing.
+    app.use("*", async (c, next) => {
+      const tenantId = c.req.header("x-test-tenant");
+      if (tenantId) {
+        // Access the module's internal tenantMap through getTenantId's
+        // WeakMap keyed on the underlying Request. Using a small helper
+        // that mirrors what the real middleware does.
+        const { __testSetTenant } = await import("../src/auth/tenant.js");
+        __testSetTenant(c.req.raw, tenantId);
+      }
+      return next();
+    });
+
+    app.route("/v1/conversations", createConversationRoutes(db));
+    return { db, app };
+  }
+
+  it("tenant A cannot list tenant B's conversations", async () => {
+    const { app } = await buildMultiTenantApp();
+
+    // Tenant B creates a conversation
+    await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-b" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "tenant B secret" }] }),
+    });
+
+    // Tenant A lists
+    const res = await req(app, "/v1/conversations", { headers: { "x-test-tenant": "tenant-a" } });
+    const body = await res.json();
+    expect(body.conversations).toHaveLength(0);
+  });
+
+  it("tenant A cannot read tenant B's specific conversation by id", async () => {
+    const { app } = await buildMultiTenantApp();
+
+    const created = await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-b" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "secret" }] }),
+    }).then((r) => r.json());
+
+    const res = await req(app, `/v1/conversations/${created.id}`, {
+      headers: { "x-test-tenant": "tenant-a" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("in multi-tenant mode, a request with NO tenant context returns empty list (fail-safe)", async () => {
+    const { app } = await buildMultiTenantApp();
+
+    // Seed a conversation owned by tenant-b
+    await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-b" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "secret" }] }),
+    });
+
+    // Request without x-test-tenant header — simulates the bug where tenant
+    // resolution fails silently. Must return empty, not everything.
+    const res = await req(app, "/v1/conversations");
+    const body = await res.json();
+    expect(body.conversations).toHaveLength(0);
+  });
+
+  it("self-host mode (PROVARA_MODE unset) keeps legacy behavior — null tenant = all rows", async () => {
+    // Don't set PROVARA_MODE — defaults to self_hosted
+    const db = await makeTestDb();
+    const app = new Hono();
+    app.route("/v1/conversations", createConversationRoutes(db));
+
+    await req(app, "/v1/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "hello" }] }),
+    });
+
+    const res = await req(app, "/v1/conversations");
+    const body = await res.json();
+    expect(body.conversations).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #178. **Security-adjacent fix — ships before any real paying customers.** Closes a systemic cross-tenant data leakage path that affected ~30 database queries across 11 route files.

Reported by a second test user who opened the Playground and saw the first user's saved chat sessions in the sidebar.

## Root cause

The pattern throughout our multi-tenant queries:

```ts
const where = tenantId ? eq(table.tenantId, tenantId) : undefined;
```

In multi-tenant mode, `undefined` where clause = **"return everything across all tenants."** Any code path that reached a handler without resolved tenant context leaked cross-tenant data. The tenant middleware normally prevents this, but the query pattern itself was unsafe by construction.

## Fix

New helper `tenantFilter(column, tenantId)` in `auth/tenant.ts`, mode-aware:

| Scenario | Return |
|---|---|
| `tenantId` is set | `eq(column, tenantId)` — scope to that tenant |
| `tenantId` null/undefined in **multi-tenant mode** | `sql\`0 = 1\`` — zero rows, fail-safe |
| `tenantId` null/undefined in **self_hosted mode** | `undefined` — no filter, legacy single-tenant behavior |

Mechanically replaces every unsafe site across `conversations`, `feedback`, `analytics`, `tokens`, `guardrails`, `regression`, `ab-tests`, `alerts`, `prompts`, `api-keys`, and `providers` routes. Self-hosted behavior is preserved; multi-tenant now fails safe.

## Secondary fix: OAuth account-merge warning

`routes/auth.ts` now logs when a new OAuth sign-in merges into an existing user by email match. Intentional for "link my Google and GitHub" flows, but if two people legitimately share an email their accounts would end up sharing the same `tenant_id`. The warning makes such merges auditable post-hoc — and explains cross-account data appearances that aren't a bug in `tenantFilter` but a consequence of shared email.

## Test plan

- [x] `npx vitest run` — 207/207 (4 new isolation tests)
- [x] `tsc --noEmit` clean
- [ ] Manual on Railway: sign in as two distinct users with different emails, confirm playground conversation lists are cleanly separated
- [ ] Audit log: `grep '[auth] OAuth merge' <railway logs>` to surface any unintended account merges from the reporter's session

## What's NOT in this PR

- Migration to scope `conversations` / `feedback` / `model_scores` by tenant where they were previously global (that's #176 — the adaptive-routing global-vs-tenant question)
- Dashboard UX for the merge warning (log line is enough for operators)
- Email-merge blocker (intentional feature, can't just remove it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
