### PR TITLE
feat(#197): routing isolation toggles — API + dashboard

### DIFF
--- a/apps/web/src/app/dashboard/routing/page.tsx
+++ b/apps/web/src/app/dashboard/routing/page.tsx
@@ -105,6 +105,157 @@ function RoutingMatrix({ stats }: { stats: RoutingStat[] }) {
   );
 }
 
+function IsolationSection({
+  isolation,
+  saving,
+  onToggleConsume,
+  onToggleContribute,
+}: {
+  isolation: IsolationResponse;
+  saving: null | "consumesPool" | "contributesPool";
+  onToggleConsume: () => void;
+  onToggleContribute: () => void;
+}) {
+  const tierLabel =
+    isolation.tier === "enterprise" ? "Enterprise" : isolation.tier === "team" ? "Team" : "Pro";
+  const isolatedByDefault = isolation.tier === "team" || isolation.tier === "enterprise";
+  const matrixEmpty = isolatedByDefault && !isolation.preferences.consumesPool;
+
+  return (
+    <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-6 space-y-5">
+      <div className="flex items-start justify-between gap-6">
+        <div>
+          <h2 className="text-sm font-semibold text-zinc-300">Adaptive Isolation</h2>
+          <p className="text-xs text-zinc-500 mt-1 max-w-2xl">
+            Controls whether your tenant's routing matrix is isolated from the shared pool and whether your ratings contribute to it. Current plan: <span className="text-zinc-300">{tierLabel}</span>.
+          </p>
+        </div>
+        <a
+          href="/enterprise-data-handling"
+          className="text-xs text-blue-400 hover:text-blue-300 whitespace-nowrap"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Data handling ↗
+        </a>
+      </div>
+
+      {!isolation.canToggle && (
+        <div className="rounded border border-zinc-800 bg-zinc-950/60 px-4 py-3 text-xs text-zinc-400">
+          Pro plans use the shared routing pool for both reads and writes. Isolated per-tenant routing is a Team and Enterprise feature.{" "}
+          <a href="/pricing" className="text-blue-400 hover:text-blue-300">Compare plans</a>.
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <ToggleRow
+          label="Use pooled routing signal"
+          hint="When your matrix is empty or sparse, fall back to the shared pool at decision time. Pool data is never copied into your matrix."
+          on={isolation.policy.readsPool}
+          saving={saving === "consumesPool"}
+          disabled={!isolation.canToggle}
+          onClick={onToggleConsume}
+        />
+        <ToggleRow
+          label="Contribute ratings to pooled signal"
+          hint="When on, your ratings update the shared pool in addition to your own matrix. Contributions merge into a statistical model and cannot be retroactively removed — turn off at any time to stop future contributions."
+          warning
+          on={isolation.policy.writesPool}
+          saving={saving === "contributesPool"}
+          disabled={!isolation.canToggle}
+          onClick={onToggleContribute}
+        />
+      </div>
+
+      {matrixEmpty && (
+        <div className="rounded border border-zinc-800 bg-zinc-950/60 px-4 py-3 text-xs text-zinc-400">
+          Your routing matrix is isolated. Until your own ratings accrue, routing falls back to cost-based selection for cells you have no history on. Turn on <span className="text-zinc-300">Use pooled routing signal</span> to bootstrap from the shared pool without cutting ties.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ToggleRow({
+  label,
+  hint,
+  on,
+  saving,
+  disabled,
+  warning,
+  onClick,
+}: {
+  label: string;
+  hint: string;
+  on: boolean;
+  saving: boolean;
+  disabled: boolean;
+  warning?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-6">
+      <div className="flex-1">
+        <p className="text-sm text-zinc-300">{label}</p>
+        <p className={`text-xs mt-1 max-w-2xl ${warning ? "text-amber-300/80" : "text-zinc-500"}`}>{hint}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || saving}
+        className={`px-3 py-1.5 rounded text-xs font-medium transition-colors shrink-0 ${
+          disabled
+            ? "bg-zinc-800 text-zinc-600 cursor-not-allowed"
+            : on
+            ? "bg-emerald-900/50 text-emerald-300 hover:bg-emerald-800/50"
+            : "bg-zinc-800 text-zinc-500 hover:bg-zinc-700"
+        } ${saving ? "opacity-60" : ""}`}
+      >
+        {saving ? "Saving..." : on ? "On" : "Off"}
+      </button>
+    </div>
+  );
+}
+
+function ContributeConfirmModal({
+  onCancel,
+  onConfirm,
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div className="w-full max-w-md rounded-lg border border-zinc-800 bg-zinc-900 p-6 shadow-xl">
+        <h3 className="text-base font-semibold text-zinc-100">Contribute to the shared pool?</h3>
+        <p className="mt-3 text-sm text-zinc-400 leading-relaxed">
+          Ratings you contribute will merge into the shared pool's statistical model and{" "}
+          <span className="text-amber-300">cannot be retroactively removed</span>. You can stop future contributions at any time by turning this toggle back off, but past contributions remain in the pool.
+        </p>
+        <p className="mt-3 text-xs text-zinc-500">
+          See the <a href="/enterprise-data-handling" className="text-blue-400 hover:text-blue-300" target="_blank" rel="noreferrer">data handling addendum</a> for the full contractual language.
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:bg-zinc-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded bg-emerald-700 px-3 py-1.5 text-xs font-medium text-emerald-50 hover:bg-emerald-600"
+          >
+            I understand, enable
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 const routingStatsColumns: Column<RoutingStat>[] = [
   { key: "taskType", label: "Task Type", sortable: true, filterable: true, render: (row) => row.taskType ? <Badge variant={row.taskType}>{row.taskType}</Badge> : <>—</>, getValue: (row) => row.taskType },
   { key: "complexity", label: "Complexity", sortable: true, filterable: true, render: (row) => row.complexity ? <Badge variant={row.complexity}>{row.complexity}</Badge> : <>—</>, getValue: (row) => row.complexity },
@@ -119,22 +270,43 @@ interface RoutingConfig {
   abTestPreempts: boolean;
 }
 
+type IsolationTier = "free" | "pro" | "team" | "enterprise";
+
+interface IsolationResponse {
+  tier: IsolationTier;
+  canToggle: boolean;
+  policy: {
+    readsPool: boolean;
+    writesPool: boolean;
+    readsTenantRow: boolean;
+    writesTenantRow: boolean;
+  };
+  preferences: {
+    consumesPool: boolean;
+    contributesPool: boolean;
+  };
+}
+
 export default function RoutingPage() {
   const [stats, setStats] = useState<RoutingStat[]>([]);
   const [distribution, setDistribution] = useState<Distribution | null>(null);
   const [adaptiveCells, setAdaptiveCells] = useState<AdaptiveCell[]>([]);
   const [routingConfig, setRoutingConfig] = useState<RoutingConfig | null>(null);
   const [savingConfig, setSavingConfig] = useState(false);
+  const [isolation, setIsolation] = useState<IsolationResponse | null>(null);
+  const [savingIsolation, setSavingIsolation] = useState<null | "consumesPool" | "contributesPool">(null);
+  const [contributeConfirm, setContributeConfirm] = useState(false);
   const [loading, setLoading] = useState(true);
   const { pulseTick, recentUpdateCount } = useAdaptiveScoreBuffer(adaptiveCells);
 
   useEffect(() => {
     async function fetchData() {
       try {
-        const [statsRes, distRes, configRes] = await Promise.all([
+        const [statsRes, distRes, configRes, isoRes] = await Promise.all([
           gatewayFetchRaw("/v1/analytics/routing/stats"),
           gatewayFetchRaw("/v1/analytics/routing/distribution"),
           gatewayFetchRaw("/v1/routing/config"),
+          gatewayFetchRaw("/v1/routing/isolation").catch(() => null),
         ]);
         const statsData = await statsRes.json();
         const distData = await distRes.json();
@@ -142,6 +314,9 @@ export default function RoutingPage() {
         setStats(statsData.stats || []);
         setDistribution(distData);
         setRoutingConfig(configData);
+        if (isoRes && isoRes.ok) {
+          setIsolation(await isoRes.json());
+        }
       } catch (err) {
         console.error("Failed to fetch routing data:", err);
       } finally {
@@ -150,6 +325,52 @@ export default function RoutingPage() {
     }
     fetchData();
   }, []);
+
+  async function patchIsolation(payload: { consumesPool?: boolean; contributesPool?: boolean }, key: "consumesPool" | "contributesPool") {
+    setSavingIsolation(key);
+    try {
+      const res = await gatewayFetchRaw("/v1/routing/isolation", {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as IsolationResponse;
+        // Re-fetch to get updated derived policy (backend recomputes).
+        const policyRes = await gatewayFetchRaw("/v1/routing/isolation");
+        if (policyRes.ok) {
+          setIsolation(await policyRes.json());
+        } else {
+          setIsolation((prev) => (prev ? { ...prev, preferences: data.preferences } : prev));
+        }
+      } else {
+        console.error("isolation patch failed", await res.text());
+      }
+    } catch (err) {
+      console.error("isolation patch error", err);
+    } finally {
+      setSavingIsolation(null);
+    }
+  }
+
+  function onToggleConsume() {
+    if (!isolation || !isolation.canToggle || savingIsolation) return;
+    patchIsolation({ consumesPool: !isolation.preferences.consumesPool }, "consumesPool");
+  }
+
+  function onToggleContribute() {
+    if (!isolation || !isolation.canToggle || savingIsolation) return;
+    // Irreversibility warning fires only when enabling (turning off is safe).
+    if (!isolation.preferences.contributesPool) {
+      setContributeConfirm(true);
+      return;
+    }
+    patchIsolation({ contributesPool: false }, "contributesPool");
+  }
+
+  function confirmContribute() {
+    setContributeConfirm(false);
+    patchIsolation({ contributesPool: true }, "contributesPool");
+  }
 
   async function toggleAbTestPreempts() {
     if (!routingConfig || savingConfig) return;
@@ -197,6 +418,28 @@ export default function RoutingPage() {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
       <h1 className="text-2xl font-bold">Routing Analytics</h1>
+
+      {/* Adaptive Isolation — only visible when backend returns a response
+          (i.e. cloud deployment with known tier). Free tenants are hidden
+          entirely; Pro sees disabled toggles with upgrade copy; Team +
+          Enterprise get working toggles with an irreversibility modal
+          gating the "contribute to pool" enable. */}
+      {isolation && isolation.tier !== "free" && (
+        <IsolationSection
+          isolation={isolation}
+          saving={savingIsolation}
+          onToggleConsume={onToggleConsume}
+          onToggleContribute={onToggleContribute}
+        />
+      )}
+
+      {/* Modal — irreversibility confirmation for "contribute to pool" enable */}
+      {contributeConfirm && (
+        <ContributeConfirmModal
+          onCancel={() => setContributeConfirm(false)}
+          onConfirm={confirmContribute}
+        />
+      )}
 
       {/* Routing Config */}
       {routingConfig && (

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -18,6 +18,7 @@ import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createConversationRoutes } from "./routes/conversations.js";
 import { createShareHandlers } from "./routes/shares.js";
 import { createRoutingConfigRoutes } from "./routes/routing-config.js";
+import { createRoutingIsolationRoutes } from "./routes/routing-isolation.js";
 import { createProviderCrudRoutes } from "./routes/providers.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import { createTeamRoutes } from "./routes/team.js";
@@ -164,6 +165,7 @@ export async function createRouter(ctx: RouterContext) {
   app.route("/v1/feedback", createFeedbackRoutes(ctx.db, routingEngine.adaptive));
   app.route("/v1/conversations", createConversationRoutes(ctx.db));
   app.route("/v1/routing/config", createRoutingConfigRoutes(ctx.db));
+  app.route("/v1/routing/isolation", createRoutingIsolationRoutes(ctx.db));
 
   // Mount token management routes (owner only)
   app.route("/v1/admin/tokens", createTokenRoutes(ctx.db));

--- a/packages/gateway/src/routes/routing-isolation.ts
+++ b/packages/gateway/src/routes/routing-isolation.ts
@@ -1,0 +1,112 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { getAuthUser } from "../auth/admin.js";
+import { getTenantId } from "../auth/tenant.js";
+import { getTenantIsolationPolicy } from "../routing/adaptive/isolation-policy.js";
+import {
+  getIsolationPreferences,
+  updateIsolationPreferences,
+} from "../routing/adaptive/isolation-preferences.js";
+
+/**
+ * Routes for per-tenant adaptive isolation toggles (#197, C4 of #176).
+ *
+ * GET returns the live policy + raw toggle state + tier-derived capability
+ * so the dashboard can render the right combination of controls without
+ * re-implementing tier rules client-side.
+ *
+ * PATCH is gated on tier: only Team and Enterprise can change toggles
+ * (Free/Pro have no tenant row; toggles would be meaningless). The
+ * underlying `updateIsolationPreferences` also refuses — double gate.
+ */
+export function createRoutingIsolationRoutes(db: Db) {
+  const app = new Hono();
+
+  app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    if (!tenantId) {
+      return c.json(
+        { error: { message: "Authentication required.", type: "auth_error" } },
+        401,
+      );
+    }
+
+    const policy = await getTenantIsolationPolicy(db, tenantId);
+    const prefs = await getIsolationPreferences(db, tenantId);
+    const canToggle = policy.tier === "team" || policy.tier === "enterprise";
+
+    return c.json({
+      tier: policy.tier,
+      canToggle,
+      policy: {
+        readsPool: policy.readsPool,
+        writesPool: policy.writesPool,
+        readsTenantRow: policy.readsTenantRow,
+        writesTenantRow: policy.writesTenantRow,
+      },
+      preferences: prefs,
+    });
+  });
+
+  app.patch("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    if (!tenantId) {
+      return c.json(
+        { error: { message: "Authentication required.", type: "auth_error" } },
+        401,
+      );
+    }
+
+    const policy = await getTenantIsolationPolicy(db, tenantId);
+    if (policy.tier !== "team" && policy.tier !== "enterprise") {
+      return c.json(
+        {
+          error: {
+            message: "Adaptive isolation toggles are available on Team and Enterprise plans.",
+            type: "insufficient_tier",
+          },
+          tier: policy.tier,
+          upgradeUrl: "https://provara.xyz/pricing",
+        },
+        403,
+      );
+    }
+
+    let body: { consumesPool?: boolean; contributesPool?: boolean };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json(
+        { error: { message: "Invalid JSON body.", type: "validation_error" } },
+        400,
+      );
+    }
+
+    const next: { consumesPool?: boolean; contributesPool?: boolean } = {};
+    if (typeof body.consumesPool === "boolean") next.consumesPool = body.consumesPool;
+    if (typeof body.contributesPool === "boolean") next.contributesPool = body.contributesPool;
+    if (Object.keys(next).length === 0) {
+      return c.json(
+        {
+          error: {
+            message: "At least one of consumesPool or contributesPool must be provided.",
+            type: "validation_error",
+          },
+        },
+        400,
+      );
+    }
+
+    const user = getAuthUser(c.req.raw);
+    const changedBy = user?.id ?? "unknown";
+
+    const merged = await updateIsolationPreferences(db, tenantId, next, changedBy);
+    return c.json({
+      tier: policy.tier,
+      canToggle: true,
+      preferences: merged,
+    });
+  });
+
+  return app;
+}

--- a/packages/gateway/tests/routing-isolation-routes.test.ts
+++ b/packages/gateway/tests/routing-isolation-routes.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Hono } from "hono";
+import { eq } from "drizzle-orm";
+import { adaptiveIsolationPreferencesLog } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+import { createRoutingIsolationRoutes } from "../src/routes/routing-isolation.js";
+import { __testSetTenant } from "../src/auth/tenant.js";
+
+/**
+ * C4 (#197) — API surface for adaptive isolation toggles.
+ *
+ * Tests mount the routes into a bare Hono app and simulate the tenant
+ * middleware by calling the `__testSetTenant` helper. The admin auth +
+ * role middleware are skipped here — they're covered by existing
+ * admin-auth tests; this file focuses on tier-gating and write semantics.
+ */
+
+function appFor(db: Parameters<typeof createRoutingIsolationRoutes>[0], tenantId?: string) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (tenantId) {
+      __testSetTenant(c.req.raw, tenantId);
+    }
+    await next();
+  });
+  app.route("/", createRoutingIsolationRoutes(db));
+  return app;
+}
+
+describe("routing-isolation API — C4", () => {
+  afterEach(() => resetTierEnv());
+
+  describe("GET /", () => {
+    it("returns 401 when no tenantId is present", async () => {
+      const db = await makeTestDb();
+      const app = appFor(db);
+      const res = await app.request("/");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns Free policy for an unsubscribed tenant", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      const app = appFor(db, "t-free");
+      const res = await app.request("/");
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.tier).toBe("free");
+      expect(body.canToggle).toBe(false);
+      expect(body.preferences).toEqual({ consumesPool: false, contributesPool: false });
+    });
+
+    it("returns Pro policy with canToggle=false", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-pro", { tier: "pro" });
+      const app = appFor(db, "t-pro");
+      const res = await app.request("/");
+      const body = await res.json();
+      expect(body.tier).toBe("pro");
+      expect(body.canToggle).toBe(false);
+    });
+
+    it("returns Team policy with canToggle=true and default toggles off", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const app = appFor(db, "t-team");
+      const res = await app.request("/");
+      const body = await res.json();
+      expect(body.tier).toBe("team");
+      expect(body.canToggle).toBe(true);
+      expect(body.preferences).toEqual({ consumesPool: false, contributesPool: false });
+      expect(body.policy.readsPool).toBe(false);
+      expect(body.policy.writesPool).toBe(false);
+    });
+  });
+
+  describe("PATCH /", () => {
+    it("returns 403 for a Pro tenant attempting to toggle", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-pro", { tier: "pro" });
+      const app = appFor(db, "t-pro");
+      const res = await app.request("/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ consumesPool: true }),
+      });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error.type).toBe("insufficient_tier");
+    });
+
+    it("flips consumesPool for a Team tenant and logs the change", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const app = appFor(db, "t-team");
+      const res = await app.request("/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ consumesPool: true }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.preferences.consumesPool).toBe(true);
+      expect(body.preferences.contributesPool).toBe(false);
+
+      const logs = await db
+        .select()
+        .from(adaptiveIsolationPreferencesLog)
+        .where(eq(adaptiveIsolationPreferencesLog.tenantId, "t-team"))
+        .all();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].field).toBe("consumes_pool");
+      // Without admin middleware attaching a user, changedBy falls back.
+      expect(logs[0].changedBy).toBe("unknown");
+    });
+
+    it("rejects empty body with 400", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const app = appFor(db, "t-team");
+      const res = await app.request("/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("ignores non-boolean values silently (no write if nothing valid)", async () => {
+      const db = await makeTestDb();
+      await grantIntelligenceAccess(db, "t-team", { tier: "team" });
+      const app = appFor(db, "t-team");
+      const res = await app.request("/", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ consumesPool: "yes" }),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
Closes #197. Closes the last open task (T7) on #176.

## Summary

Exposes C2's per-tenant adaptive isolation policy through the dashboard so Team and Enterprise tenants can flip the two toggles themselves, with a tier-gated UX and an irreversibility-warning modal on the contribute-pool enable.

## Backend — `/v1/routing/isolation`

- **`GET /`** returns `{ tier, canToggle, policy, preferences }`. `policy` is the four-field live policy from C2 (`readsPool`, `writesPool`, `readsTenantRow`, `writesTenantRow`); `preferences` is the raw toggle state. `canToggle` is tier-derived (`team`/`enterprise` only) so the UI doesn't re-implement tier rules.
- **`PATCH /`** accepts `{ consumesPool?, contributesPool? }`, validates booleans, refuses Free/Pro with 403 + `insufficient_tier`. Threads the authed user id into `updateIsolationPreferences` as `changedBy`, so every toggle transition shows up in the `adaptive_isolation_preferences_log` audit table with a real actor.
- Mounted at `/v1/routing/isolation` — already inside the `adminAuth` + `tenantMiddleware` prefixes.

## Dashboard — `/dashboard/routing`

New "Adaptive Isolation" section, placed above the existing Routing Configuration panel:

- **Free** — section is hidden entirely. Pool is their only mode; nothing to choose.
- **Pro** — section is visible with toggles **disabled**. Copy points at `/pricing` so the upgrade path is discoverable, but the toggles don't pretend to work.
- **Team / Enterprise** — toggles enabled, defaults off.
  - **"Use pooled routing signal"** flips on one click with a clean opt-out path.
  - **"Contribute ratings to pooled signal"** enable opens a confirmation modal. Opt-out (turning it off) is one click, no modal. Copy acknowledges irreversibility: "Contributions merge into a statistical model and cannot be retroactively removed. You can stop future contributions at any time by turning this toggle back off, but past contributions remain in the pool."
  - **Empty-matrix hint** appears when isolation is active and `consumesPool` is off, pointing Team/Enterprise tenants toward a warm-start without committing to pool writes.
  - Addendum link in the section header + modal.

## Test plan

- [x] `npx tsc --noEmit` clean for gateway, db, web.
- [x] `npm test -w packages/gateway`: **321 passed** (up from 313).
- [x] 8 new route tests in `tests/routing-isolation-routes.test.ts`: 401 without tenant, GET policies for Free/Pro/Team, PATCH 403 for Pro, PATCH flips consumesPool + writes audit log, 400 on empty body, 400 on non-boolean values.
- [x] `npx next build -w apps/web` — routing page prerenders clean.
- [ ] Visual QA on each tier — your call post-merge per session cadence memory.

## Follow-ups

- Enterprise can view their audit log today only by DB — no UI surface yet. Worth a small follow-up to add a "toggle history" subsection if Enterprise customers start asking. Defer until someone asks.
- Admin override (operator flipping a tenant's toggle on their behalf) — not scoped; `changedBy` already accepts `"operator"` as a sentinel so the API path is ready when/if the admin UI ships.

Last-code-by: opus-4-7 (claude-code)
