### PR TITLE
feat(#196): per-tenant regression + cost-migration cycles

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -122,14 +122,17 @@ if (cloudDeployment) {
     intervalMs: COST_MIGRATION_INTERVAL_MS,
     initialDelayMs: 90_000,
     handler: async () => {
+      // runCostMigrationCycle logs one line per scope (pool + each tenant)
+      // with non-zero execution — see migrations.ts. Scheduler-level log
+      // only fires for the "evaluated candidates but all skipped" case so
+      // quiet cycles stay genuinely quiet.
       const stats = await runCostMigrationCycle(db);
       if (stats.executed.length > 0) {
-        console.log(
-          `[cost-migration] executed ${stats.executed.length} migration(s), projected $${stats.executed.reduce((s, m) => s + m.projectedMonthlySavingsUsd, 0).toFixed(2)}/mo saved`,
-        );
         // Refresh the boost table so the router picks up the new migration
         // without a restart — boost applies on the very next routing decision.
         await app.routingEngine.boostTable.refresh();
+      } else if (stats.evaluated > 0) {
+        console.log(`[cost-migration] evaluated ${stats.evaluated} candidate(s), none executed (cooldown or caps)`);
       }
     },
   });

--- a/packages/gateway/src/routing/adaptive/isolation-policy.ts
+++ b/packages/gateway/src/routing/adaptive/isolation-policy.ts
@@ -1,6 +1,6 @@
 import type { Db } from "@provara/db";
-import { tenantAdaptiveIsolation } from "@provara/db";
-import { eq } from "drizzle-orm";
+import { subscriptions, tenantAdaptiveIsolation } from "@provara/db";
+import { eq, inArray } from "drizzle-orm";
 import { isCloudDeployment } from "../../config.js";
 import { getSubscriptionForTenant } from "../../stripe/subscriptions.js";
 
@@ -101,4 +101,29 @@ export async function getTenantIsolationPolicy(
     writesPool: prefs?.contributesPool ?? false,
     readsPool: prefs?.consumesPool ?? false,
   };
+}
+
+/**
+ * List tenantIds eligible for per-tenant adaptive cycles — Team + Enterprise
+ * subscribers in an active-ish status. Used by `runCostMigrationCycle` and
+ * any other cycle that needs to iterate the set of tenants with their own
+ * `model_scores` rows.
+ *
+ * Free/Pro are excluded by design: they have no tenant-scoped rows (per
+ * C2 policy), so a per-tenant cycle for them is always a no-op. Keeping
+ * them out of the iteration keeps logs clean and avoids wasted scans.
+ *
+ * Off-cloud returns an empty list — self-host is single-tenant and the
+ * pool cycle covers it.
+ */
+export async function listTenantsWithAdaptiveIsolation(db: Db): Promise<string[]> {
+  if (!isCloudDeployment()) return [];
+  const rows = await db
+    .select({ tenantId: subscriptions.tenantId, tier: subscriptions.tier, status: subscriptions.status })
+    .from(subscriptions)
+    .where(inArray(subscriptions.tier, ["team", "enterprise"]))
+    .all();
+  return rows
+    .filter((r) => ACTIVE_STATUSES.has(r.status) && r.tenantId)
+    .map((r) => r.tenantId);
 }

--- a/packages/gateway/src/routing/adaptive/migrations.ts
+++ b/packages/gateway/src/routing/adaptive/migrations.ts
@@ -3,6 +3,9 @@ import { costMigrations, modelScores, requests, appConfig } from "@provara/db";
 import { and, eq, sql, desc, isNull, gt } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { MIN_SAMPLES, getModelCost } from "./scoring.js";
