### PR TITLE
fix: bump gateway vitest testTimeout to 30s

### DIFF
--- a/packages/gateway/vitest.config.ts
+++ b/packages/gateway/vitest.config.ts
@@ -7,5 +7,11 @@ export default defineConfig({
     environment: "node",
     pool: "forks", // each test file gets its own process — isolates the judge-config module-level state
     reporters: process.env.CI ? ["dot"] : ["default"],
+    // 30s per test. Some tests in usage-metering.test.ts seed 100k+
+    // request rows via batched inserts; on slower CI runners the 5s
+    // default timed out during the seeding phase even though the test
+    // logic itself was fine. Bumping the default is simpler (and
+    // consistent) than decorating each heavy test with a per-call override.
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary

Bumps the gateway vitest per-test timeout from the 5s default to 30s. Fixes the reproducible CI failures on \`tests/usage-metering.test.ts\` — 3 tests that seed 100k+ request rows have been timing out on every master CI run for the last 6+ merges.

## Why

Locally the heavy-seed tests run in ~3s each, but CI runners are slower and reliably cross 5s during the bulk-insert seeding phase. The test logic itself is correct; the default just never fit this suite's data shape. Decorating each heavy \`it()\` individually would work but the problem is systemic enough for the suite — the bump keeps the config small.

## Test plan

- [x] \`npx vitest run tests/usage-metering.test.ts\` — 23/23 in ~21s locally
- [ ] CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)