### PR TITLE
fix: magic-link email URL points to gateway, not web app

### DIFF
--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -27,6 +27,11 @@ import { sendEmail } from "../email/index.js";
 import { welcomeEmail, magicLinkEmail } from "../email/templates.js";
 
 const DASHBOARD_URL = () => process.env.DASHBOARD_URL || "http://localhost:3000";
+// The gateway's own public URL (same value OAuth callbacks are registered
+// at). Used by any flow that needs to generate a URL pointing back at
+// the gateway — e.g. the magic-link email (#204). Distinct from
+// DASHBOARD_URL, which is the web app.
+const GATEWAY_PUBLIC_URL = () => process.env.OAUTH_REDIRECT_BASE || "http://localhost:4000";
 const STATE_COOKIE = "provara_oauth_state";
 const RETURN_COOKIE = "provara_oauth_return";
 
@@ -255,7 +260,11 @@ export function createAuthRoutes(db: Db) {
     // client shows a consistent "check your inbox" state; a delivery
     // failure surfaces via the user not seeing the email.
     try {
-      const verifyUrl = `${DASHBOARD_URL()}/auth/magic/verify?token=${encodeURIComponent(plainToken)}`;
+      // The verify URL points to the GATEWAY, not the web app: the
+      // endpoint is owned by the gateway, which sets the session cookie
+      // on its own origin (matches OAuth callback behavior — see #204
+      // post-merge 404 from hitting www.provara.xyz/auth/magic/verify).
+      const verifyUrl = `${GATEWAY_PUBLIC_URL()}/auth/magic/verify?token=${encodeURIComponent(plainToken)}`;
       const tmpl = magicLinkEmail({
         verifyUrl,
         email,


### PR DESCRIPTION
## Summary

The verify URL in the magic-link email was built against `DASHBOARD_URL` (www.provara.xyz). The handler lives on the gateway, so production sends a 404. Real bug report: https://www.provara.xyz/auth/magic/verify?token=e-ZLM34WAd17oWtDCNLG2yOiUx2fiHo8.

Matches the OAuth callback pattern — the gateway owns the redirect target so it can set the session cookie on its own origin before redirecting to `/dashboard`.

## Change

- New `GATEWAY_PUBLIC_URL()` helper reads `OAUTH_REDIRECT_BASE` (the env var prod already sets for OAuth). One additional use site; nothing else changes.
- Every other redirect to the web app (login error pages, `/dashboard`) still uses `DASHBOARD_URL`.

## Workaround for a link already in an inbox

Swap the host from `www.provara.xyz` to the gateway host (e.g. `gateway.provara.xyz`) and click again — the token is still valid until its 15-minute TTL expires.

## Test plan

- [x] Typecheck clean.
- [x] Existing magic-link tests still pass (the email URL shape isn't asserted in tests — URL generation happens inside a try/catch that's a no-op under test without `RESEND_API_KEY`).
- [ ] Post-merge: send yourself a magic link, verify the email contains `gateway.provara.xyz/auth/magic/verify?token=...` and clicks through cleanly.

Last-code-by: opus-4-7 (claude-code)