+import { POOL_KEY } from "./score-store.js";
+import { listTenantsWithAdaptiveIsolation } from "./isolation-policy.js";
+import { tenantHasIntelligenceAccess } from "../../auth/tier.js";
 
 function numEnv(v: string | undefined, fallback: number): number {
   if (v === undefined || v === "") return fallback;
@@ -128,9 +131,21 @@ async function projectSavings(
  * (winner - epsilon) quality with enough samples and fresh signal. Returns
  * ranked candidates for the current cycle; caller enforces the per-run
  * cap and cooldown.
+ *
+ * Scope: `scopeTenantId` is the DB-layer tenant key. Pass `POOL_KEY` ("")
+ * for the shared-pool pass (Free/Pro), or a real tenantId for Team/Enterprise
+ * tenants that maintain their own row. Pre-#196 (C3) this scanned globally —
+ * a silent cross-tenant leak once tenant rows started existing.
  */
-export async function findMigrationCandidates(db: Db): Promise<MigrationCandidate[]> {
-  const rows = await db.select().from(modelScores).all();
+export async function findMigrationCandidates(
+  db: Db,
+  scopeTenantId: string = POOL_KEY,
+): Promise<MigrationCandidate[]> {
+  const rows = await db
+    .select()
+    .from(modelScores)
+    .where(eq(modelScores.tenantId, scopeTenantId))
+    .all();
   const cells = new Map<string, CellRow[]>();
   const now = Date.now();
   const staleCutoff = now - 30 * 24 * 60 * 60 * 1000;
@@ -280,24 +295,76 @@ export interface MigrationCycleStats {
   skippedCooldown: number;
 }
 
-export async function runCostMigrationCycle(db: Db): Promise<MigrationCycleStats> {
-  const enabled = await isCostMigrationEnabled(db, null);
+/**
+ * Per-scope migration pass. Returns stats for a single (scope) iteration.
+ * `scope` is `null` for the shared pool; for a Team/Enterprise tenant it's
+ * the tenantId. Keeps opt-in gate and cooldown semantics identical to the
+ * pre-#196 global cycle — just bounded by scope.
+ */
+async function runCostMigrationScope(
+  db: Db,
+  scope: string | null,
+): Promise<MigrationCycleStats> {
+  const enabled = await isCostMigrationEnabled(db, scope);
   if (!enabled) {
     return { evaluated: 0, executed: [], skippedCooldown: 0 };
   }
 
-  const candidates = await findMigrationCandidates(db);
+  const dbScope = scope ?? POOL_KEY;
+  const candidates = await findMigrationCandidates(db, dbScope);
   const executed: ExecutedMigration[] = [];
   let skipped = 0;
 
   for (const candidate of candidates) {
     if (executed.length >= MAX_MIGRATIONS_PER_CYCLE) break;
-    const result = await executeMigration(db, null, candidate);
+    const result = await executeMigration(db, scope, candidate);
     if (result) executed.push(result);
     else skipped++;
   }
 
   return { evaluated: candidates.length, executed, skippedCooldown: skipped };
+}
+
+/**
+ * Top-level migration cycle — runs one pass for the shared pool and one
+ * pass per Team/Enterprise tenant with isolation. Pool keeps benefiting
+ * Free/Pro unchanged; tenant passes respect tier gate + per-tenant
+ * opt-in + per-scope MAX_MIGRATIONS cap.
+ *
+ * Pre-C3 this ran once globally with `tenantId=null` hardcoded, meaning
+ * tenant-scoped `model_scores` rows were invisible to it and global rows
+ * were mutated on every tenant's behalf. Now the global scope is the
+ * pool proper, and tenant scopes are distinct.
+ */
+export async function runCostMigrationCycle(db: Db): Promise<MigrationCycleStats> {
+  const poolStats = await runCostMigrationScope(db, null);
+
+  const aggregate: MigrationCycleStats = {
+    evaluated: poolStats.evaluated,
+    executed: [...poolStats.executed],
+    skippedCooldown: poolStats.skippedCooldown,
+  };
+
+  if (poolStats.executed.length > 0) {
+    const saved = poolStats.executed.reduce((s, m) => s + m.projectedMonthlySavingsUsd, 0);
+    console.log(`[cost-migration] pool: executed ${poolStats.executed.length}, projected $${saved.toFixed(2)}/mo`);
+  }
+
+  const tenantIds = await listTenantsWithAdaptiveIsolation(db);
+  for (const tenantId of tenantIds) {
+    const hasTier = await tenantHasIntelligenceAccess(db, tenantId);
+    if (!hasTier) continue;
+    const stats = await runCostMigrationScope(db, tenantId);
+    aggregate.evaluated += stats.evaluated;
+    aggregate.executed.push(...stats.executed);
+    aggregate.skippedCooldown += stats.skippedCooldown;
+    if (stats.executed.length > 0) {
+      const saved = stats.executed.reduce((s, m) => s + m.projectedMonthlySavingsUsd, 0);
+      console.log(`[cost-migration] tenant=${tenantId}: executed ${stats.executed.length}, projected $${saved.toFixed(2)}/mo`);
+    }
+  }
+
+  return aggregate;
 }
 
 /**

--- a/packages/gateway/src/routing/adaptive/regression.ts
+++ b/packages/gateway/src/routing/adaptive/regression.ts
@@ -366,6 +366,11 @@ export interface ReplayCycleStats {
  * Narrow interface the replay cycle uses to write judge scores back into
  * the adaptive router's EMA (#163). Typed as a thin subset so this module
  * doesn't need to import the full AdaptiveRouter and create a cycle.
+ *
+ * `tenantId` widened in #196 (C3) so regression-driven EMA updates honor
+ * the cell's tenant scoping. Pre-C3, the replay cycle dropped tenantId
+ * on the floor and every update landed in the pool — invisible for
+ * Team/Enterprise tenants whose policy has `writesPool: false`.
  */
 export interface AdaptiveScoreWriter {
   updateScore(
@@ -375,6 +380,7 @@ export interface AdaptiveScoreWriter {
     model: string,
     score: number,
     source: "user" | "judge",
+    tenantId?: string | null,
   ): Promise<void>;
 }
 
@@ -485,6 +491,7 @@ export async function runReplayCycle(
                 cell.model,
                 score,
                 "judge",
+                cell.tenantId,
               );
             } catch (err) {
               console.warn(

--- a/packages/gateway/tests/adaptive-cycles-tenant-scope.test.ts
+++ b/packages/gateway/tests/adaptive-cycles-tenant-scope.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { modelScores, costMigrations, requests } from "@provara/db";
+import type { Db } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+import {
+  MIGRATION_MIN_SAMPLES,
+  findMigrationCandidates,
+  runCostMigrationCycle,
+  setCostMigrationOptIn,
+} from "../src/routing/adaptive/migrations.js";
+import { POOL_KEY } from "../src/routing/adaptive/score-store.js";
+import { listTenantsWithAdaptiveIsolation } from "../src/routing/adaptive/isolation-policy.js";
+
+async function seedScopedScore(
+  db: Db,
+  scope: string,
+  taskType: string,
+  complexity: string,
+  provider: string,
+  model: string,
+  qualityScore: number,
+  sampleCount = MIGRATION_MIN_SAMPLES,
+) {
+  await db.insert(modelScores).values({
+    tenantId: scope,
+    taskType,
+    complexity,
+    provider,
+    model,
+    qualityScore,
+    sampleCount,
+    updatedAt: new Date(),
+  }).run();
+}
+
+async function seedRequests(db: Db, params: { provider: string; model: string; taskType: string; complexity: string; count: number }) {
+  for (let i = 0; i < params.count; i++) {
+    await db.insert(requests).values({
+      id: `r-${params.provider}-${params.model}-${i}-${Math.random()}`,
+      provider: params.provider,
+      model: params.model,
+      prompt: "test",
+      taskType: params.taskType,
+      complexity: params.complexity,
+      inputTokens: 1000,
+      outputTokens: 500,
+      createdAt: new Date(),
+    }).run();
+  }
+}
+
+describe("adaptive cycle tenant scoping — C3", () => {
+  afterEach(() => resetTierEnv());
+
+  describe("findMigrationCandidates scoping", () => {
+    let db: Db;
+    beforeEach(async () => {
+      db = await makeTestDb();
+    });
+
+    it("defaults to the pool scope (empty string tenantId)", async () => {
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "medium", count: 10 });
+
+      const candidates = await findMigrationCandidates(db);
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0].from.provider).toBe("openai");
+    });
+
+    it("scopes to a single tenant and ignores pool rows + other tenants", async () => {
+      // Pool rows — should NOT show up in tenant-a candidates.
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+
+      // Tenant-a rows — one cell with a migration candidate.
+      await seedScopedScore(db, "tenant-a", "writing", "complex", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, "tenant-a", "writing", "complex", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "writing", complexity: "complex", count: 10 });
+
+      // Tenant-b has nothing.
+      const poolCands = await findMigrationCandidates(db, POOL_KEY);
+      const tenantACands = await findMigrationCandidates(db, "tenant-a");
+      const tenantBCands = await findMigrationCandidates(db, "tenant-b");
+
+      expect(poolCands).toHaveLength(1);
+      expect(poolCands[0].taskType).toBe("coding");
+      expect(tenantACands).toHaveLength(1);
+      expect(tenantACands[0].taskType).toBe("writing");
+      expect(tenantBCands).toEqual([]);
+    });
+  });
+
+  describe("listTenantsWithAdaptiveIsolation", () => {
+    it("returns empty off-cloud regardless of subscriptions", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      delete process.env.PROVARA_CLOUD; // off-cloud
+      const tenants = await listTenantsWithAdaptiveIsolation(db);
+      expect(tenants).toEqual([]);
+    });
+
+    it("returns only Team + Enterprise active tenants", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await grantIntelligenceAccess(db, "t-ent", { tier: "enterprise" });
+      await grantIntelligenceAccess(db, "t-pro", { tier: "pro" });
+      process.env.PROVARA_CLOUD = "true";
+
+      const tenants = await listTenantsWithAdaptiveIsolation(db);
+      expect(tenants.sort()).toEqual(["t-ent", "t-team"]);
+    });
+
+    it("excludes canceled Team tenants", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team", status: "active" });
+      await grantIntelligenceAccess(db, "t-canceled", { tier: "team" });
+      process.env.PROVARA_CLOUD = "true";
+
+      // Flip t-canceled to canceled status.
+      const { subscriptions } = await import("@provara/db");
+      await db.update(subscriptions).set({ status: "canceled" }).where(eq(subscriptions.tenantId, "t-canceled")).run();
+
+      const tenants = await listTenantsWithAdaptiveIsolation(db);
+      expect(tenants).toEqual(["t-team"]);
+    });
+  });
+
+  describe("runCostMigrationCycle — pool + per-tenant", () => {
+    it("pool cycle fires when only pool rows exist", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      await setCostMigrationOptIn(db, null, true);
+
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "medium", count: 10 });
+
+      const stats = await runCostMigrationCycle(db);
+      expect(stats.executed).toHaveLength(1);
+
+      const row = await db.select().from(costMigrations).get();
+      expect(row?.tenantId).toBeNull();
+    });
+
+    it("per-tenant cycle fires for a Team tenant with tenant-scoped rows", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await setCostMigrationOptIn(db, "t-team", true);
+
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "writing", complexity: "complex", count: 10 });
+
+      const stats = await runCostMigrationCycle(db);
+      expect(stats.executed).toHaveLength(1);
+
+      const rows = await db.select().from(costMigrations).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe("t-team");
+    });
+
+    it("pool + tenant cycles run independently with distinct migration rows", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await setCostMigrationOptIn(db, null, true);
+      await setCostMigrationOptIn(db, "t-team", true);
+
+      // Pool migration candidate
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "medium", count: 10 });
+
+      // Tenant migration candidate (different cell to avoid cooldown interference)
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "writing", complexity: "complex", count: 10 });
+
+      const stats = await runCostMigrationCycle(db);
+      expect(stats.executed).toHaveLength(2);
+
+      const rows = await db.select().from(costMigrations).all();
+      const scopes = rows.map((r) => r.tenantId).sort();
+      expect(scopes).toEqual([null, "t-team"]);
+    });
+
+    it("tenant opt-in OFF → no tenant migration fires even if pool fires", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      await setCostMigrationOptIn(db, null, true);
+      // t-team opt-in NOT set
+
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "medium", count: 10 });
+
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "writing", complexity: "complex", count: 10 });
+
+      const stats = await runCostMigrationCycle(db);
+      expect(stats.executed).toHaveLength(1);
+      expect(stats.executed[0].taskType).toBe("coding"); // pool only
+
+      const rows = await db.select().from(costMigrations).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBeNull();
+    });
+
+    it("pool opt-in OFF → pool cycle skipped even when tenant cycle fires", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      // pool opt-in NOT set
+      await setCostMigrationOptIn(db, "t-team", true);
+
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, POOL_KEY, "coding", "medium", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "coding", complexity: "medium", count: 10 });
+
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o", 4.5);
+      await seedScopedScore(db, "t-team", "writing", "complex", "openai", "gpt-4o-mini", 4.4);
+      await seedRequests(db, { provider: "openai", model: "gpt-4o", taskType: "writing", complexity: "complex", count: 10 });
+
+      const stats = await runCostMigrationCycle(db);
+      expect(stats.executed).toHaveLength(1);
+      expect(stats.executed[0].taskType).toBe("writing"); // tenant only
+
+      const rows = await db.select().from(costMigrations).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].tenantId).toBe("t-team");
+    });
+  });
+});

