### PR TITLE
fix: prevent double-subscribe for tenants with an active plan

### DIFF
--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -299,6 +299,12 @@ function BillingPageInner() {
               const lookupKey = annual ? plan.annualLookupKey : plan.monthlyLookupKey;
               const price = annual ? plan.priceAnnual : plan.priceMonthly;
               const suffix = annual ? "/yr" : "/mo";
+              // Plan changes for tenants already on a paid tier go through
+              // the Stripe Portal — a second Checkout would create a second
+              // subscription on the same customer, which the backend now
+              // refuses with 409 anyway.
+              const isPlanChange = currentTierRank > TIER_ORDER.free;
+              const busyKey = isPlanChange ? "portal" : lookupKey;
               return (
                 <div key={plan.tier} className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
                   <div className="flex items-center gap-2">
@@ -319,11 +325,17 @@ function BillingPageInner() {
                     ))}
                   </ul>
                   <button
-                    onClick={() => startCheckout(lookupKey)}
+                    onClick={() => (isPlanChange ? openPortal() : startCheckout(lookupKey))}
                     disabled={busy !== null}
                     className="mt-5 w-full px-3 py-2 rounded text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white disabled:opacity-50"
                   >
-                    {busy === lookupKey ? "Starting checkout…" : `Upgrade to ${plan.label}`}
+                    {busy === busyKey
+                      ? isPlanChange
+                        ? "Opening portal…"
+                        : "Starting checkout…"
+                      : isPlanChange
+                        ? `Change plan in portal`
+                        : `Upgrade to ${plan.label}`}
                   </button>
                 </div>
               );

--- a/packages/gateway/src/routes/billing.ts
+++ b/packages/gateway/src/routes/billing.ts
@@ -31,6 +31,8 @@ function quotaForTier(tier: string): number {
   return TIER_QUOTAS[tier] ?? Number.MAX_SAFE_INTEGER;
 }
 
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set(["active", "trialing", "past_due"]);
+
 export function createBillingRoutes(db: Db) {
   const app = new Hono();
 
@@ -194,6 +196,26 @@ export function createBillingRoutes(db: Db) {
       return c.json({ error: { message: "Authentication required.", type: "auth_error" } }, 401);
     }
 
+    // Refuse a second Checkout when the tenant is already on a paid,
+    // active(-ish) plan. Our schema allows one subscription per tenant
+    // (unique index on subscriptions.tenant_id and .stripe_customer_id);
+    // a second Stripe sub would bill the customer twice and crash the
+    // webhook upsert on UNIQUE collision. Plan changes (Pro → Team, etc.)
+    // go through the Stripe Portal, not a fresh Checkout.
+    const existingSub = await getSubscriptionForTenant(db, tenantId);
+    if (existingSub && ACTIVE_SUBSCRIPTION_STATUSES.has(existingSub.status)) {
+      return c.json(
+        {
+          error: {
+            message:
+              "You already have an active subscription. Use the billing portal to change your plan.",
+            type: "already_subscribed",
+          },
+        },
+        409,
+      );
+    }
+
     const body = await c.req
       .json<{ priceLookupKey?: string }>()
       .catch(() => ({} as { priceLookupKey?: string }));
@@ -211,12 +233,10 @@ export function createBillingRoutes(db: Db) {
       );
     }
 
-    // Re-use the existing Stripe customer if the tenant already has a
-    // subscription, otherwise Checkout creates a fresh one. Either way
-    // the subscription's `metadata.tenantId` (set below) is what the
-    // webhook uses to link it back.
-    const existingSub = await getSubscriptionForTenant(db, tenantId);
-
+    // Re-use the existing Stripe customer if the tenant has a dormant
+    // (canceled/incomplete_expired) subscription row, otherwise Checkout
+    // creates a fresh one. Either way the subscription's `metadata.tenantId`
+    // (set below) is what the webhook uses to link it back.
     const dashboardOrigin = c.req.header("origin") || "https://www.provara.xyz";
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",

--- a/packages/gateway/tests/billing.test.ts
+++ b/packages/gateway/tests/billing.test.ts
@@ -16,6 +16,7 @@ vi.mock("../src/auth/tenant.js", async (importOriginal) => {
 });
 
 import { createBillingRoutes } from "../src/routes/billing.js";
+import { __resetStripeForTests } from "../src/stripe/index.js";
 
 function buildApp(db: Db) {
   const app = new Hono();
@@ -196,5 +197,30 @@ describe("/v1/billing/checkout-session", () => {
     // 503 bails before auth check because Stripe is unconfigured — both
     // are acceptable; pin whichever we actually return.
     expect([401, 503]).toContain(res.status);
+  });
+
+  it("returns 409 when the tenant already has an active subscription", async () => {
+    // Make getStripe() non-null so the 503 guard doesn't short-circuit.
+    // A bogus key is fine because the guard runs before any real Stripe
+    // API call (which would fail).
+    process.env.STRIPE_SECRET_KEY = "sk_test_dummy_for_unit_test";
+    __resetStripeForTests();
+    try {
+      await seedTenantWithUser(db, "tenant-active");
+      await grantIntelligenceAccess(db, "tenant-active", { tier: "pro" });
+
+      const app = buildApp(db);
+      const res = await app.request("/v1/billing/checkout-session", {
+        method: "POST",
+        headers: { "x-test-tenant": "tenant-active", "content-type": "application/json" },
+        body: JSON.stringify({ priceLookupKey: "cloud_team_monthly" }),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error.type).toBe("already_subscribed");
+    } finally {
+      delete process.env.STRIPE_SECRET_KEY;
+      __resetStripeForTests();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `/v1/billing/checkout-session` returns **409 `already_subscribed`** when the tenant already has an active/trialing/past_due subscription. Prevents a second Stripe sub on the same customer, which would double-bill AND crash the webhook upsert on the `tenant_id` / `stripe_customer_id` UNIQUE indexes.
- `/dashboard/billing` upgrade cards now route to the Stripe Portal (`Change plan in portal`) when the tenant is on a paid tier. Free→Pro still uses Checkout — Checkout is only for the first subscription.

## Why
Hit this live in sandbox: a Pro tenant with `tier=free` in the DB (separate metadata bug, fixed out-of-band) saw a Pro upgrade card, clicked it, and ended up with two active Pro subscriptions on one customer. The webhook for the second sub failed with `SQLITE_CONSTRAINT: UNIQUE constraint failed: subscriptions.stripe_customer_id` — so Stripe was billing a sub Provara never recorded.

The backend 409 is the authoritative fix (closes the data-corruption hole even from stale tabs or direct API hits). The dashboard change removes the footgun from the happy path.

## Test plan
- [x] `npx vitest run tests/billing.test.ts` — 11/11 pass (1 new test covering 409 `already_subscribed`)
- [x] `tsc --noEmit` clean on both `@provara/gateway` and `@provara/web`
- [ ] Visual QA on dashboard: as a Free tenant, "Upgrade to Pro" still opens Checkout; as a Pro tenant, the Team card button reads "Change plan in portal" and opens the Stripe Portal
- [ ] Curl check: `POST /v1/billing/checkout-session` as a Pro tenant returns 409 `already_subscribed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)