### PR TITLE
fix: operator tenants see adaptive isolation toggles without a sub

### DIFF
--- a/packages/gateway/src/auth/tier.ts
+++ b/packages/gateway/src/auth/tier.ts
@@ -14,7 +14,7 @@ import { getSubscriptionForTenant } from "../stripe/subscriptions.js";
  * check; acceptable because Intelligence routes are not on the hot path
  * for chat completions.
  */
-async function isOperatorTenant(db: Db, tenantId: string | null | undefined): Promise<boolean> {
+export async function isOperatorTenant(db: Db, tenantId: string | null | undefined): Promise<boolean> {
   if (!tenantId) return false;
   const allowlist = getOperatorEmails();
   if (allowlist.length === 0) return false;

--- a/packages/gateway/src/routing/adaptive/isolation-policy.ts
+++ b/packages/gateway/src/routing/adaptive/isolation-policy.ts
@@ -3,6 +3,7 @@ import { subscriptions, tenantAdaptiveIsolation } from "@provara/db";
 import { eq, inArray } from "drizzle-orm";
 import { isCloudDeployment } from "../../config.js";
 import { getSubscriptionForTenant } from "../../stripe/subscriptions.js";
+import { isOperatorTenant } from "../../auth/tier.js";
 
 /**
  * Tier-aware adaptive isolation policy per #176/#195. Four fields:
@@ -69,6 +70,11 @@ function normalizeTier(raw: string | null | undefined): Tier {
  * the worst case (subscription + preferences), both indexed on
  * tenantId. Not cached yet — see #195 comment; add TTL caching if
  * latency shows up in hot-path tracing.
+ *
+ * Operator bypass (#173): tenants on the PROVARA_OPERATOR_EMAILS
+ * allowlist are treated as Enterprise-equivalent regardless of
+ * subscription. Mirrors `tenantHasIntelligenceAccess` — operators
+ * are "us", they see every feature we ship.
  */
 export async function getTenantIsolationPolicy(
   db: Db,
@@ -79,6 +85,22 @@ export async function getTenantIsolationPolicy(
 
   // Unauthenticated / anonymous: pool-only, like Free. No tenant row exists.
   if (!tenantId) return FREE_POLICY;
+
+  const operator = await isOperatorTenant(db, tenantId);
+  if (operator) {
+    const prefs = await db
+      .select()
+      .from(tenantAdaptiveIsolation)
+      .where(eq(tenantAdaptiveIsolation.tenantId, tenantId))
+      .get();
+    return {
+      tier: "enterprise",
+      writesTenantRow: true,
+      readsTenantRow: true,
+      writesPool: prefs?.contributesPool ?? false,
+      readsPool: prefs?.consumesPool ?? false,
+    };
+  }
 
   const sub = await getSubscriptionForTenant(db, tenantId);
   const tier = sub && ACTIVE_STATUSES.has(sub.status) ? normalizeTier(sub.tier) : "free";

--- a/packages/gateway/tests/adaptive-isolation-policy.test.ts
+++ b/packages/gateway/tests/adaptive-isolation-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { eq } from "drizzle-orm";
 import { modelScores, adaptiveIsolationPreferencesLog } from "@provara/db";
 import { makeTestDb } from "./_setup/db.js";
-import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+import { grantIntelligenceAccess, resetTierEnv, seedOperatorUser } from "./_setup/tier.js";
 import { POOL_KEY } from "../src/routing/adaptive/score-store.js";
 import { getTenantIsolationPolicy } from "../src/routing/adaptive/isolation-policy.js";
 import { updateIsolationPreferences, getIsolationPreferences } from "../src/routing/adaptive/isolation-preferences.js";
@@ -68,6 +68,30 @@ describe("adaptive isolation policy — C2", () => {
         readsTenantRow: true,
         readsPool: false,
       });
+    });
+
+    it("treats operator tenants as Enterprise-equivalent even without a subscription", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      await seedOperatorUser(db, "t-op", "ops@provara.xyz");
+      const policy = await getTenantIsolationPolicy(db, "t-op");
+      expect(policy.tier).toBe("enterprise");
+      expect(policy).toMatchObject({
+        writesTenantRow: true,
+        readsTenantRow: true,
+        writesPool: false,
+        readsPool: false,
+      });
+    });
+
+    it("operator tenant's toggles still apply on top of the Enterprise baseline", async () => {
+      const db = await makeTestDb();
+      process.env.PROVARA_CLOUD = "true";
+      await seedOperatorUser(db, "t-op", "ops@provara.xyz");
+      await updateIsolationPreferences(db, "t-op", { consumesPool: true }, "self");
+      const policy = await getTenantIsolationPolicy(db, "t-op");
+      expect(policy.readsPool).toBe(true);
+      expect(policy.writesPool).toBe(false);
     });
 
     it("returns isolated Enterprise policy by default", async () => {


### PR DESCRIPTION
## Summary

Extends the operator bypass (#173) to the adaptive isolation policy. Pre-fix, an operator tenant without a Team/Enterprise subscription fell through to Free in `getTenantIsolationPolicy` — the dashboard section hid, PATCH returned 403. Inconsistent with `tenantHasIntelligenceAccess`, which already short-circuits operator tenants.

## Changes

- Export `isOperatorTenant` from `auth/tier.ts` (was module-private).
- `getTenantIsolationPolicy` checks it before the subscription lookup; operator → Enterprise-equivalent baseline with toggles from `tenant_adaptive_isolation` layered on top.

## Test plan

- [x] Typecheck clean.
- [x] 2 new tests in `adaptive-isolation-policy.test.ts`: operator baseline is Enterprise-isolated; operator's toggle flips still apply.
- [x] Full gateway suite: **323 passed** (up from 321).

## Why

Caught while dogfooding the C4 dashboard after #202 merged — operator sessions couldn't see their own feature. This matches the "operators are us, full access" intent of #173.

Last-code-by: opus-4-7 (claude-code)