--- a/packages/gateway/tests/regression.test.ts
+++ b/packages/gateway/tests/regression.test.ts
@@ -605,10 +605,10 @@ describe("closed feedback loop (#163)", () => {
       });
     }
 
-    const updates: Array<{ taskType: string; complexity: string; provider: string; model: string; score: number; source: string }> = [];
+    const updates: Array<{ taskType: string; complexity: string; provider: string; model: string; score: number; source: string; tenantId?: string | null }> = [];
     const adaptiveStub = {
-      async updateScore(taskType: string, complexity: string, provider: string, model: string, score: number, source: "user" | "judge") {
-        updates.push({ taskType, complexity, provider, model, score, source });
+      async updateScore(taskType: string, complexity: string, provider: string, model: string, score: number, source: "user" | "judge", tenantId?: string | null) {
+        updates.push({ taskType, complexity, provider, model, score, source, tenantId });
       },
     };
 
@@ -632,6 +632,7 @@ describe("closed feedback loop (#163)", () => {
         model: "gpt-4o",
         score: 2,
         source: "judge",
+        tenantId: "t", // C3: tenantId threads from cell → adaptive.updateScore
       });
     }
   });


### PR DESCRIPTION
Closes #196. Part of #176.

## Summary

Closes the last two tenant-leak paths in the adaptive-routing cycles:

