### PR TITLE
feat(#204): magic-link signup/login flow

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -22,6 +22,12 @@ function errorMessage(code: string | null): string | null {
       return "The sign-in link expired mid-flow. Please start again.";
     case "email_unverified":
       return "That email is already registered with another sign-in method, and the provider you used did not verify email ownership. Please sign in with your original provider.";
+    case "magic_link_invalid":
+      return "That magic link is invalid. Request a fresh one below.";
+    case "magic_link_expired":
+      return "That magic link has expired. Request a fresh one below.";
+    case "magic_link_used":
+      return "That magic link has already been used. Request a fresh one below.";
     case null:
       return null;
     default:
@@ -127,6 +133,14 @@ function LoginContent() {
           </a>
         </div>
 
+        <div className="flex items-center gap-3 text-xs text-zinc-500">
+          <div className="h-px bg-zinc-800 flex-1" />
+          <span>or</span>
+          <div className="h-px bg-zinc-800 flex-1" />
+        </div>
+
+        <MagicLinkForm returnTo={returnTo} />
+
         <div className="pt-2 text-center space-y-2">
           <p className="text-xs text-zinc-500">
             By signing in, you agree to our{" "}
@@ -149,6 +163,120 @@ function LoginContent() {
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Magic-link request form. Two terminal states:
+ *
+ * - Email belongs to an existing user → `{status: "sent"}` from the
+ *   gateway → we swap in a "check your inbox" confirmation.
+ * - Email does not exist → `{status: "new_user"}` → redirect to
+ *   /signup?email=X so the user can provide first/last name before we
+ *   issue the link.
+ */
+function MagicLinkForm({ returnTo }: { returnTo: string }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (sending) return;
+    setLocalError(null);
+
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed || !trimmed.includes("@")) {
+      setLocalError("Enter a valid email.");
+      return;
+    }
+
+    setSending(true);
+    try {
+      const res = await gatewayFetchRaw("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: trimmed }),
+      });
+      if (res.status === 429) {
+        setLocalError("Too many requests for this email. Try again in a few minutes.");
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setLocalError(body?.error?.message ?? "Something went wrong. Try again.");
+        return;
+      }
+      const data = (await res.json()) as { status: "sent" | "new_user" };
+      if (data.status === "new_user") {
+        const qs = new URLSearchParams({ email: trimmed });
+        if (returnTo && returnTo !== "/dashboard") qs.set("return", returnTo);
+        router.push(`/signup?${qs.toString()}`);
+        return;
+      }
+      setSentTo(trimmed);
+    } catch (err) {
+      setLocalError("Network error. Check your connection and try again.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (sentTo) {
+    return (
+      <div className="rounded-lg border border-emerald-900/60 bg-emerald-950/30 px-4 py-4 text-sm text-emerald-200 space-y-2">
+        <p>
+          <strong className="text-emerald-100">Check your inbox.</strong> We sent a sign-in link to{" "}
+          <span className="font-mono text-emerald-50">{sentTo}</span>. The link expires in 15 minutes.
+        </p>
+        <p className="text-xs text-emerald-300/70">
+          Didn&apos;t get it?{" "}
+          <button
+            type="button"
+            onClick={() => {
+              setSentTo(null);
+              setEmail("");
+            }}
+            className="underline hover:text-emerald-100"
+          >
+            Try a different email
+          </button>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-2">
+      <label htmlFor="magic-email" className="sr-only">
+        Email
+      </label>
+      <input
+        id="magic-email"
+        type="email"
+        autoComplete="email"
+        placeholder="you@example.com"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={sending}
+        className="w-full px-4 py-3 rounded-lg bg-zinc-900 border border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-600"
+      />
+      {localError && (
+        <p className="text-xs text-red-400">{localError}</p>
+      )}
+      <button
+        type="submit"
+        disabled={sending}
+        className="flex items-center justify-center gap-3 w-full px-4 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-500 transition-colors disabled:opacity-60"
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </svg>
+        {sending ? "Sending…" : "Sign in with Magic Link"}
+      </button>
+    </form>
   );
 }
 

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
+import { useSearchParams, useRouter } from "next/navigation";
+import { gatewayFetchRaw } from "../../lib/gateway-client";
+import { PublicNav } from "../../components/public-nav";
+
+/**
+ * Magic-link signup form (#204). Reached when /login determines no user
+ * row matches the entered email. Collects first + last name, then re-
+ * issues the magic-link request with those names attached — the verify
+ * endpoint creates the user atomically on click.
+ */
+function SignupContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const email = searchParams.get("email") ?? "";
+  const returnTo = searchParams.get("return") ?? "/dashboard";
+
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Direct visit without a seeded email is useless — send them back.
+    if (!email) {
+      router.replace("/login");
+    }
+  }, [email, router]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (sending) return;
+    const first = firstName.trim();
+    const last = lastName.trim();
+    if (!first || !last) {
+      setError("Please enter both your first and last name.");
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      const res = await gatewayFetchRaw("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email, firstName: first, lastName: last }),
+      });
+      if (res.status === 429) {
+        setError("Too many requests for this email. Try again in a few minutes.");
+        return;
+      }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body?.error?.message ?? "Something went wrong. Try again.");
+        return;
+      }
+      setSentTo(email);
+    } catch {
+      setError("Network error. Check your connection and try again.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  if (!email) return null;
+
+  if (sentTo) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center px-4">
+        <div className="w-full max-w-md space-y-5">
+          <h1 className="text-2xl font-bold text-center">Check your inbox</h1>
+          <div className="rounded-lg border border-emerald-900/60 bg-emerald-950/30 px-4 py-4 text-sm text-emerald-100 space-y-2">
+            <p>
+              We sent a sign-in link to <span className="font-mono text-emerald-50">{sentTo}</span>. Click it to finish creating your account. The link expires in 15 minutes.
+            </p>
+          </div>
+          <p className="text-xs text-zinc-500 text-center">
+            Wrong email?{" "}
+            <Link href="/login" className="text-blue-400 hover:text-blue-300">
+              Go back
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold">Finish signing up</h1>
+          <p className="text-zinc-400 mt-2 text-sm">
+            We&apos;ll email a magic link to{" "}
+            <span className="font-mono text-zinc-200">{email}</span> once you add your name.
+          </p>
+        </div>
+
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label htmlFor="first-name" className="text-xs text-zinc-400">First name</label>
+              <input
+                id="first-name"
+                type="text"
+                autoComplete="given-name"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                disabled={sending}
+                className="w-full px-3 py-2.5 rounded-lg bg-zinc-900 border border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-600"
+                placeholder="Ada"
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="last-name" className="text-xs text-zinc-400">Last name</label>
+              <input
+                id="last-name"
+                type="text"
+                autoComplete="family-name"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                disabled={sending}
+                className="w-full px-3 py-2.5 rounded-lg bg-zinc-900 border border-zinc-800 text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:border-zinc-600"
+                placeholder="Lovelace"
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-xs text-red-400">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={sending}
+            className="w-full px-4 py-3 rounded-lg font-medium bg-blue-600 text-white hover:bg-blue-500 transition-colors disabled:opacity-60"
+          >
+            {sending ? "Sending link…" : "Send my magic link"}
+          </button>
+        </form>
+
+        {returnTo !== "/dashboard" && (
+          <p className="text-xs text-zinc-500 text-center">
+            After signing in we&apos;ll take you to{" "}
+            <span className="font-mono text-zinc-300">{returnTo}</span>.
+          </p>
+        )}
+
+        <p className="text-xs text-zinc-500 text-center">
+          Already have an account?{" "}
+          <Link href="/login" className="text-blue-400 hover:text-blue-300">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function SignupPage() {
+  return (
+    <>
+      <PublicNav />
+      <Suspense>
+        <SignupContent />
+      </Suspense>
+    </>
+  );
+}

--- a/packages/db/drizzle/0029_peaceful_night_thrasher.sql
+++ b/packages/db/drizzle/0029_peaceful_night_thrasher.sql
@@ -1,0 +1,29 @@
+CREATE TABLE `magic_link_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`email` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`pending_first_name` text,
+	`pending_last_name` text,
+	`created_at` integer NOT NULL,
+	`expires_at` integer NOT NULL,
+	`consumed_at` integer
+);
+--> statement-breakpoint
+CREATE INDEX `magic_link_tokens_email_idx` ON `magic_link_tokens` (`email`);--> statement-breakpoint
+CREATE INDEX `magic_link_tokens_hash_idx` ON `magic_link_tokens` (`token_hash`);--> statement-breakpoint
+ALTER TABLE `users` ADD `first_name` text;--> statement-breakpoint
+ALTER TABLE `users` ADD `last_name` text;--> statement-breakpoint
+-- Backfill split names from legacy `name` column. Split on the first
+-- space: `last_name` = trailing token, `first_name` = everything before.
+-- Rows with a single token (e.g. one-word display names from GitHub)
+-- get it all in `first_name` and `last_name` stays NULL.
+UPDATE `users`
+  SET `first_name` = CASE
+    WHEN instr(`name`, ' ') > 0 THEN substr(`name`, 1, instr(`name`, ' ') - 1)
+    ELSE `name`
+  END,
+  `last_name` = CASE
+    WHEN instr(`name`, ' ') > 0 THEN substr(`name`, instr(`name`, ' ') + 1)
+    ELSE NULL
+  END
+  WHERE `name` IS NOT NULL AND `first_name` IS NULL AND `last_name` IS NULL;

--- a/packages/db/drizzle/meta/0029_snapshot.json
+++ b/packages/db/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2860 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "da538984-1b51-4056-8b8a-b4b31fb3f476",
+  "prevId": "40e2d701-ac44-4d8d-ba3d-eae604d0da89",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "adaptive_isolation_preferences_log": {
+      "name": "adaptive_isolation_preferences_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_first_name": {
+          "name": "pending_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_last_name": {
+          "name": "pending_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_email_idx": {
+          "name": "magic_link_tokens_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "magic_link_tokens_hash_idx": {
+          "name": "magic_link_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_adaptive_isolation": {
+      "name": "tenant_adaptive_isolation",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumes_pool": {
+          "name": "consumes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contributes_pool": {
+          "name": "contributes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1776493737525,
       "tag": "0028_amazing_sabretooth",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1776510146882,
+      "tag": "0029_peaceful_night_thrasher",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,9 +1,15 @@
-import { sqliteTable, text, integer, real, blob, uniqueIndex, primaryKey } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, blob, uniqueIndex, index, primaryKey } from "drizzle-orm/sqlite-core";
 
 export const users = sqliteTable("users", {
   id: text("id").primaryKey(),
   email: text("email").notNull().unique(),
+  // `name` is kept for back-compat with OAuth flow reads; new code should
+  // read `firstName` / `lastName` and rely on server-side concatenation
+  // at insert time. Magic-link (#204) added the split fields; OAuth
+  // `upsertUser` still populates `name` the same way.
   name: text("name"),
+  firstName: text("first_name"),
+  lastName: text("last_name"),
   avatarUrl: text("avatar_url"),
   tenantId: text("tenant_id").notNull(),
   role: text("role", { enum: ["owner", "member"] }).notNull().default("owner"),
@@ -37,6 +43,38 @@ export const sessions = sqliteTable("sessions", {
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+/**
+ * Magic-link sign-in / signup tokens (#204).
+ *
+ * Token lifecycle: created by POST /auth/magic-link/request, consumed by
+ * GET /auth/magic/verify. Single-use (consumedAt stamp) with a 15-minute
+ * TTL. SHA-256 hashed at rest — plain token only exists in the email.
+ *
+ * Signup carriers: when the request comes from an email with no existing
+ * user row, the client resubmits /request with firstName + lastName. We
+ * stash those on the token row so the verify endpoint has everything it
+ * needs to create the user atomically on click — no intermediate "pending
+ * signup" state anywhere else in the system.
+ *
+ * Rate limit: the request handler counts rows for a given email where
+ * createdAt > now - 15min; rejects at 3.
+ */
+export const magicLinkTokens = sqliteTable("magic_link_tokens", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull(),
+  tokenHash: text("token_hash").notNull(),
+  pendingFirstName: text("pending_first_name"),
+  pendingLastName: text("pending_last_name"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  consumedAt: integer("consumed_at", { mode: "timestamp" }),
+}, (t) => [
+  index("magic_link_tokens_email_idx").on(t.email),
+  index("magic_link_tokens_hash_idx").on(t.tokenHash),
+]);
 
 export const customProviders = sqliteTable("custom_providers", {
   id: text("id").primaryKey(),

--- a/packages/gateway/src/email/templates.ts
+++ b/packages/gateway/src/email/templates.ts
@@ -105,6 +105,54 @@ export function inviteEmail(params: InviteEmailParams): { subject: string; html:
   return { subject, html: emailShell(subject, body), text };
 }
 
+export interface MagicLinkEmailParams {
+  verifyUrl: string;
+  email: string;
+  isNewUser: boolean;
+  expiresAt: Date;
+}
+
+export function magicLinkEmail(params: MagicLinkEmailParams): { subject: string; html: string; text: string } {
+  const expiresLabel = "15 minutes";
+  const subject = params.isNewUser
+    ? "Finish signing up for Provara"
+    : "Your Provara sign-in link";
+  const headline = params.isNewUser
+    ? "One click away from your new Provara account"
+    : "Sign in to Provara";
+  const intro = params.isNewUser
+    ? `Click the button below to finish creating your account on <strong style="color:#fafafa;">${escapeHtml(params.email)}</strong>. The link expires in ${expiresLabel}.`
+    : `Click the button below to sign in as <strong style="color:#fafafa;">${escapeHtml(params.email)}</strong>. The link expires in ${expiresLabel}.`;
+  const body = `
+    <p style="font-size:16px; color:#fafafa; margin:0 0 18px;">${headline}</p>
+    <p style="margin:0 0 22px;">${intro}</p>
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="margin:0 0 24px;">
+      <tr>
+        <td style="background:#2563eb; border-radius:8px;">
+          <a href="${escapeHtml(params.verifyUrl)}" style="display:inline-block; padding:12px 22px; color:#ffffff; font-weight:600; text-decoration:none; font-size:14px;">${params.isNewUser ? "Finish signing up" : "Sign in"} &rarr;</a>
+        </td>
+      </tr>
+    </table>
+    <p style="margin:0 0 8px; color:#a1a1aa; font-size:13px;">Or paste this link into your browser:</p>
+    <p style="margin:0 0 20px; word-break:break-all; font-size:12px; color:#60a5fa;"><a href="${escapeHtml(params.verifyUrl)}" style="color:#60a5fa;">${escapeHtml(params.verifyUrl)}</a></p>
+    <p style="margin:0; font-size:12px; color:#71717a;">If you didn't request this, you can ignore this email — nothing happens until the link is clicked.</p>
+  `;
+  const text = [
+    headline,
+    "",
+    params.isNewUser
+      ? `Finish creating your Provara account for ${params.email}. Link expires in ${expiresLabel}.`
+      : `Sign in to Provara as ${params.email}. Link expires in ${expiresLabel}.`,
+    "",
+    params.verifyUrl,
+    "",
+    "If you didn't request this, ignore this email.",
+    "",
+    "Provara · operated by CoreLumen, LLC",
+  ].join("\n");
+  return { subject, html: emailShell(subject, body), text };
+}
+
 export interface WelcomeEmailParams {
   name: string;
   dashboardUrl: string;

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -1,7 +1,8 @@
 import { Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
+import { createHash } from "node:crypto";
 import type { Db } from "@provara/db";
-import { users, oauthAccounts, teamInvites } from "@provara/db";
+import { users, oauthAccounts, teamInvites, magicLinkTokens } from "@provara/db";
 import { eq, and, gte, isNull, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import {
@@ -23,7 +24,7 @@ import {
   getSessionFromCookie,
 } from "../auth/session.js";
 import { sendEmail } from "../email/index.js";
-import { welcomeEmail } from "../email/templates.js";
+import { welcomeEmail, magicLinkEmail } from "../email/templates.js";
 
 const DASHBOARD_URL = () => process.env.DASHBOARD_URL || "http://localhost:3000";
 const STATE_COOKIE = "provara_oauth_state";
@@ -172,7 +173,287 @@ export function createAuthRoutes(db: Db) {
     });
   });
 
+  // --- Magic link (#204) ---
+
+  /**
+   * Request a magic link. Body: `{ email, firstName?, lastName? }`.
+   *
+   * - If a user with that email exists: generate + email a link,
+   *   return `{status: "sent"}`.
+   * - If no user and no names provided: return `{status: "new_user"}` so
+   *   the client can redirect to the signup form.
+   * - If no user but names provided: store the names on the token row
+   *   and email the link — verify-time endpoint will create the user
+   *   atomically on click.
+   *
+   * Rate limit: 3 outstanding (non-consumed, non-expired) tokens per
+   * email per 15-minute window.
+   */
+  app.post("/magic-link/request", async (c) => {
+    let body: { email?: unknown; firstName?: unknown; lastName?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: { message: "Invalid JSON body.", type: "validation_error" } }, 400);
+    }
+    const email = typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+    if (!isValidEmail(email)) {
+      return c.json({ error: { message: "A valid email is required.", type: "validation_error" } }, 400);
+    }
+
+    const firstName = typeof body.firstName === "string" ? body.firstName.trim() : "";
+    const lastName = typeof body.lastName === "string" ? body.lastName.trim() : "";
+
+    const existingUser = await db.select().from(users).where(eq(users.email, email)).get();
+
+    // No user + no names → tell the client to collect names first.
+    if (!existingUser && (!firstName || !lastName)) {
+      return c.json({ status: "new_user" });
+    }
+
+    // Rate limit: recent outstanding tokens for this email.
+    const windowStart = new Date(Date.now() - MAGIC_LINK_TTL_MS);
+    const outstanding = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(magicLinkTokens)
+      .where(
+        and(
+          eq(magicLinkTokens.email, email),
+          gte(magicLinkTokens.createdAt, windowStart),
+          isNull(magicLinkTokens.consumedAt),
+        ),
+      )
+      .get();
+    if ((outstanding?.count ?? 0) >= MAGIC_LINK_MAX_OUTSTANDING) {
+      return c.json(
+        {
+          error: {
+            message: "Too many magic-link requests for this email. Try again in a few minutes.",
+            type: "rate_limited",
+          },
+        },
+        429,
+      );
+    }
+
+    // Generate token, hash, persist.
+    const plainToken = nanoid(32);
+    const tokenHash = hashMagicToken(plainToken);
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + MAGIC_LINK_TTL_MS);
+    await db.insert(magicLinkTokens).values({
+      id: nanoid(),
+      email,
+      tokenHash,
+      pendingFirstName: existingUser ? null : firstName,
+      pendingLastName: existingUser ? null : lastName,
+      createdAt: now,
+      expiresAt,
+    }).run();
+
+    // Send. Non-blocking failure logging — we still return 200 so the
+    // client shows a consistent "check your inbox" state; a delivery
+    // failure surfaces via the user not seeing the email.
+    try {
+      const verifyUrl = `${DASHBOARD_URL()}/auth/magic/verify?token=${encodeURIComponent(plainToken)}`;
+      const tmpl = magicLinkEmail({
+        verifyUrl,
+        email,
+        isNewUser: !existingUser,
+        expiresAt,
+      });
+      await sendEmail({
+        to: email,
+        subject: tmpl.subject,
+        html: tmpl.html,
+        text: tmpl.text,
+      });
+    } catch (err) {
+      console.warn("[auth] magic-link email send failed (non-blocking):", err);
+    }
+
+    return c.json({ status: "sent" });
+  });
+
+  /**
+   * Verify + consume a magic-link token. Routes to `/dashboard` on
+   * success with a session cookie set. On any validation failure the
+   * user is redirected back to `/login?error=<code>` so the reason
+   * surfaces in the login UI.
+   */
+  app.get("/magic/verify", async (c) => {
+    const plainToken = c.req.query("token");
+    if (!plainToken || typeof plainToken !== "string") {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=magic_link_invalid`);
+    }
+    const tokenHash = hashMagicToken(plainToken);
+
+    const row = await db
+      .select()
+      .from(magicLinkTokens)
+      .where(eq(magicLinkTokens.tokenHash, tokenHash))
+      .get();
+
+    if (!row) {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=magic_link_invalid`);
+    }
+    if (row.consumedAt) {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=magic_link_used`);
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=magic_link_expired`);
+    }
+
+    // Atomic consume: UPDATE ... WHERE consumed_at IS NULL so two
+    // simultaneous clicks can't both consume.
+    const claim = await db
+      .update(magicLinkTokens)
+      .set({ consumedAt: new Date() })
+      .where(and(eq(magicLinkTokens.id, row.id), isNull(magicLinkTokens.consumedAt)))
+      .run();
+    const affected = (claim as unknown as { rowsAffected?: number; changes?: number }).rowsAffected
+      ?? (claim as unknown as { changes?: number }).changes
+      ?? 0;
+    if (affected === 0) {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=magic_link_used`);
+    }
+
+    // Find or create the user.
+    const user = await upsertUserFromMagicLink(db, {
+      email: row.email,
+      pendingFirstName: row.pendingFirstName,
+      pendingLastName: row.pendingLastName,
+    });
+
+    const sessionId = await createSession(db, user.id);
+    setSessionCookie(c, sessionId);
+    return c.redirect(`${DASHBOARD_URL()}/dashboard`);
+  });
+
   return app;
