### PR TITLE
fix: drop redundant Compare Plans link (404 bug)

### DIFF
--- a/apps/web/src/components/gated-panel.tsx
+++ b/apps/web/src/components/gated-panel.tsx
@@ -83,14 +83,12 @@ export function GatedPanel({ reason, currentTier, upgradeUrl, feature, requiredT
             {isInactive ? "Manage billing" : `Upgrade to ${requiredTier.charAt(0).toUpperCase() + requiredTier.slice(1)}`}
           </a>
         )}
-        {upgradeUrl && !isSelfHost && (
-          <a
-            href={upgradeUrl}
-            className="ml-2 text-xs text-zinc-500 hover:text-zinc-300"
-          >
-            Compare plans →
-          </a>
-        )}
+        {/* Removed the "Compare plans" secondary link — it pointed at the
+         * backend's upgradeUrl (https://provara.xyz/dashboard/billing, no
+         * www) which 404'd against the actual www deployment, and it was
+         * redundant with the primary Upgrade button above which already
+         * routes to /dashboard/billing. If we ever build a public pricing
+         * page this is where it'd re-enter. */}
       </div>
     </div>
   );


### PR DESCRIPTION
Compare Plans secondary link 404'd because the backend-provided upgradeUrl had no www prefix. Also redundant with the primary Upgrade button which goes to the same place. Removed. Public /pricing marketing page is a separate follow-up.