1. **Replay cycle → adaptive EMA.** `runReplayCycle` called `adaptive.updateScore` without a `tenantId`, so regression-driven score updates always landed in the pool. For Team/Enterprise tenants (whose C2 policy has `writesPool: false` by default), this silently suppressed regression-driven EMA adjustments to their tenant row. Fix: thread `cell.tenantId` through; widen `AdaptiveScoreWriter` signature.
2. **Cost-migration cycle.** Was entirely global — `findMigrationCandidates(db)` scanned every `model_scores` row, `executeMigration(db, null, ...)` hardcoded NULL. With tenant rows now existing post-C1, this both missed tenant-scoped cells and wrote global migration rows on their behalf. Fix: `runCostMigrationCycle` iterates pool + each Team/Enterprise tenant; each scope has its own opt-in gate, tier gate, and MAX_MIGRATIONS cap.

## Strategy

Internal per-tenant loop inside the cycle — scheduler code unchanged. Reasons:

- Regression cycles are already shaped this way (via `distinctEligibleCells` grouping on `requests.tenantId`).
- Scheduler stays ignorant of tenants; cycles own the iteration.
- Per-scope log lines beat a single aggregate rollup for debuggability.

Full rationale in the [shiplog/plan comment on #196](https://github.com/syndicalt/provara/issues/196#issuecomment-4273046954).

## Changes

- **`regression.ts`**: `AdaptiveScoreWriter.updateScore` now takes optional `tenantId`; `runReplayCycle` passes `cell.tenantId` through.
- **`migrations.ts`**:
  - `findMigrationCandidates(db, scopeTenantId = POOL_KEY)` — scoped scan.
  - `runCostMigrationScope(db, scope)` — single-scope pass, reusable.
  - `runCostMigrationCycle(db)` — iterates `[null (pool), ...listTenantsWithAdaptiveIsolation(db)]`, gates per scope, accumulates stats, logs per non-empty scope.
- **`isolation-policy.ts`**: `listTenantsWithAdaptiveIsolation(db)` — returns `string[]` of Team/Enterprise tenants in active status. Off-cloud returns empty.
- **`index.ts`** (scheduler): drops the single-line rollup in favor of per-scope logs inside the cycle. Adds a "evaluated N, none executed" line only when cooldowns/caps swallowed every candidate.

## Test plan

- [x] 10 new tests in `tests/adaptive-cycles-tenant-scope.test.ts`: scope default-arg, per-tenant scope selection, `listTenantsWithAdaptiveIsolation` filtering (off-cloud, tier filter, canceled status), pool-only cycle, tenant-only cycle, concurrent pool + tenant cycles write distinct rows, tenant opt-in OFF suppresses only tenant cycle, pool opt-in OFF suppresses only pool cycle.
- [x] `regression.test.ts` updated: replay→adaptive stub now asserts `tenantId: "t"` threads through.
- [x] `npm test -w packages/gateway`: **313 passed** (up from 303).
- [x] Typecheck clean across db, gateway, web.
- [ ] Visual QA deferred — no UI surface.

## Follow-ups

- C4 (#197) — dashboard toggles for consumes/contributes pool. Backend in place; dashboard wires it.
- Perf: per-tenant iteration is O(isolated tenants) per cycle; at scale each iteration hits DB once for candidates + once for cooldowns. Add a batched candidate scan if this shows up in tracing.

Last-code-by: opus-4-7 (claude-code)