+}
+
+const MAGIC_LINK_TTL_MS = 15 * 60 * 1000;
+const MAGIC_LINK_MAX_OUTSTANDING = 3;
+
+function hashMagicToken(plain: string): string {
+  return createHash("sha256").update(plain).digest("hex");
+}
+
+function isValidEmail(email: string): boolean {
+  // Deliberately permissive — we delegate real validation to whether
+  // the provider actually delivers. Block only the obviously-broken.
+  if (email.length < 3 || email.length > 254) return false;
+  const atIdx = email.indexOf("@");
+  return atIdx > 0 && atIdx < email.length - 1 && email.indexOf(" ") === -1;
+}
+
+/**
+ * Magic-link equivalent of `upsertUser`. Either returns the existing
+ * user row (email already in `users`) or inserts a fresh one using the
+ * pending names captured at request time. Mirrors the team-invite
+ * claim logic from `upsertUser` so a new signup via magic link lands
+ * in the inviter's tenant when applicable.
+ *
+ * Email is treated as verified because the user provably received and
+ * clicked the link — that's the whole point of the magic-link primitive.
+ */
+async function upsertUserFromMagicLink(
+  db: Db,
+  params: {
+    email: string;
+    pendingFirstName: string | null;
+    pendingLastName: string | null;
+  },
+) {
+  const existing = await db.select().from(users).where(eq(users.email, params.email)).get();
+  if (existing) return existing;
+
+  const firstName = params.pendingFirstName ?? "";
+  const lastName = params.pendingLastName ?? "";
+  const combinedName = [firstName, lastName].filter(Boolean).join(" ") || null;
+
+  const userId = nanoid();
+  let tenantId = nanoid(12);
+  let role: "owner" | "member" = "owner";
+  let claimedInviteToken: string | null = null;
+
+  const pending = await db
+    .select()
+    .from(teamInvites)
+    .where(
+      and(
+        sql`LOWER(${teamInvites.invitedEmail}) = ${params.email.toLowerCase()}`,
+        isNull(teamInvites.consumedAt),
+        gte(teamInvites.expiresAt, new Date()),
+      ),
+    )
+    .get();
+
+  if (pending) {
+    const claim = await db
+      .update(teamInvites)
+      .set({ consumedAt: new Date() })
+      .where(and(eq(teamInvites.token, pending.token), isNull(teamInvites.consumedAt)))
+      .run();
+    const affected = (claim as unknown as { rowsAffected?: number; changes?: number }).rowsAffected
+      ?? (claim as unknown as { changes?: number }).changes
+      ?? 0;
+    if (affected > 0) {
+      tenantId = pending.tenantId;
+      role = pending.invitedRole;
+      claimedInviteToken = pending.token;
+      console.log(
+        `[auth] magic-link invite claimed — token=${pending.token} email=${params.email} tenant=${pending.tenantId} role=${pending.invitedRole}`,
+      );
+    }
+  }
+
+  await db.insert(users).values({
+    id: userId,
+    email: params.email,
+    name: combinedName,
+    firstName: firstName || null,
+    lastName: lastName || null,
+    avatarUrl: null,
+    tenantId,
+    role,
+  }).run();
+
+  if (claimedInviteToken) {
+    await db
+      .update(teamInvites)
+      .set({ consumedByUserId: userId })
+      .where(eq(teamInvites.token, claimedInviteToken))
+      .run();
+  }
+
+  if (!claimedInviteToken) {
+    try {
+      const dashboardUrl = process.env.DASHBOARD_URL || "https://www.provara.xyz/dashboard";
+      const tmpl = welcomeEmail({ name: combinedName ?? params.email, dashboardUrl });
+      await sendEmail({
+        to: params.email,
+        subject: tmpl.subject,
+        html: tmpl.html,
+        text: tmpl.text,
+      });
+    } catch (err) {
+      console.warn("[auth] welcome email failed (non-blocking):", err);
+    }
+  }
+
+  return {
+    id: userId,
+    email: params.email,
+    name: combinedName,
+    firstName: firstName || null,
+    lastName: lastName || null,
+    avatarUrl: null,
+    tenantId,
+    role,
+    createdAt: new Date(),
+  };
 }
 
 /**

--- a/packages/gateway/tests/magic-link.test.ts
+++ b/packages/gateway/tests/magic-link.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import { createHash } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { magicLinkTokens, users, teamInvites, sessions } from "@provara/db";
+import type { Db } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import { createAuthRoutes } from "../src/routes/auth.js";
+
+/**
+ * #204 — magic-link signup/login tests.
+ *
+ * The routes live under `createAuthRoutes` which is mounted at `/auth`
+ * in the real app. Tests mount the same factory to a bare Hono app and
+ * drive it directly so we don't need to simulate the full admin/tenant
+ * middleware chain.
+ */
+
+function app(db: Db) {
+  const a = new Hono();
+  a.route("/auth", createAuthRoutes(db));
+  return a;
+}
+
+function hash(plain: string) {
+  return createHash("sha256").update(plain).digest("hex");
+}
+
+// Set before each test to a predictable value so the verify redirect is testable.
+const DASHBOARD = "http://test.local";
+
+describe("magic link request + verify (#204)", () => {
+  beforeEach(() => {
+    process.env.DASHBOARD_URL = DASHBOARD;
+    process.env.MODE = "multi_tenant";
+  });
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+    vi.restoreAllMocks();
+  });
+
+  async function seedUser(db: Db, email: string, tenantId = "t-1") {
+    await db.insert(users).values({
+      id: "u-" + email,
+      email,
+      name: "Ada Lovelace",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      tenantId,
+      role: "owner",
+      createdAt: new Date(),
+    }).run();
+  }
+
+  describe("POST /auth/magic-link/request", () => {
+    it("returns new_user when email is unknown and no names were provided", async () => {
+      const db = await makeTestDb();
+      const res = await app(db).request("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: "stranger@example.com" }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("new_user");
+      const tokens = await db.select().from(magicLinkTokens).all();
+      expect(tokens).toHaveLength(0);
+    });
+
+    it("issues a token and persists pending names for a new signup", async () => {
+      const db = await makeTestDb();
+      const res = await app(db).request("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: "new@example.com", firstName: "Ada", lastName: "Lovelace" }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("sent");
+
+      const rows = await db.select().from(magicLinkTokens).where(eq(magicLinkTokens.email, "new@example.com")).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].pendingFirstName).toBe("Ada");
+      expect(rows[0].pendingLastName).toBe("Lovelace");
+      expect(rows[0].consumedAt).toBeNull();
+    });
+
+    it("issues a token without pending names for an existing user", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "existing@example.com");
+      const res = await app(db).request("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: "existing@example.com" }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const rows = await db.select().from(magicLinkTokens).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].pendingFirstName).toBeNull();
+      expect(rows[0].pendingLastName).toBeNull();
+    });
+
+    it("rejects a 4th request in the 15-minute window for the same email", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "limit@example.com");
+      const r1 = await app(db).request("/auth/magic-link/request", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "limit@example.com" }),
+      });
+      const r2 = await app(db).request("/auth/magic-link/request", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "limit@example.com" }),
+      });
+      const r3 = await app(db).request("/auth/magic-link/request", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "limit@example.com" }),
+      });
+      const r4 = await app(db).request("/auth/magic-link/request", {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: "limit@example.com" }),
+      });
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(r3.status).toBe(200);
+      expect(r4.status).toBe(429);
+    });
+
+    it("rejects malformed email with 400", async () => {
+      const db = await makeTestDb();
+      const res = await app(db).request("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: "not-an-email" }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("normalizes email to lowercase for user lookup + token storage", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "case@example.com");
+      const res = await app(db).request("/auth/magic-link/request", {
+        method: "POST",
+        body: JSON.stringify({ email: "CASE@EXAMPLE.COM" }),
+        headers: { "content-type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("sent");
+      const rows = await db.select().from(magicLinkTokens).all();
+      expect(rows[0].email).toBe("case@example.com");
+    });
+  });
+
+  describe("GET /auth/magic/verify", () => {
+    async function seedToken(db: Db, params: {
+      plainToken?: string;
+      email: string;
+      pendingFirstName?: string | null;
+      pendingLastName?: string | null;
+      expiresAt?: Date;
+      consumedAt?: Date | null;
+    }) {
+      const plain = params.plainToken ?? "plain-token-abc";
+      const now = new Date();
+      await db.insert(magicLinkTokens).values({
+        id: "mlt-" + plain,
+        email: params.email,
+        tokenHash: hash(plain),
+        pendingFirstName: params.pendingFirstName ?? null,
+        pendingLastName: params.pendingLastName ?? null,
+        createdAt: now,
+        expiresAt: params.expiresAt ?? new Date(now.getTime() + 10 * 60 * 1000),
+        consumedAt: params.consumedAt ?? null,
+      }).run();
+      return plain;
+    }
+
+    it("logs an existing user in and consumes the token", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "known@example.com");
+      const plain = await seedToken(db, { email: "known@example.com" });
+
+      const res = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`${DASHBOARD}/dashboard`);
+      expect(res.headers.get("set-cookie")).toMatch(/provara_session=/);
+
+      const row = await db.select().from(magicLinkTokens).where(eq(magicLinkTokens.tokenHash, hash(plain))).get();
+      expect(row?.consumedAt).toBeTruthy();
+
+      const sessionRows = await db.select().from(sessions).all();
+      expect(sessionRows).toHaveLength(1);
+    });
+
+    it("creates a new user atomically using pending names", async () => {
+      const db = await makeTestDb();
+      const plain = await seedToken(db, {
+        email: "fresh@example.com",
+        pendingFirstName: "Grace",
+        pendingLastName: "Hopper",
+      });
+
+      const res = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`${DASHBOARD}/dashboard`);
+
+      const user = await db.select().from(users).where(eq(users.email, "fresh@example.com")).get();
+      expect(user).toBeDefined();
+      expect(user?.firstName).toBe("Grace");
+      expect(user?.lastName).toBe("Hopper");
+      expect(user?.name).toBe("Grace Hopper");
+      expect(user?.tenantId).toBeTruthy();
+      expect(user?.role).toBe("owner");
+    });
+
+    it("redirects to /login?error=magic_link_invalid for an unknown token", async () => {
+      const db = await makeTestDb();
+      const res = await app(db).request(`/auth/magic/verify?token=does-not-exist`);
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`${DASHBOARD}/login?error=magic_link_invalid`);
+    });
+
+    it("redirects with magic_link_expired for past-TTL tokens", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "a@example.com");
+      const plain = await seedToken(db, {
+        email: "a@example.com",
+        expiresAt: new Date(Date.now() - 1000),
+      });
+      const res = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(res.headers.get("location")).toBe(`${DASHBOARD}/login?error=magic_link_expired`);
+    });
+
+    it("redirects with magic_link_used when token was already consumed", async () => {
+      const db = await makeTestDb();
+      await seedUser(db, "b@example.com");
+      const plain = await seedToken(db, {
+        email: "b@example.com",
+        consumedAt: new Date(),
+      });
+      const res = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(res.headers.get("location")).toBe(`${DASHBOARD}/login?error=magic_link_used`);
+    });
+
+    it("a second click on a single-use token is rejected (no second session)", async () => {
+      const db = await makeTestDb();
+      const plain = await seedToken(db, {
+        email: "single@example.com",
+        pendingFirstName: "Sin",
+        pendingLastName: "Gle",
+      });
+      const r1 = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(r1.status).toBe(302);
+      expect(r1.headers.get("location")).toBe(`${DASHBOARD}/dashboard`);
+
+      const r2 = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(r2.headers.get("location")).toBe(`${DASHBOARD}/login?error=magic_link_used`);
+      const sessionRows = await db.select().from(sessions).all();
+      expect(sessionRows).toHaveLength(1); // only the first one stuck
+    });
+
+    it("claims a pending team invite when present", async () => {
+      const db = await makeTestDb();
+      // Seed the inviter + team invite.
+      await seedUser(db, "inviter@example.com", "tenant-inviter");
+      const inviteToken = "inv-token-xyz";
+      await db.insert(teamInvites).values({
+        token: inviteToken,
+        tenantId: "tenant-inviter",
+        invitedEmail: "invitee@example.com",
+        invitedRole: "member",
+        invitedByUserId: "u-inviter@example.com",
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        createdAt: new Date(),
+      }).run();
+
+      const plain = await seedToken(db, {
+        email: "invitee@example.com",
+        pendingFirstName: "Iona",
+        pendingLastName: "Vitee",
+      });
+      const res = await app(db).request(`/auth/magic/verify?token=${encodeURIComponent(plain)}`);
+      expect(res.status).toBe(302);
+
+      const user = await db.select().from(users).where(eq(users.email, "invitee@example.com")).get();
+      expect(user?.tenantId).toBe("tenant-inviter");
+      expect(user?.role).toBe("member");
+
+      const invite = await db.select().from(teamInvites).where(eq(teamInvites.token, inviteToken)).get();
+      expect(invite?.consumedAt).toBeTruthy();
+      expect(invite?.consumedByUserId).toBe(user?.id);
+    });
+  });
+});


