### PR TITLE
feat(#195): tenant-aware router with tier-gated pool reads + writes

### DIFF
--- a/packages/db/drizzle/0028_amazing_sabretooth.sql
+++ b/packages/db/drizzle/0028_amazing_sabretooth.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `adaptive_isolation_preferences_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text NOT NULL,
+	`field` text NOT NULL,
+	`old_value` integer NOT NULL,
+	`new_value` integer NOT NULL,
+	`changed_at` integer NOT NULL,
+	`changed_by` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `tenant_adaptive_isolation` (
+	`tenant_id` text PRIMARY KEY NOT NULL,
+	`consumes_pool` integer DEFAULT false NOT NULL,
+	`contributes_pool` integer DEFAULT false NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/db/drizzle/meta/0028_snapshot.json
+++ b/packages/db/drizzle/meta/0028_snapshot.json
@@ -1,0 +1,2765 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "40e2d701-ac44-4d8d-ba3d-eae604d0da89",
+  "prevId": "5c915afb-f130-4529-9fe7-e3840ddc484d",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "adaptive_isolation_preferences_log": {
+      "name": "adaptive_isolation_preferences_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_adaptive_isolation": {
+      "name": "tenant_adaptive_isolation",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumes_pool": {
+          "name": "consumes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contributes_pool": {
+          "name": "contributes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1776492290150,
       "tag": "0027_flawless_pretty_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1776493737525,
+      "tag": "0028_amazing_sabretooth",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -281,6 +281,44 @@ export const modelScores = sqliteTable("model_scores", {
 ]);
 
 /**
+ * Per-tenant adaptive isolation toggles (#176 / #195). Rows exist only for
+ * tenants that have ever had their toggles touched — absence means "tier
+ * defaults apply". The live policy is computed by
+ * `tenantAdaptiveIsolationPolicy(db, tenantId)` which layers defaults +
+ * this row.
+ *
+ * Boolean semantics (SQLite ints 0/1). Toggles are valid only for Team
+ * and Enterprise tiers; API-side enforcement rejects writes from Free
+ * and Pro tenants.
+ */
+export const tenantAdaptiveIsolation = sqliteTable("tenant_adaptive_isolation", {
+  tenantId: text("tenant_id").primaryKey(),
+  consumesPool: integer("consumes_pool", { mode: "boolean" }).notNull().default(false),
+  contributesPool: integer("contributes_pool", { mode: "boolean" }).notNull().default(false),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+/**
+ * Append-only audit log of every change to a tenant's isolation toggles.
+ * Supports Enterprise "when was I contributing to the pool?" audits and
+ * our own debugging. `changedBy` is the user id that performed the
+ * change, or a literal `"operator"` for admin overrides.
+ */
+export const adaptiveIsolationPreferencesLog = sqliteTable("adaptive_isolation_preferences_log", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id").notNull(),
+  field: text("field").notNull(), // 'consumes_pool' | 'contributes_pool'
+  oldValue: integer("old_value", { mode: "boolean" }).notNull(),
+  newValue: integer("new_value", { mode: "boolean" }).notNull(),
+  changedAt: integer("changed_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  changedBy: text("changed_by").notNull(),
+});
+
+/**
  * Persistent playground conversations. Sessions are tenant-scoped; the
  * `messages` column stores the full transcript as JSON (serialized
  * `ChatMessage[]`) because turns are a UI grouping, not an analytics

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -263,6 +263,7 @@ export async function createRouter(ctx: RouterContext) {
 
     // Route the request through the intelligent routing engine
     const tokenInfo = getTokenInfo(c.req.raw);
+    const tenantId = tokenInfo?.tenant || getTenantId(c.req.raw) || null;
     const routingResult = await routingEngine.route({
       messages: request.messages,
       provider: providerName,
@@ -271,9 +272,8 @@ export async function createRouter(ctx: RouterContext) {
       complexityHint: complexity_hint,
       routingProfile: (tokenInfo?.routingProfile as RoutingProfile) || undefined,
       routingWeights: tokenInfo?.routingWeights || undefined,
+      tenantId,
     });
-
-    const tenantId = tokenInfo?.tenant || getTenantId(c.req.raw) || null;
 
     // Check cache before calling any provider.
     // Cache lookup order: exact-match (in-memory) → semantic-match (embedding

--- a/packages/gateway/src/routes/feedback.ts
+++ b/packages/gateway/src/routes/feedback.ts
@@ -96,6 +96,7 @@ export function createFeedbackRoutes(db: Db, adaptive: AdaptiveRouter) {
         request.model,
         body.score,
         "user",
+        resolvedTenant,
       );
     }
 

--- a/packages/gateway/src/routing/adaptive/isolation-policy.ts
+++ b/packages/gateway/src/routing/adaptive/isolation-policy.ts
@@ -1,0 +1,104 @@
+import type { Db } from "@provara/db";
+import { tenantAdaptiveIsolation } from "@provara/db";
+import { eq } from "drizzle-orm";
+import { isCloudDeployment } from "../../config.js";
+import { getSubscriptionForTenant } from "../../stripe/subscriptions.js";
+
+/**
+ * Tier-aware adaptive isolation policy per #176/#195. Four fields:
+ *
+ * - `writesTenantRow` — does this tenant maintain its own `model_scores`
+ *   row dimension (i.e. are we keeping per-tenant EMA)?
+ * - `writesPool` — do feedback ratings update the shared pool row?
+ * - `readsTenantRow` — does the router consult the tenant's row at
+ *   decision time?
+ * - `readsPool` — does the router consult the shared pool row (either
+ *   primary or as fallback when the tenant row is empty/insufficient)?
+ *
+ * The combinations allowed per tier:
+ *
+ * | Tier       | writesTenant | writesPool  | readsTenant | readsPool    |
+ * |------------|--------------|-------------|-------------|--------------|
+ * | free       | false        | true        | false       | true         |
+ * | pro        | false        | true        | false       | true         |
+ * | team       | true         | toggle      | true        | toggle       |
+ * | enterprise | true         | toggle      | true        | toggle       |
+ *
+ * For Free/Pro there are no toggles — they are always in the shared pool.
+ * For Team/Enterprise the defaults are isolated, and two opt-in toggles
+ * (`consumes_pool`, `contributes_pool`) flip `readsPool` and `writesPool`.
+ *
+ * Self-host (`PROVARA_CLOUD=false`) is single-tenant by definition, so
+ * everyone is treated as Free-equivalent regardless of inputs.
+ */
+export type Tier = "free" | "pro" | "team" | "enterprise";
+
+export interface IsolationPolicy {
+  tier: Tier;
+  writesTenantRow: boolean;
+  writesPool: boolean;
+  readsTenantRow: boolean;
+  readsPool: boolean;
+}
+
+const FREE_POLICY: IsolationPolicy = {
+  tier: "free",
+  writesTenantRow: false,
+  writesPool: true,
+  readsTenantRow: false,
+  readsPool: true,
+};
+
+const PRO_POLICY: IsolationPolicy = {
+  ...FREE_POLICY,
+  tier: "pro",
+};
+
+/** Which tiers are eligible for the per-tenant isolation toggles. */
+const ISOLATION_TIERS = new Set<Tier>(["team", "enterprise"]);
+
+const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
+
+function normalizeTier(raw: string | null | undefined): Tier {
+  if (raw === "pro" || raw === "team" || raw === "enterprise") return raw;
+  return "free";
+}
+
+/**
+ * Resolve the live isolation policy for a tenant. Hits two tables in
+ * the worst case (subscription + preferences), both indexed on
+ * tenantId. Not cached yet — see #195 comment; add TTL caching if
+ * latency shows up in hot-path tracing.
+ */
+export async function getTenantIsolationPolicy(
+  db: Db,
+  tenantId: string | null | undefined,
+): Promise<IsolationPolicy> {
+  // Self-host: single tenant, pool-only. Same path as Free.
+  if (!isCloudDeployment()) return FREE_POLICY;
+
+  // Unauthenticated / anonymous: pool-only, like Free. No tenant row exists.
+  if (!tenantId) return FREE_POLICY;
+
+  const sub = await getSubscriptionForTenant(db, tenantId);
+  const tier = sub && ACTIVE_STATUSES.has(sub.status) ? normalizeTier(sub.tier) : "free";
+
+  if (!ISOLATION_TIERS.has(tier)) {
+    return tier === "pro" ? PRO_POLICY : FREE_POLICY;
+  }
+
+  // Team/Enterprise: load toggles.
+  const prefs = await db
+    .select()
+    .from(tenantAdaptiveIsolation)
+    .where(eq(tenantAdaptiveIsolation.tenantId, tenantId))
+    .get();
+
+  return {
+    tier,
+    writesTenantRow: true,
+    readsTenantRow: true,
+    writesPool: prefs?.contributesPool ?? false,
+    readsPool: prefs?.consumesPool ?? false,
+  };
+}

--- a/packages/gateway/src/routing/adaptive/isolation-preferences.ts
+++ b/packages/gateway/src/routing/adaptive/isolation-preferences.ts
@@ -1,0 +1,97 @@
+import type { Db } from "@provara/db";
+import { adaptiveIsolationPreferencesLog, tenantAdaptiveIsolation } from "@provara/db";
+import { eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantIsolationPolicy, type IsolationPolicy } from "./isolation-policy.js";
+
+/**
+ * Per-tenant toggles read + write. Writes atomically:
+ *   1. Upsert the `tenant_adaptive_isolation` row.
+ *   2. Append one row per changed field to `adaptive_isolation_preferences_log`.
+ *
+ * The log is append-only and carries `changedBy` so Enterprise audits can
+ * answer "who flipped this, and when?".
+ */
+export interface IsolationPreferences {
+  consumesPool: boolean;
+  contributesPool: boolean;
+}
+
+export async function getIsolationPreferences(
+  db: Db,
+  tenantId: string,
+): Promise<IsolationPreferences> {
+  const row = await db
+    .select()
+    .from(tenantAdaptiveIsolation)
+    .where(eq(tenantAdaptiveIsolation.tenantId, tenantId))
+    .get();
+  return {
+    consumesPool: row?.consumesPool ?? false,
+    contributesPool: row?.contributesPool ?? false,
+  };
+}
+
+/**
+ * Update a tenant's toggles and log every field that actually changed.
+ * Idempotent — calling with the same values as current state is a no-op
+ * (no log entry). Throws if the tenant's tier isn't eligible for
+ * isolation toggles (Free/Pro); the API layer normally catches this
+ * first, but we defend in depth.
+ */
+export async function updateIsolationPreferences(
+  db: Db,
+  tenantId: string,
+  next: Partial<IsolationPreferences>,
+  changedBy: string,
+): Promise<IsolationPreferences> {
+  const policy = await getTenantIsolationPolicy(db, tenantId);
+  if (policy.tier !== "team" && policy.tier !== "enterprise") {
+    throw new Error(
+      `tenant ${tenantId} on tier "${policy.tier}" cannot modify isolation preferences`,
+    );
+  }
+
+  const current = await getIsolationPreferences(db, tenantId);
+  const merged: IsolationPreferences = {
+    consumesPool: next.consumesPool ?? current.consumesPool,
+    contributesPool: next.contributesPool ?? current.contributesPool,
+  };
+
+  const changes: { field: string; oldValue: boolean; newValue: boolean }[] = [];
+  if (merged.consumesPool !== current.consumesPool) {
+    changes.push({ field: "consumes_pool", oldValue: current.consumesPool, newValue: merged.consumesPool });
+  }
+  if (merged.contributesPool !== current.contributesPool) {
+    changes.push({ field: "contributes_pool", oldValue: current.contributesPool, newValue: merged.contributesPool });
+  }
+
+  if (changes.length === 0) return current;
+
+  const now = new Date();
+  await db
+    .insert(tenantAdaptiveIsolation)
+    .values({ tenantId, ...merged, updatedAt: now })
+    .onConflictDoUpdate({
+      target: tenantAdaptiveIsolation.tenantId,
+      set: { ...merged, updatedAt: now },
+    })
+    .run();
+
+  for (const c of changes) {
+    await db.insert(adaptiveIsolationPreferencesLog).values({
+      id: nanoid(),
+      tenantId,
+      field: c.field,
+      oldValue: c.oldValue,
+      newValue: c.newValue,
+      changedAt: now,
+      changedBy,
+    }).run();
+  }
+
+  return merged;
+}
+
+/** Re-exports so API layer can keep imports flat. */
+export { getTenantIsolationPolicy, type IsolationPolicy };

--- a/packages/gateway/src/routing/adaptive/router.ts
+++ b/packages/gateway/src/routing/adaptive/router.ts
@@ -6,6 +6,7 @@ import { MIN_SAMPLES, computeRouteScore, getModelCost, resolveWeights } from "./
 import { isStaleTimestamp, pickExploration } from "./exploration.js";
 import { POOL_KEY, createScoreStore, type ScoreStore } from "./score-store.js";
 import { loadScoresFromDb, persistScore } from "./persistence.js";
+import { getTenantIsolationPolicy, type IsolationPolicy } from "./isolation-policy.js";
 import type { FeedbackSource, ModelScore, RoutingProfile, RoutingWeights } from "./types.js";
 
 export type AdaptiveRouter = Awaited<ReturnType<typeof createAdaptiveRouter>>;
@@ -32,29 +33,28 @@ export interface AdaptiveRouterOptions {
  * sync via `updateScore` / `updateLatency`. Single-process constraints
  * apply — see `score-store.ts` for the horizontal-scaling note.
  *
- * Tenant scoping added by #194 (C1 of #176). All public methods accept an
- * optional trailing `tenantId`; omitting it (or passing `null`/`undefined`)
- * operates on the shared pool — identical to pre-#176 behavior. Call sites
- * that actually want tenant-aware routing live in C2 (#195).
+ * Tenant scoping plumbing landed in #194 (C1). Tier-aware read fallback
+ * and tier-gated writes land here (#195 / C2). Policy is resolved per
+ * call via `getTenantIsolationPolicy(db, tenantId)` — no TTL cache yet;
+ * see #195 discussion.
  */
 export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOptions = {}) {
   const store: ScoreStore = createScoreStore();
   const getScoreBoost = options.getScoreBoost ?? (() => 0);
   const isCellRegressing = options.isCellRegressing ?? (() => false);
 
-  async function updateScore(
+  /** Apply an EMA update to a single (tenantKey, cell) slot — memory + DB. */
+  async function applyUpdateTo(
+    tenantKey: string | null,
     taskType: string,
     complexity: string,
     provider: string,
     model: string,
     newScore: number,
-    source: FeedbackSource,
-    tenantId?: string | null,
+    alpha: number,
+    now: Date,
   ): Promise<void> {
-    const alpha = getQualityAlpha(source);
-    const existing = store.get(taskType, complexity, provider, model, tenantId);
-    const now = new Date();
-
+    const existing = store.get(taskType, complexity, provider, model, tenantKey);
     let qualityScore: number;
     let sampleCount: number;
     if (existing) {
@@ -78,10 +78,9 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
           avgLatencyMs: 0,
           updatedAt: now,
         },
-        tenantId,
+        tenantKey,
       );
     }
-
     await persistScore(
       db,
       taskType,
@@ -90,8 +89,35 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
       model,
       qualityScore,
       sampleCount,
-      tenantId ?? POOL_KEY,
+      tenantKey ?? POOL_KEY,
     );
+  }
+
+  /**
+   * Feedback-driven EMA update. Routes the update to the tenant row,
+   * the pool row, or both, per the tenant's isolation policy. An
+   * omitted / nullish `tenantId` is treated as an anonymous caller
+   * (pool-only). Self-host and unauthenticated paths also end up here.
+   */
+  async function updateScore(
+    taskType: string,
+    complexity: string,
+    provider: string,
+    model: string,
+    newScore: number,
+    source: FeedbackSource,
+    tenantId?: string | null,
+  ): Promise<void> {
+    const policy = await getTenantIsolationPolicy(db, tenantId);
+    const alpha = getQualityAlpha(source);
+    const now = new Date();
+
+    if (policy.writesTenantRow && tenantId) {
+      await applyUpdateTo(tenantId, taskType, complexity, provider, model, newScore, alpha, now);
+    }
+    if (policy.writesPool) {
+      await applyUpdateTo(null, taskType, complexity, provider, model, newScore, alpha, now);
+    }
   }
 
   function updateLatency(
@@ -102,42 +128,32 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     latencyMs: number,
     tenantId?: string | null,
   ): void {
-    const existing = store.get(taskType, complexity, provider, model, tenantId);
-    if (existing) {
-      existing.avgLatencyMs = ema(existing.avgLatencyMs, latencyMs, EMA_ALPHA);
+    // Latency is an in-memory signal, not persisted. Update wherever the
+    // request's routing decision was sourced from — see getBestModel's
+    // policy gating. For simplicity, update both dimensions if they
+    // exist; a stale latency in an unused dimension is harmless.
+    const tenantExisting = tenantId
+      ? store.get(taskType, complexity, provider, model, tenantId)
+      : undefined;
+    if (tenantExisting) {
+      tenantExisting.avgLatencyMs = ema(tenantExisting.avgLatencyMs, latencyMs, EMA_ALPHA);
+    }
+    const poolExisting = store.get(taskType, complexity, provider, model);
+    if (poolExisting) {
+      poolExisting.avgLatencyMs = ema(poolExisting.avgLatencyMs, latencyMs, EMA_ALPHA);
     }
   }
 
-  /**
-   * Pick the best model for a cell. Returns `via: "exploration"` when the
-   * ε-greedy branch fired (uniform-random from allCandidates, ignoring EMA)
-   * and `via: "adaptive"` when the EMA-scoring branch picked the winner.
-   * Returns null when no adaptive candidate qualifies and exploration
-   * didn't fire — caller falls through to cheapest-first.
-   *
-   * Cells whose most-recent update is older than the stale threshold get
-   * a boosted exploration rate so their stored EMA doesn't drift further
-   * from current truth. See #148.
-   */
-  function getBestModel(
-    taskType: TaskType,
-    complexity: Complexity,
-    profile: RoutingProfile,
+  /** Pure pick-from-a-single-cell, reused for tenant and pool paths. */
+  function pickBestFromCell(
+    cellMap: Map<string, ModelScore> | undefined,
     availableProviders: Set<string>,
-    allCandidates: RouteTarget[],
-    customWeights?: RoutingWeights,
-    tenantId?: string | null,
-  ): { target: RouteTarget; via: "adaptive" | "exploration" } | null {
-    const cellMap = store.getCellMap(taskType, complexity, tenantId);
-    const stale = isCellStale(cellMap);
-    const regressed = isCellRegressing(taskType, complexity);
-    const exploration = pickExploration(allCandidates, availableProviders, { stale, regressed });
-    if (exploration) {
-      return { target: exploration, via: "exploration" };
-    }
-
+    taskType: string,
+    complexity: string,
+    profile: RoutingProfile,
+    customWeights: RoutingWeights | undefined,
+  ): RouteTarget | null {
     if (!cellMap || cellMap.size === 0) return null;
-
     const candidates = Array.from(cellMap.values()).filter(
       (s) => s.sampleCount >= MIN_SAMPLES && availableProviders.has(s.provider),
     );
@@ -145,11 +161,7 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
 
     const weights = resolveWeights(profile, customWeights);
     let best: { target: RouteTarget; score: number } | null = null;
-
     for (const candidate of candidates) {
-      // Grace boost (#153) nudges migration targets up during their window
-      // without mutating the underlying EMA — normal routing wins back if
-      // the migration picked wrong once the boost expires.
       const boost = getScoreBoost(taskType, complexity, candidate.provider, candidate.model);
       const score = computeRouteScore(
         candidate.qualityScore + boost,
@@ -161,8 +173,54 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
         best = { target: { provider: candidate.provider, model: candidate.model }, score };
       }
     }
+    return best?.target ?? null;
+  }
 
-    return best ? { target: best.target, via: "adaptive" } : null;
+  /**
+   * Pick the best model for a cell. Returns `via: "exploration"` when the
+   * ε-greedy branch fired (uniform-random from allCandidates, ignoring EMA)
+   * and `via: "adaptive"` when the EMA-scoring branch picked the winner.
+   * Returns null when no adaptive candidate qualifies and exploration
+   * didn't fire — caller falls through to cheapest-first.
+   *
+   * Tier-aware fallback: consults the tenant row first (when policy
+   * allows), then the pool row (when policy allows). Cells whose
+   * most-recent update is older than the stale threshold get a boosted
+   * exploration rate so their stored EMA doesn't drift further from
+   * current truth (#148).
+   */
+  async function getBestModel(
+    taskType: TaskType,
+    complexity: Complexity,
+    profile: RoutingProfile,
+    availableProviders: Set<string>,
+    allCandidates: RouteTarget[],
+    customWeights?: RoutingWeights,
+    tenantId?: string | null,
+  ): Promise<{ target: RouteTarget; via: "adaptive" | "exploration" } | null> {
+    const policy = await getTenantIsolationPolicy(db, tenantId);
+    const tenantCell =
+      policy.readsTenantRow && tenantId ? store.getCellMap(taskType, complexity, tenantId) : undefined;
+    const poolCell = policy.readsPool ? store.getCellMap(taskType, complexity) : undefined;
+
+    // Stale/exploration decision uses whichever cell the router will
+    // actually consult first. If the tenant row exists with data, it's
+    // primary; else the pool row (if the tenant can read it).
+    const primaryCell = tenantCell && tenantCell.size > 0 ? tenantCell : poolCell;
+    const stale = isCellStale(primaryCell);
+    const regressed = isCellRegressing(taskType, complexity);
+    const exploration = pickExploration(allCandidates, availableProviders, { stale, regressed });
+    if (exploration) {
+      return { target: exploration, via: "exploration" };
+    }
+
+    const tenantPick = pickBestFromCell(tenantCell, availableProviders, taskType, complexity, profile, customWeights);
+    if (tenantPick) return { target: tenantPick, via: "adaptive" };
+
+    const poolPick = pickBestFromCell(poolCell, availableProviders, taskType, complexity, profile, customWeights);
+    if (poolPick) return { target: poolPick, via: "adaptive" };
+
+    return null;
   }
 
   function getCellScores(
@@ -177,6 +235,13 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     tenantId?: string | null,
   ): { taskType: string; complexity: string; scores: ModelScore[] }[] {
     return store.getAllScores(tenantId);
+  }
+
+  /** Resolve the live tier + toggle policy for a tenant. */
+  async function getIsolationPolicy(
+    tenantId?: string | null,
+  ): Promise<IsolationPolicy> {
+    return getTenantIsolationPolicy(db, tenantId);
   }
 
   /**
@@ -222,6 +287,7 @@ export async function createAdaptiveRouter(db: Db, options: AdaptiveRouterOption
     getBestModel,
     getCellScores,
     getAllScores,
+    getIsolationPolicy,
     isStale,
     lastUpdated,
     loadScoresFromDb: () => loadScoresFromDb(db, store),

--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -29,6 +29,13 @@ export interface RoutingRequest {
   complexityHint?: Complexity;
   routingProfile?: RoutingProfile;
   routingWeights?: RoutingWeights;
+  /**
+   * Tenant identity of the caller. Drives the adaptive router's tier-
+   * aware read fallback (#195) — Team/Enterprise tenants see their
+   * isolated matrix with pool as optional fallback; Free/Pro see the
+   * shared pool only. `null`/`undefined` = anonymous caller, pool-only.
+   */
+  tenantId?: string | null;
 }
 
 export async function createRoutingEngine(config: RoutingEngineConfig) {
@@ -158,13 +165,14 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
 
     // A/B test candidate (may or may not run before adaptive based on config)
     const abResult = await findActiveAbTest(taskType, complexity);
-    const adaptiveResult = adaptive.getBestModel(
+    const adaptiveResult = await adaptive.getBestModel(
       taskType,
       complexity,
       profile,
       availableProviders,
       allFallbacks,
-      request.routingWeights
+      request.routingWeights,
+      request.tenantId,
     );
 
     // Ordering:

--- a/packages/gateway/src/routing/judge.ts
+++ b/packages/gateway/src/routing/judge.ts
@@ -237,7 +237,8 @@ export function createJudge(registry: ProviderRegistry, db: Db, adaptive: Adapti
           ctx.provider,
           ctx.model,
           result.average,
-          "judge"
+          "judge",
+          ctx.tenantId,
         );
       }
     } catch (err) {

--- a/packages/gateway/tests/adaptive-isolation-policy.test.ts
+++ b/packages/gateway/tests/adaptive-isolation-policy.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { modelScores, adaptiveIsolationPreferencesLog } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+import { POOL_KEY } from "../src/routing/adaptive/score-store.js";
+import { getTenantIsolationPolicy } from "../src/routing/adaptive/isolation-policy.js";
+import { updateIsolationPreferences, getIsolationPreferences } from "../src/routing/adaptive/isolation-preferences.js";
+import { createAdaptiveRouter } from "../src/routing/adaptive/router.js";
+import type { RoutingProfile } from "../src/routing/adaptive/types.js";
+
+/**
+ * C2 (#195) — tier-aware adaptive routing tests. Verifies the four-
+ * dimensional isolation policy (tenant reads/writes × pool reads/writes)
+ * across the Free/Pro/Team/Enterprise tiers and the opt-in toggles.
+ */
+describe("adaptive isolation policy — C2", () => {
+  afterEach(() => resetTierEnv());
+
+  describe("getTenantIsolationPolicy", () => {
+    it("returns Free-equivalent policy for self-host (no PROVARA_CLOUD)", async () => {
+      const db = await makeTestDb();
+      const policy = await getTenantIsolationPolicy(db, "any-tenant");
+      expect(policy.tier).toBe("free");
+      expect(policy).toMatchObject({
+        writesTenantRow: false,
+        writesPool: true,
+        readsTenantRow: false,
+        readsPool: true,
+      });
+    });
+
+    it("returns Free policy for unauthenticated caller on Cloud", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      const policy = await getTenantIsolationPolicy(db, null);
+      expect(policy.tier).toBe("free");
+      expect(policy.writesTenantRow).toBe(false);
+      expect(policy.readsPool).toBe(true);
+    });
+
+    it("returns Free policy for an unsubscribed tenant on Cloud", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      const policy = await getTenantIsolationPolicy(db, "no-sub");
+      expect(policy.tier).toBe("free");
+      expect(policy.writesTenantRow).toBe(false);
+    });
+
+    it("returns Pro policy for a Pro subscriber", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-pro", { tier: "pro" });
+      const policy = await getTenantIsolationPolicy(db, "t-pro");
+      expect(policy.tier).toBe("pro");
+      expect(policy.writesTenantRow).toBe(false);
+      expect(policy.writesPool).toBe(true);
+      expect(policy.readsPool).toBe(true);
+    });
+
+    it("returns isolated Team policy by default (both toggles off)", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const policy = await getTenantIsolationPolicy(db, "t-team");
+      expect(policy.tier).toBe("team");
+      expect(policy).toMatchObject({
+        writesTenantRow: true,
+        writesPool: false,
+        readsTenantRow: true,
+        readsPool: false,
+      });
+    });
+
+    it("returns isolated Enterprise policy by default", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-ent", { tier: "enterprise" });
+      const policy = await getTenantIsolationPolicy(db, "t-ent");
+      expect(policy.tier).toBe("enterprise");
+      expect(policy.writesPool).toBe(false);
+      expect(policy.readsPool).toBe(false);
+    });
+
+    it("flips readsPool when a Team tenant opts in to consume the pool", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-admin");
+      const policy = await getTenantIsolationPolicy(db, "t-team");
+      expect(policy.readsPool).toBe(true);
+      expect(policy.readsTenantRow).toBe(true); // tenant row still consulted first
+      expect(policy.writesPool).toBe(false);
+    });
+
+    it("flips writesPool when a Team tenant opts in to contribute", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { contributesPool: true }, "u-admin");
+      const policy = await getTenantIsolationPolicy(db, "t-team");
+      expect(policy.writesPool).toBe(true);
+      expect(policy.writesTenantRow).toBe(true); // tenant row still written
+      expect(policy.readsPool).toBe(false);
+    });
+  });
+
+  describe("updateIsolationPreferences", () => {
+    it("rejects toggle changes for Free tenants", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      await expect(
+        updateIsolationPreferences(db, "t-free", { consumesPool: true }, "u-admin"),
+      ).rejects.toThrow(/cannot modify isolation preferences/);
+    });
+
+    it("rejects toggle changes for Pro tenants", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-pro", { tier: "pro" });
+      await expect(
+        updateIsolationPreferences(db, "t-pro", { consumesPool: true }, "u-admin"),
+      ).rejects.toThrow(/cannot modify isolation preferences/);
+    });
+
+    it("logs an audit entry on first flip", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { contributesPool: true }, "u-owner");
+
+      const logs = await db
+        .select()
+        .from(adaptiveIsolationPreferencesLog)
+        .where(eq(adaptiveIsolationPreferencesLog.tenantId, "t-team"))
+        .all();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].field).toBe("contributes_pool");
+      expect(logs[0].oldValue).toBe(false);
+      expect(logs[0].newValue).toBe(true);
+      expect(logs[0].changedBy).toBe("u-owner");
+    });
+
+    it("is idempotent — no log entry when the value doesn't change", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-owner");
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-owner");
+
+      const logs = await db
+        .select()
+        .from(adaptiveIsolationPreferencesLog)
+        .where(eq(adaptiveIsolationPreferencesLog.tenantId, "t-team"))
+        .all();
+      expect(logs).toHaveLength(1);
+    });
+
+    it("logs each changed field independently", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(
+        db,
+        "t-team",
+        { consumesPool: true, contributesPool: true },
+        "u-owner",
+      );
+
+      const logs = await db
+        .select()
+        .from(adaptiveIsolationPreferencesLog)
+        .where(eq(adaptiveIsolationPreferencesLog.tenantId, "t-team"))
+        .orderBy(adaptiveIsolationPreferencesLog.field)
+        .all();
+      expect(logs).toHaveLength(2);
+      expect(logs.map((l) => l.field).sort()).toEqual(["consumes_pool", "contributes_pool"]);
+    });
+
+    it("round-trips through getIsolationPreferences", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      expect(await getIsolationPreferences(db, "t-team")).toEqual({
+        consumesPool: false,
+        contributesPool: false,
+      });
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-owner");
+      expect(await getIsolationPreferences(db, "t-team")).toEqual({
+        consumesPool: true,
+        contributesPool: false,
+      });
+    });
+  });
+
+  describe("router.updateScore — write dispatch by tier", () => {
+    it("Team tenant with contributesPool ON writes both tenant row and pool", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { contributesPool: true }, "u-admin");
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.8, "user", "t-team");
+
+      const rows = await db.select().from(modelScores).orderBy(modelScores.tenantId).all();
+      expect(rows).toHaveLength(2);
+      expect(rows.find((r) => r.tenantId === POOL_KEY)?.qualityScore).toBeCloseTo(0.8);
+      expect(rows.find((r) => r.tenantId === "t-team")?.qualityScore).toBeCloseTo(0.8);
+    });
+
+    it("Enterprise tenant defaults: writes only tenant row, never pool", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-ent", { tier: "enterprise" });
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.7, "user", "t-ent");
+
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe("t-ent");
+    });
+
+    it("opt-out after opt-in: future writes stop; past pool data remains", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { contributesPool: true }, "u-admin");
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user", "t-team");
+      // Opt out
+      await updateIsolationPreferences(db, "t-team", { contributesPool: false }, "u-admin");
+      // Subsequent write should go only to tenant row
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.5, "user", "t-team");
+
+      const pool = await db
+        .select()
+        .from(modelScores)
+        .where(eq(modelScores.tenantId, POOL_KEY))
+        .get();
+      // Pool still holds the first contribution; opt-out does not rewind.
+      expect(pool).toBeDefined();
+      expect(pool!.sampleCount).toBe(1);
+    });
+  });
+
+  describe("router.getBestModel — read fallback by tier", () => {
+    const providers = new Set(["openai"]);
+    const candidates = [{ provider: "openai", model: "gpt-4" }];
+
+    it("Team tenant with empty matrix does NOT fall back to pool by default", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const router = await createAdaptiveRouter(db);
+
+      // Seed pool with strong scores, tenant matrix stays empty.
+      for (let i = 0; i < 5; i++) {
+        await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user");
+      }
+
+      const result = await router.getBestModel(
+        "coding",
+        "medium",
+        "balanced" satisfies RoutingProfile,
+        providers,
+        candidates,
+        undefined,
+        "t-team",
+      );
+      // Isolated Team with no tenant row → returns null (caller falls back to cost-based).
+      // Exploration MIGHT fire randomly — accept either null OR via=exploration; never adaptive.
+      if (result) {
+        expect(result.via).toBe("exploration");
+      } else {
+        expect(result).toBeNull();
+      }
+    });
+
+    it("Team tenant opted in to pool reads does fall back to pool", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-admin");
+      const router = await createAdaptiveRouter(db);
+
+      for (let i = 0; i < 5; i++) {
+        await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user");
+      }
+
+      // Disable exploration randomness by forcing many attempts; at least one
+      // should come back adaptive (via pool fallback).
+      let sawAdaptive = false;
+      for (let i = 0; i < 50; i++) {
+        const result = await router.getBestModel(
+          "coding",
+          "medium",
+          "balanced" satisfies RoutingProfile,
+          providers,
+          candidates,
+          undefined,
+          "t-team",
+        );
+        if (result?.via === "adaptive") {
+          sawAdaptive = true;
+          expect(result.target.provider).toBe("openai");
+          expect(result.target.model).toBe("gpt-4");
+        }
+      }
+      expect(sawAdaptive).toBe(true);
+    });
+
+    it("read-through only: pool consumption never populates the tenant row", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await updateIsolationPreferences(db, "t-team", { consumesPool: true }, "u-admin");
+      const router = await createAdaptiveRouter(db);
+
+      // Pool has data, tenant matrix is empty.
+      for (let i = 0; i < 5; i++) {
+        await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user");
+      }
+
+      // Invoke the router repeatedly — no tenant row should appear.
+      for (let i = 0; i < 20; i++) {
+        await router.getBestModel(
+          "coding",
+          "medium",
+          "balanced" satisfies RoutingProfile,
+          providers,
+          candidates,
+          undefined,
+          "t-team",
+        );
+      }
+
+      expect(router.getCellScores("coding", "medium", "t-team")).toEqual([]);
+    });
+  });
+});

--- a/packages/gateway/tests/adaptive-tenant-scope.test.ts
+++ b/packages/gateway/tests/adaptive-tenant-scope.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { and, eq } from "drizzle-orm";
 import { modelScores } from "@provara/db";
 import { makeTestDb } from "./_setup/db.js";
+import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
 import { createScoreStore, POOL_KEY } from "../src/routing/adaptive/score-store.js";
 import { loadScoresFromDb, persistScore } from "../src/routing/adaptive/persistence.js";
 import { createAdaptiveRouter } from "../src/routing/adaptive/router.js";
@@ -144,8 +145,10 @@ describe("adaptive tenant scope — C1 foundation", () => {
     });
   });
 
-  describe("router.updateScore", () => {
-    it("default-arg updates the pool row only", async () => {
+  describe("router.updateScore — tier-dispatched writes (C2)", () => {
+    afterEach(() => resetTierEnv());
+
+    it("default-arg (no tenantId) updates the pool row only", async () => {
       const db = await makeTestDb();
       const router = await createAdaptiveRouter(db);
 
@@ -156,8 +159,9 @@ describe("adaptive tenant scope — C1 foundation", () => {
       expect(rows[0].tenantId).toBe(POOL_KEY);
     });
 
-    it("tenant-scoped updates write a tenant row without touching the pool", async () => {
+    it("Team tenant with default toggles writes tenant row only (no pool bleed)", async () => {
       const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "tenant-a", { tier: "team" });
       const router = await createAdaptiveRouter(db);
 
       await router.updateScore("coding", "medium", "openai", "gpt-4", 0.5, "user");
@@ -172,8 +176,9 @@ describe("adaptive tenant scope — C1 foundation", () => {
       expect(tenant?.qualityScore).toBeCloseTo(0.9);
     });
 
-    it("tenant isolation — tenant-a ratings do not influence tenant-b", async () => {
+    it("Team tenant-a's ratings do not influence tenant-b or the pool", async () => {
       const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "tenant-a", { tier: "team" });
       const router = await createAdaptiveRouter(db);
 
       await router.updateScore("coding", "medium", "openai", "gpt-4", 0.9, "user", "tenant-a");
@@ -181,6 +186,18 @@ describe("adaptive tenant scope — C1 foundation", () => {
       expect(router.getCellScores("coding", "medium", "tenant-b")).toEqual([]);
       expect(router.getCellScores("coding", "medium")).toEqual([]);
       expect(router.getCellScores("coding", "medium", "tenant-a")).toHaveLength(1);
+    });
+
+    it("Free tenant writes to the pool even when tenantId is passed", async () => {
+      const db = await makeTestDb();
+      // No subscription → Free tier → always pools.
+      const router = await createAdaptiveRouter(db);
+
+      await router.updateScore("coding", "medium", "openai", "gpt-4", 0.7, "user", "tenant-free");
+
+      const rows = await db.select().from(modelScores).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe(POOL_KEY);
     });
   });
 });


### PR DESCRIPTION
Closes #195. Part of #176.

## Summary

Flips the C1 (#194) plumbing into actual tier-aware adaptive routing. Feedback and judge EMA updates now dispatch based on the tenant's isolation policy, and the router consults the tenant row first with optional pool fallback on reads.

- **New tables.** `tenant_adaptive_isolation` (per-tenant toggle row) and `adaptive_isolation_preferences_log` (append-only audit). Migration `0028_amazing_sabretooth.sql`.
- **`getTenantIsolationPolicy(db, tenantId)`.** Single entry point returning the four-field policy: `writesTenantRow`, `writesPool`, `readsTenantRow`, `readsPool`. Derived from tier + toggles. Self-host and Free/Pro are always pool-only; Team/Enterprise default to isolated with two opt-in toggles.
- **`updateIsolationPreferences`.** Idempotent upsert + audit log write. Rejects Free/Pro callers at the library level (defense in depth; API layer in C4 will reject first).
- **Router dispatch.**
  - `updateScore` writes tenant row and/or pool per policy. Opt-out is *not* retroactive — past pool contributions remain (documented).
  - `getBestModel` is now **async**. Consults tenant row first, falls back to pool only when policy allows. Read-through only: pool reads never populate the tenant row.
  - Exploration decision uses the cell the router will actually consult (tenant if present, else pool).
- **Threading.** `tenantId` added to `RoutingRequest`, wired through `routingEngine.route()`, `feedback.ts`, and `judge.ts`. Call sites already had the tenant in scope.

## State-management contract (unchanged from #195 body)

- **Reads are read-through only** — verified by test.
- **Writes to pool are irreversible** — verified by test.
- **Audit log** records every toggle transition with `changedBy`.

## Test plan

- [x] `npx tsc --noEmit` green for db, gateway, web.
- [x] `npm test -w packages/gateway`: **303 passed** (up from 282).
  - 11 C1 foundation tests (tenant-scope) updated to match C2 tier dispatch.
  - 20 new tests (`adaptive-isolation-policy.test.ts`) across: self-host/unauth/Free/Pro/Team/Enterprise policies, toggle flips (both directions), audit log (append, idempotent, two-field atomic), `updateScore` write dispatch (Team-with-contribute, Enterprise-default, opt-out-after-opt-in), and `getBestModel` read fallback (Team isolated sees empty, Team-opt-in sees pool, read-through invariant).
- [ ] Visual QA deferred — no UI surface in this PR; C4 (#197) brings the dashboard.

## Breaking-ish note

`getBestModel` is now async. The one call site inside `routing/index.ts` is already inside an async fn; added an `await`. No external callers of `AdaptiveRouter.getBestModel` exist.

## Follow-ups

- C3 (#196) — per-tenant regression + cost-migration cycles, now unblocked.
- C4 (#197) — dashboard toggles + `GET/PATCH /api/v1/routing/isolation`, now unblocked.
- Performance: policy lookup is a DB hit per `getBestModel`/`updateScore` call. If latency shows up in tracing, add an in-process TTL cache keyed on `tenantId`.

Last-code-by: opus-4-7 (claude-code)
