### PR TITLE
feat(#194): scope model_scores by tenant with empty-string pool sentinel

### DIFF
--- a/packages/db/drizzle/0027_flawless_pretty_boy.sql
+++ b/packages/db/drizzle/0027_flawless_pretty_boy.sql
@@ -1,0 +1,17 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_model_scores` (
+	`tenant_id` text DEFAULT '' NOT NULL,
+	`task_type` text NOT NULL,
+	`complexity` text NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`quality_score` real NOT NULL,
+	`sample_count` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`tenant_id`, `task_type`, `complexity`, `provider`, `model`)
+);
+--> statement-breakpoint
+INSERT INTO `__new_model_scores`("task_type", "complexity", "provider", "model", "quality_score", "sample_count", "updated_at") SELECT "task_type", "complexity", "provider", "model", "quality_score", "sample_count", "updated_at" FROM `model_scores`;--> statement-breakpoint
+DROP TABLE `model_scores`;--> statement-breakpoint
+ALTER TABLE `__new_model_scores` RENAME TO `model_scores`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/packages/db/drizzle/meta/0027_snapshot.json
+++ b/packages/db/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,2666 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5c915afb-f130-4529-9fe7-e3840ddc484d",
+  "prevId": "b5d13183-2194-492a-ac15-33a0209c78a1",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1776479360120,
       "tag": "0026_naive_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1776492290150,
+      "tag": "0027_flawless_pretty_boy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -266,6 +266,7 @@ export const promptVersions = sqliteTable("prompt_versions", {
 });
 
 export const modelScores = sqliteTable("model_scores", {
+  tenantId: text("tenant_id").notNull().default(""),
   taskType: text("task_type").notNull(),
   complexity: text("complexity").notNull(),
   provider: text("provider").notNull(),
@@ -276,7 +277,7 @@ export const modelScores = sqliteTable("model_scores", {
     .notNull()
     .$defaultFn(() => new Date()),
 }, (table) => [
-  primaryKey({ columns: [table.taskType, table.complexity, table.provider, table.model] }),
+  primaryKey({ columns: [table.tenantId, table.taskType, table.complexity, table.provider, table.model] }),
 ]);
 
 /**

--- a/packages/gateway/src/routing/adaptive/persistence.ts
+++ b/packages/gateway/src/routing/adaptive/persistence.ts
@@ -2,16 +2,23 @@ import type { Db } from "@provara/db";
 import { feedback, modelScores, requests } from "@provara/db";
 import { eq, sql } from "drizzle-orm";
 import { getModelCost } from "./scoring.js";
-import type { ScoreStore } from "./score-store.js";
+import { POOL_KEY, type ScoreStore } from "./score-store.js";
 
 /**
  * Hydrate the in-memory score store from the DB. Precedence:
  *
  *   1. `model_scores` rows — authoritative live EMA persisted across restarts.
+ *      Rows are keyed by (tenantId, taskType, complexity, provider, model).
+ *      Pool rows have `tenantId = POOL_KEY` ("") — see score-store.ts for why.
  *   2. `feedback` aggregation — seed for cells that have feedback history
  *      but no `model_scores` row yet (first boot after the table was added,
  *      or cells that predate live learning). Once `updateScore` fires for
  *      a cell, step 2 no longer applies to it.
+ *
+ * Feedback + latency aggregations remain pool-scoped in C1. Per-tenant
+ * feedback hydration is a C2 concern (#195) — adding it here would change
+ * pool behavior because the aggregate over all `requests` is what the
+ * pool has always used.
  *
  * Latency EMA is seeded from the rolling average of logged requests, since
  * it's never written to `model_scores`.
@@ -19,6 +26,7 @@ import type { ScoreStore } from "./score-store.js";
 export async function loadScoresFromDb(db: Db, store: ScoreStore): Promise<void> {
   const persisted = await db
     .select({
+      tenantId: modelScores.tenantId,
       taskType: modelScores.taskType,
       complexity: modelScores.complexity,
       provider: modelScores.provider,
@@ -31,7 +39,7 @@ export async function loadScoresFromDb(db: Db, store: ScoreStore): Promise<void>
     .all();
 
   for (const row of persisted) {
-    const cell = store.ensureCell(row.taskType, row.complexity);
+    const cell = store.ensureCell(row.taskType, row.complexity, row.tenantId);
     cell.set(`${row.provider}:${row.model}`, {
       provider: row.provider,
       model: row.model,
@@ -96,8 +104,11 @@ export async function loadScoresFromDb(db: Db, store: ScoreStore): Promise<void>
 
 /**
  * Upsert a single `model_scores` row. Composite primary key is
- * (taskType, complexity, provider, model) — conflict on any of those
+ * (tenantId, taskType, complexity, provider, model) — conflict on any of those
  * updates the score in place rather than inserting a duplicate.
+ *
+ * `tenantId` defaults to `POOL_KEY` ("") so existing pool-scoped callers
+ * (pre-#176/C2) behave identically.
  */
 export async function persistScore(
   db: Db,
@@ -107,13 +118,20 @@ export async function persistScore(
   model: string,
   qualityScore: number,
   sampleCount: number,
+  tenantId: string = POOL_KEY,
 ): Promise<void> {
   const updatedAt = new Date();
   await db
     .insert(modelScores)
-    .values({ taskType, complexity, provider, model, qualityScore, sampleCount, updatedAt })
+    .values({ tenantId, taskType, complexity, provider, model, qualityScore, sampleCount, updatedAt })
     .onConflictDoUpdate({
-      target: [modelScores.taskType, modelScores.complexity, modelScores.provider, modelScores.model],
+      target: [
+        modelScores.tenantId,
+        modelScores.taskType,
+        modelScores.complexity,
+        modelScores.provider,
+        modelScores.model,
+      ],
       set: { qualityScore, sampleCount, updatedAt },
     })
     .run();

--- a/packages/gateway/src/routing/adaptive/router.ts
+++ b/packages/gateway/src/routing/adaptive/router.ts
@@ -4,7 +4,7 @@ import type { RouteTarget } from "../types.js";
 import { EMA_ALPHA, ema, getQualityAlpha } from "./ema.js";
 import { MIN_SAMPLES, computeRouteScore, getModelCost, resolveWeights } from "./scoring.js";
 import { isStaleTimestamp, pickExploration } from "./exploration.js";
-import { createScoreStore, type ScoreStore } from "./score-store.js";
+import { POOL_KEY, createScoreStore, type ScoreStore } from "./score-store.js";
 import { loadScoresFromDb, persistScore } from "./persistence.js";
 import type { FeedbackSource, ModelScore, RoutingProfile, RoutingWeights } from "./types.js";
 
@@ -31,6 +31,11 @@ export interface AdaptiveRouterOptions {
  * The in-memory score store is hydrated at construction time and stays in
  * sync via `updateScore` / `updateLatency`. Single-process constraints
  * apply — see `score-store.ts` for the horizontal-scaling note.
+ *
+ * Tenant scoping added by #194 (C1 of #176). All public methods accept an
+ * optional trailing `tenantId`; omitting it (or passing `null`/`undefined`)
+ * operates on the shared pool — identical to pre-#176 behavior. Call sites
+ * that actually want tenant-aware routing live in C2 (#195).
  */
 export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOptions = {}) {
   const store: ScoreStore = createScoreStore();
@@ -44,9 +49,10 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     model: string,
     newScore: number,
     source: FeedbackSource,
+    tenantId?: string | null,
   ): Promise<void> {
     const alpha = getQualityAlpha(source);
-    const existing = store.get(taskType, complexity, provider, model);
+    const existing = store.get(taskType, complexity, provider, model, tenantId);
     const now = new Date();
 
     let qualityScore: number;
@@ -60,18 +66,32 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     } else {
       qualityScore = newScore;
       sampleCount = 1;
-      store.set(taskType, complexity, {
-        provider,
-        model,
-        qualityScore,
-        sampleCount,
-        costPer1M: getModelCost(model),
-        avgLatencyMs: 0,
-        updatedAt: now,
-      });
+      store.set(
+        taskType,
+        complexity,
+        {
+          provider,
+          model,
+          qualityScore,
+          sampleCount,
+          costPer1M: getModelCost(model),
+          avgLatencyMs: 0,
+          updatedAt: now,
+        },
+        tenantId,
+      );
     }
 
-    await persistScore(db, taskType, complexity, provider, model, qualityScore, sampleCount);
+    await persistScore(
+      db,
+      taskType,
+      complexity,
+      provider,
+      model,
+      qualityScore,
+      sampleCount,
+      tenantId ?? POOL_KEY,
+    );
   }
 
   function updateLatency(
@@ -80,8 +100,9 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     provider: string,
     model: string,
     latencyMs: number,
+    tenantId?: string | null,
   ): void {
-    const existing = store.get(taskType, complexity, provider, model);
+    const existing = store.get(taskType, complexity, provider, model, tenantId);
     if (existing) {
       existing.avgLatencyMs = ema(existing.avgLatencyMs, latencyMs, EMA_ALPHA);
     }
@@ -105,8 +126,9 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     availableProviders: Set<string>,
     allCandidates: RouteTarget[],
     customWeights?: RoutingWeights,
+    tenantId?: string | null,
   ): { target: RouteTarget; via: "adaptive" | "exploration" } | null {
-    const cellMap = store.getCellMap(taskType, complexity);
+    const cellMap = store.getCellMap(taskType, complexity, tenantId);
     const stale = isCellStale(cellMap);
     const regressed = isCellRegressing(taskType, complexity);
     const exploration = pickExploration(allCandidates, availableProviders, { stale, regressed });
@@ -143,12 +165,18 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     return best ? { target: best.target, via: "adaptive" } : null;
   }
 
-  function getCellScores(taskType: string, complexity: string): ModelScore[] {
-    return store.getCellScores(taskType, complexity);
+  function getCellScores(
+    taskType: string,
+    complexity: string,
+    tenantId?: string | null,
+  ): ModelScore[] {
+    return store.getCellScores(taskType, complexity, tenantId);
   }
 
-  function getAllScores(): { taskType: string; complexity: string; scores: ModelScore[] }[] {
-    return store.getAllScores();
+  function getAllScores(
+    tenantId?: string | null,
+  ): { taskType: string; complexity: string; scores: ModelScore[] }[] {
+    return store.getAllScores(tenantId);
   }
 
   /**
@@ -173,13 +201,17 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
   }
 
   /** Public read for analytics/UI: is this cell past the stale threshold? */
-  function isStale(taskType: string, complexity: string): boolean {
-    return isCellStale(store.getCellMap(taskType, complexity));
+  function isStale(taskType: string, complexity: string, tenantId?: string | null): boolean {
+    return isCellStale(store.getCellMap(taskType, complexity, tenantId));
   }
 
   /** Public read for analytics/UI: the cell's most-recent updatedAt. */
-  function lastUpdated(taskType: string, complexity: string): Date | null {
-    return cellLastUpdated(store.getCellMap(taskType, complexity));
+  function lastUpdated(
+    taskType: string,
+    complexity: string,
+    tenantId?: string | null,
+  ): Date | null {
+    return cellLastUpdated(store.getCellMap(taskType, complexity, tenantId));
   }
 
   await loadScoresFromDb(db, store);

--- a/packages/gateway/src/routing/adaptive/score-store.ts
+++ b/packages/gateway/src/routing/adaptive/score-store.ts
@@ -1,5 +1,17 @@
 import type { ModelScore } from "./types.js";
 
+/**
+ * Sentinel for the shared-pool row in `model_scores`. Empty string, not NULL,
+ * because SQLite treats NULL values in composite PK columns as distinct —
+ * `ON CONFLICT (tenant_id, ...)` does not fire for NULL and you'd accumulate
+ * duplicates on every upsert. See #176/#194 for the trace; the decision lives
+ * in memory `project_adaptive_isolation_state_mgmt.md`.
+ *
+ * This constant leaks nowhere outside the routing subsystem — API surfaces,
+ * dashboards, and Privacy Policy treat the pool as "no tenant" conceptually.
+ */
+export const POOL_KEY = "";
+
 export function cellKey(taskType: string, complexity: string): string {
   return `${taskType}:${complexity}`;
 }
@@ -8,8 +20,16 @@ export function modelKey(provider: string, model: string): string {
   return `${provider}:${model}`;
 }
 
+export function resolveTenantKey(tenantId: string | null | undefined): string {
+  return tenantId ?? POOL_KEY;
+}
+
 /**
- * In-memory score map. One entry per `(taskType, complexity, provider, model)`.
+ * In-memory score map. One entry per `(tenant, taskType, complexity, provider, model)`.
+ *
+ * Tenant dimension added by #194 (C1 of #176). The pool is keyed by `POOL_KEY`
+ * (empty string). Default-arg callers (no `tenantId`) act on the pool, preserving
+ * pre-tenant-scoping behavior.
  *
  * Single-instance caveat: this map lives in process memory. Multiple gateway
  * replicas each hold a drifting copy; writes from replica-1 don't reach
@@ -28,44 +48,85 @@ export function modelKey(provider: string, model: string): string {
  * switching to an immutable-snapshot pattern first. Tracked in #137.
  */
 export function createScoreStore() {
-  const scores = new Map<string, Map<string, ModelScore>>();
+  // Outer key = tenantKey (POOL_KEY for pool). Middle = cellKey. Inner = modelKey.
+  const scores = new Map<string, Map<string, Map<string, ModelScore>>>();
 
-  function ensureCell(ck: string): Map<string, ModelScore> {
-    let cell = scores.get(ck);
+  function ensureTenantMap(tk: string): Map<string, Map<string, ModelScore>> {
+    let tenant = scores.get(tk);
+    if (!tenant) {
+      tenant = new Map();
+      scores.set(tk, tenant);
+    }
+    return tenant;
+  }
+
+  function ensureCellFor(tk: string, ck: string): Map<string, ModelScore> {
+    const tenant = ensureTenantMap(tk);
+    let cell = tenant.get(ck);
     if (!cell) {
       cell = new Map();
-      scores.set(ck, cell);
+      tenant.set(ck, cell);
     }
     return cell;
   }
 
   return {
-    get(taskType: string, complexity: string, provider: string, model: string): ModelScore | undefined {
-      return scores.get(cellKey(taskType, complexity))?.get(modelKey(provider, model));
+    get(
+      taskType: string,
+      complexity: string,
+      provider: string,
+      model: string,
+      tenantId?: string | null,
+    ): ModelScore | undefined {
+      return scores
+        .get(resolveTenantKey(tenantId))
+        ?.get(cellKey(taskType, complexity))
+        ?.get(modelKey(provider, model));
     },
 
-    set(taskType: string, complexity: string, score: ModelScore): void {
-      const cell = ensureCell(cellKey(taskType, complexity));
+    set(
+      taskType: string,
+      complexity: string,
+      score: ModelScore,
+      tenantId?: string | null,
+    ): void {
+      const cell = ensureCellFor(resolveTenantKey(tenantId), cellKey(taskType, complexity));
       cell.set(modelKey(score.provider, score.model), score);
     },
 
-    getCellMap(taskType: string, complexity: string): Map<string, ModelScore> | undefined {
-      return scores.get(cellKey(taskType, complexity));
+    getCellMap(
+      taskType: string,
+      complexity: string,
+      tenantId?: string | null,
+    ): Map<string, ModelScore> | undefined {
+      return scores.get(resolveTenantKey(tenantId))?.get(cellKey(taskType, complexity));
     },
 
     /** Used by persistence to hydrate rows without going through `set` for each. */
-    ensureCell(taskType: string, complexity: string): Map<string, ModelScore> {
-      return ensureCell(cellKey(taskType, complexity));
+    ensureCell(
+      taskType: string,
+      complexity: string,
+      tenantId?: string | null,
+    ): Map<string, ModelScore> {
+      return ensureCellFor(resolveTenantKey(tenantId), cellKey(taskType, complexity));
     },
 
-    getCellScores(taskType: string, complexity: string): ModelScore[] {
-      const cell = scores.get(cellKey(taskType, complexity));
+    getCellScores(
+      taskType: string,
+      complexity: string,
+      tenantId?: string | null,
+    ): ModelScore[] {
+      const cell = scores.get(resolveTenantKey(tenantId))?.get(cellKey(taskType, complexity));
       return cell ? Array.from(cell.values()) : [];
     },
 
-    getAllScores(): { taskType: string; complexity: string; scores: ModelScore[] }[] {
+    getAllScores(
+      tenantId?: string | null,
+    ): { taskType: string; complexity: string; scores: ModelScore[] }[] {
+      const tenant = scores.get(resolveTenantKey(tenantId));
+      if (!tenant) return [];
       const result: { taskType: string; complexity: string; scores: ModelScore[] }[] = [];
-      for (const [ck, cell] of scores) {
+      for (const [ck, cell] of tenant) {
         const [taskType, complexity] = ck.split(":");
         result.push({ taskType, complexity, scores: Array.from(cell.values()) });
       }

--- a/packages/gateway/tests/adaptive-tenant-scope.test.ts
+++ b/packages/gateway/tests/adaptive-tenant-scope.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { modelScores } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import { createScoreStore, POOL_KEY } from "../src/routing/adaptive/score-store.js";
+import { loadScoresFromDb, persistScore } from "../src/routing/adaptive/persistence.js";
+import { createAdaptiveRouter } from "../src/routing/adaptive/router.js";
+
+/**
+ * Foundation tests for #194 (C1 of #176). Verifies that the model_scores
+ * tenant-scoping plumbing round-trips correctly *without* changing pool-only
+ * behavior. Behavior change happens in C2 (#195).
+ */
+describe("adaptive tenant scope — C1 foundation", () => {
+  describe("persistScore", () => {
+    it("writes to the pool row when tenantId is omitted", async () => {
+      const db = await makeTestDb();
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.8, 3);
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe(POOL_KEY);
+      expect(rows[0].qualityScore).toBeCloseTo(0.8);
+      expect(rows[0].sampleCount).toBe(3);
+    });
+
+    it("ON CONFLICT updates the pool row in place (not duplicates)", async () => {
+      const db = await makeTestDb();
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.5, 1);
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.9, 2);
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].qualityScore).toBeCloseTo(0.9);
+      expect(rows[0].sampleCount).toBe(2);
+    });
+
+    it("writes tenant-scoped rows that coexist with the pool row", async () => {
+      const db = await makeTestDb();
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.5, 1);
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.9, 2, "tenant-a");
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.3, 1, "tenant-b");
+
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(3);
+
+      const pool = rows.find((r) => r.tenantId === POOL_KEY);
+      const a = rows.find((r) => r.tenantId === "tenant-a");
+      const b = rows.find((r) => r.tenantId === "tenant-b");
+      expect(pool?.qualityScore).toBeCloseTo(0.5);
+      expect(a?.qualityScore).toBeCloseTo(0.9);
+      expect(b?.qualityScore).toBeCloseTo(0.3);
+    });
+
+    it("ON CONFLICT within a tenant updates that tenant's row only", async () => {
+      const db = await makeTestDb();
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.5, 1, "tenant-a");
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.7, 5, "tenant-a");
+
+      const tenantRow = await db
+        .select()
+        .from(modelScores)
+        .where(
+          and(
+            eq(modelScores.tenantId, "tenant-a"),
+            eq(modelScores.provider, "openai"),
+            eq(modelScores.model, "gpt-4"),
+          ),
+        )
+        .get();
+      expect(tenantRow?.qualityScore).toBeCloseTo(0.7);
+      expect(tenantRow?.sampleCount).toBe(5);
+
+      const total = await db.select().from(modelScores).all();
+      expect(total).toHaveLength(1);
+    });
+  });
+
+  describe("ScoreStore", () => {
+    it("default-arg get/set operates on the pool dimension", () => {
+      const store = createScoreStore();
+      store.set("coding", "medium", {
+        provider: "openai",
+        model: "gpt-4",
+        qualityScore: 0.8,
+        sampleCount: 3,
+        costPer1M: 0,
+        avgLatencyMs: 0,
+      });
+      expect(store.get("coding", "medium", "openai", "gpt-4")?.qualityScore).toBeCloseTo(0.8);
+    });
+
+    it("tenant-scoped writes do not bleed across tenants or into the pool", () => {
+      const store = createScoreStore();
+      store.set(
+        "coding",
+        "medium",
+        {
+          provider: "openai",
+          model: "gpt-4",
+          qualityScore: 0.9,
+          sampleCount: 1,
+          costPer1M: 0,
+          avgLatencyMs: 0,
+        },
+        "tenant-a",
+      );
+
+      expect(store.get("coding", "medium", "openai", "gpt-4", "tenant-a")?.qualityScore).toBeCloseTo(0.9);
+      expect(store.get("coding", "medium", "openai", "gpt-4", "tenant-b")).toBeUndefined();
+      expect(store.get("coding", "medium", "openai", "gpt-4")).toBeUndefined();
+    });
+
+    it("getAllScores is tenant-scoped", () => {
+      const store = createScoreStore();
+      const mk = (q: number) => ({
+        provider: "openai",
+        model: "gpt-4",
+        qualityScore: q,
+        sampleCount: 1,
+        costPer1M: 0,
+        avgLatencyMs: 0,
+      });
+      store.set("coding", "medium", mk(0.5));
+      store.set("coding", "medium", mk(0.9), "tenant-a");
+
+      expect(store.getAllScores()[0].scores[0].qualityScore).toBeCloseTo(0.5);
+      expect(store.getAllScores("tenant-a")[0].scores[0].qualityScore).toBeCloseTo(0.9);
+      expect(store.getAllScores("tenant-b")).toEqual([]);
+    });
+  });
+
+  describe("loadScoresFromDb", () => {
+    it("hydrates pool rows and tenant rows into separate store dimensions", async () => {
+      const db = await makeTestDb();
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.5, 1);
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.8, 3, "tenant-a");
+      await persistScore(db, "coding", "medium", "openai", "gpt-4", 0.3, 2, "tenant-b");
+
+      const store = createScoreStore();
+      await loadScoresFromDb(db, store);
+
+      expect(store.get("coding", "medium", "openai", "gpt-4")?.qualityScore).toBeCloseTo(0.5);
+      expect(store.get("coding", "medium", "openai", "gpt-4", "tenant-a")?.qualityScore).toBeCloseTo(0.8);
+      expect(store.get("coding", "medium", "openai", "gpt-4", "tenant-b")?.qualityScore).toBeCloseTo(0.3);
+    });
+  });
+
+  describe("router.updateScore", () => {
+    it("default-arg updates the pool row only", async () => {
+      const db = await makeTestDb();
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user");
+
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe(POOL_KEY);
+    });
+
+    it("tenant-scoped updates write a tenant row without touching the pool", async () => {
+      const db = await makeTestDb();
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.5, "user");
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user", "tenant-a");
+
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(2);
+
+      const pool = rows.find((r) => r.tenantId === POOL_KEY);
+      const tenant = rows.find((r) => r.tenantId === "tenant-a");
+      expect(pool?.qualityScore).toBeCloseTo(0.5);
+      expect(tenant?.qualityScore).toBeCloseTo(0.9);
+    });
+
+    it("tenant isolation — tenant-a ratings do not influence tenant-b", async () => {
+      const db = await makeTestDb();
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user", "tenant-a");
+
+      expect(router.getCellScores("coding", "medium", "tenant-b")).toEqual([]);
+      expect(router.getCellScores("coding", "medium")).toEqual([]);
+      expect(router.getCellScores("coding", "medium", "tenant-a")).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #194. Foundation for #176 — no behavior change.

## Summary

Adds tenant scoping to the `model_scores` EMA table and the in-memory `ScoreStore`, as the foundation for #176's tenant-aware adaptive routing (Option D). Router, feedback, and judge call sites are **unchanged** — they all still operate on the shared pool row. Tenant-aware call sites ship in C2 (#195).

- Schema: `model_scores.tenant_id TEXT NOT NULL DEFAULT ""`, PK `(tenant_id, task_type, complexity, provider, model)`.
- Pool sentinel is `tenant_id = ""`, not NULL. SQLite treats NULL values in composite PK columns as distinct — `ON CONFLICT` does not fire and duplicates accumulate. Verified empirically; see the `[shiplog/implementation-issue]` comment on #194.
- `ScoreStore` is now `Map<tenantKey, Map<cellKey, Map<modelKey, ModelScore>>>`. `POOL_KEY = ""` is internal only.
- Public API (`updateScore`, `getBestModel`, `updateLatency`, `getCellScores`, `getAllScores`, `isStale`, `lastUpdated`) takes an optional trailing `tenantId?: string | null`. Omitting it uses the pool, preserving pre-C1 behavior.
- `persistScore` and `loadScoresFromDb` thread `tenantId` end-to-end.
- Migration `0027_flawless_pretty_boy.sql` — SQLite table-swap, hand-edited to omit `tenant_id` from the data-copy INSERT so existing rows take the default `""` and become pool rows. Applied cleanly to dev DB.

## Why this split

C1 is pure plumbing. C2 (#195) flips call sites and wires in the tier-gated read/write policy. Keeping them separate means the risky schema change lands in isolation — reviewable, easy to revert, zero behavioral coupling.

## Test plan

- [x] Existing suite green: 271 → 282 tests (11 added, 0 broken).
- [x] `tests/adaptive-tenant-scope.test.ts` covers: pool default-arg writes, ON CONFLICT updates pool in place (not duplicates), tenant + pool coexistence, ON CONFLICT within a tenant updates only that tenant, ScoreStore default-arg = pool, tenant isolation (A writes → B reads undefined), `loadScoresFromDb` round-trips all three dimensions, router default-arg writes pool, router tenant-scoped writes leave pool untouched, cross-tenant bleed regression test.
- [x] Typecheck green across `@provara/db`, `@provara/gateway`, `apps/web`.
- [ ] UI visual QA deferred — this PR has no UI surface; the pool-only routing behavior is unchanged.

## Timeline

- #194 filed 2026-04-18 as a scoped child of #176.
- Implementation plan posted to #194 proposing NULL-row pool.
- First migration generated, round-trip test on dev DB revealed SQLite NULL-in-PK semantics are incompatible with pool-row uniqueness.
- Switched to empty-string sentinel; correction comment posted to #194.
- Plumbing complete; 11 new tests green; zero regression.

Last-code-by: opus-4-7 (claude-code)