### PR DESCRIPTION
Closes #204.

## Summary

Adds a third authentication path to `/login` — **Sign in with Magic Link** — alongside the existing Google and GitHub OAuth buttons. New users who don't match an existing email are routed through a `/signup` form for first + last name before the link is issued. Existing users (including OAuth-only accounts) are signed in as that user via the same flow.

## Flow

```
/login → email → POST /auth/magic-link/request
  ├─ existing user  → {status: "sent"}  → check-inbox UI
  ├─ new, no names  → {status: "new_user"} → redirect /signup?email=X
  └─ new + names    → {status: "sent"}  → check-inbox UI
                                        ↓
                       user clicks link in email
                                        ↓
                GET /auth/magic/verify?token=<plain>
                                        ↓
           ┌─ existing user: createSession + redirect /dashboard
           └─ new user: insert user+tenant (claim team invite if any),
              createSession, redirect /dashboard
```

## Schema (migration `0029`)

- `users` gains `first_name` + `last_name` columns. Existing OAuth rows backfilled by splitting `name` on first space (three rows in the production DB; spot-checkable).
- `magic_link_tokens` (new): `id`, `email`, `tokenHash` (SHA-256, **no plaintext at rest**), `pendingFirstName`/`LastName`, `createdAt`, `expiresAt`, `consumedAt`. Indexes on `email` and `tokenHash`.

Keeping the legacy `users.name` column for back-compat — server concatenates on insert.

## Invariants

- **15-minute TTL**, single-use via atomic `UPDATE ... WHERE consumed_at IS NULL` (same pattern #177 used for team invites).
- **Hash-at-rest** follows the `apiTokens` pattern, not the plaintext `teamInvites.token` pattern. Magic links are a direct auth primitive — a DB leak shouldn't hand out working links.
- **Rate limit**: max 3 outstanding (non-consumed, non-expired) tokens per email per 15-minute window.
- **Existing OAuth user + magic link with matching email** → logs them into that same row. Email is identity.
- **Enumeration tradeoff (accepted)**: the `new_user` vs `sent` branching on the request endpoint reveals registration status. Alternatives (generic response, delay padding) were rejected as UX-degrading. Flagged in the issue for revisit if abuse surfaces.

## Test plan

- [x] Typecheck clean (db, gateway, web).
- [x] `npm test -w packages/gateway`: **336 passed** (up from 323).
- [x] 13 new tests (`tests/magic-link.test.ts`): new_user response, existing-user sent, rate-limit enforcement (4th rejected), malformed email, email lowercasing, verify happy paths (new + existing), invalid/expired/consumed token redirects, second-click rejected, team-invite claim on new signup.
- [x] `npx next build -w apps/web` — `/signup` renders statically.
- [ ] Visual QA deferred — your call post-merge per session cadence. Five things to eyeball:
  1. `/login` shows Google, GitHub, — or —, email input, magic link button.
  2. Submit unknown email → lands on `/signup?email=…` with email echoed.
  3. Submit known email → check-inbox confirmation in place of form.
  4. Click magic link (with `RESEND_API_KEY` set) → lands on `/dashboard`.
  5. Click a stale link → `/login?error=magic_link_expired` surfaces the error banner.

## Out of scope (per issue)

- Profile image collection (punted).
- IP-based rate limiting (email-based is enough for v1).
- Dropping legacy `users.name` column.

Last-code-by: opus-4-7 (claude-code)
