### PR TITLE
fix: SAML ACS + metadata tier-gate uses URL-path tenant, not session

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -38,6 +38,10 @@ function errorMessage(code: string | null): string | null {
       return "Your identity provider didn't return an email address. Contact your admin.";
     case "sso_email_on_other_tenant":
       return "That email is already registered to another Provara workspace. Contact your admin to resolve this.";
+    case "sso_tier_revoked":
+      return "SSO is not available for this workspace. Contact your admin — an Enterprise subscription is required.";
+    case "sso_missing_tenant":
+      return "SSO sign-in URL was malformed. Contact your admin.";
     case null:
       return null;
     default:

--- a/packages/gateway/src/auth/tier.ts
+++ b/packages/gateway/src/auth/tier.ts
@@ -275,6 +275,29 @@ export function requireEnterpriseTier(db: Db) {
 }
 
 /**
+ * Non-middleware variant of `requireEnterpriseTier` for callers that
+ * already know the tenantId (most importantly the SAML ACS handler,
+ * where the caller is mid-login and has no session to derive a tenant
+ * from — the tenant comes from the URL path).
+ *
+ * Returns true when the tenant is on Enterprise tier, or is an operator
+ * tenant, or the deployment isn't a Cloud deployment (self-host always
+ * passes — Enterprise-only features are enabled by the deployer).
+ */
+export async function tenantHasEnterpriseAccess(
+  db: Db,
+  tenantId: string | null | undefined,
+): Promise<boolean> {
+  if (!tenantId) return false;
+  if (await isOperatorTenant(db, tenantId)) return true;
+  if (!isCloudDeployment()) return true;
+  const sub = await getSubscriptionForTenant(db, tenantId);
+  if (!sub) return false;
+  if (!ACTIVE_STATUSES.has(sub.status)) return false;
+  return sub.tier === "enterprise" || sub.tier === "selfhost_enterprise";
+}
+
+/**
  * Non-middleware variant for server-side callers (scheduler cycles) that
  * need to decide per-tenant whether to process. Mirrors the middleware
  * logic exactly so the gates are consistent, including the operator

--- a/packages/gateway/src/routes/auth-saml.ts
+++ b/packages/gateway/src/routes/auth-saml.ts
@@ -13,7 +13,7 @@ import {
   validatePostResponse,
 } from "../auth/saml.js";
 import { createSession, setSessionCookie } from "../auth/session.js";
-import { requireEnterpriseTier } from "../auth/tier.js";
+import { tenantHasEnterpriseAccess } from "../auth/tier.js";
 
 /**
  * SAML SSO routes (#209). Mounted at `/auth/saml`. Per-tenant flow:
@@ -82,10 +82,20 @@ export function createSamlAuthRoutes(db: Db) {
    * tenant). Validates the response, JIT-provisions, issues a session,
    * redirects to the dashboard.
    */
-  app.post("/acs/:tenantId", requireEnterpriseTier(db), async (c) => {
+  app.post("/acs/:tenantId", async (c) => {
     const tenantId = c.req.param("tenantId");
     if (!tenantId) {
       return c.redirect(`${DASHBOARD_URL()}/login?error=sso_missing_tenant`);
+    }
+
+    // Tier gate uses the URL-path tenantId, NOT the caller's session —
+    // the caller is mid-login and has no session yet. This is the whole
+    // point of ACS. Check the tenant that owns the config row; refuse
+    // if they're not on Enterprise (defense in depth — ops shouldn't
+    // have seeded sso_configs for a non-Enterprise tenant, but if they
+    // did, we don't want the free account to be a back-door SSO bypass).
+    if (!(await tenantHasEnterpriseAccess(db, tenantId))) {
+      return c.redirect(`${DASHBOARD_URL()}/login?error=sso_tier_revoked`);
     }
 
     const form = await c.req.parseBody();
@@ -139,9 +149,14 @@ export function createSamlAuthRoutes(db: Db) {
    * tenant downgrades, metadata stops serving (also stops the IdP from
    * successfully POSTing to ACS since ACS is gated identically).
    */
-  app.get("/metadata/:tenantId", requireEnterpriseTier(db), async (c) => {
+  app.get("/metadata/:tenantId", async (c) => {
     const tenantId = c.req.param("tenantId");
     if (!tenantId) {
+      return c.json({ error: { message: "SSO not configured.", type: "not_configured" } }, 404);
+    }
+    // Tier gate on the URL-path tenant, same reasoning as ACS: the IdP
+    // fetches this endpoint without a Provara session.
+    if (!(await tenantHasEnterpriseAccess(db, tenantId))) {
       return c.json({ error: { message: "SSO not configured.", type: "not_configured" } }, 404);
     }
     const xml = await buildMetadataXml(db, tenantId, GATEWAY_PUBLIC_URL());

--- a/packages/gateway/tests/saml-routes.test.ts
+++ b/packages/gateway/tests/saml-routes.test.ts
@@ -109,34 +109,76 @@ describe("GET /auth/saml/metadata/:tenantId", () => {
   });
   afterEach(() => resetTierEnv());
 
-  it("returns SP metadata XML for a Enterprise tenant with SSO configured", async () => {
+  it("returns SP metadata XML for an Enterprise tenant with SSO configured", async () => {
+    // Tier gate now reads the URL-path tenantId, so no mocked tenant
+    // header is needed — the IdP will POST to this URL without any
+    // Provara session. This is the whole point of the fix.
     await seedSso(db, "tenant-ent");
     await grantIntelligenceAccess(db, "tenant-ent", { tier: "enterprise" });
     const app = buildApp(db);
-    const res = await app.request("/auth/saml/metadata/tenant-ent", {
-      headers: { "x-test-tenant": "tenant-ent" },
-    });
-    // NB: the tier gate pulls tenantId from getTenantId which respects the
-    // mocked header (see the vi.mock in saml.test.ts patterns). If that
-    // mock isn't in scope for this file we accept 401 too — the metadata
-    // endpoint requires it for the gate.
-    expect([200, 401]).toContain(res.status);
-    if (res.status === 200) {
-      expect(res.headers.get("content-type")).toContain("samlmetadata+xml");
-      const xml = await res.text();
-      expect(xml).toContain("tenant-ent");
-    }
+    const res = await app.request("/auth/saml/metadata/tenant-ent");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("samlmetadata+xml");
+    const xml = await res.text();
+    expect(xml).toContain("tenant-ent");
   });
 
-  it("returns 402 for a non-Enterprise tenant", async () => {
+  it("returns 404 when the URL-path tenant is not on Enterprise", async () => {
     await seedSso(db, "tenant-pro");
     await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
-    // We can't hit the tier check without the tenant mock; just confirm
-    // the route refuses when tenant resolution fails (401) or the tier
-    // gate catches it (402). Either way, no metadata is served.
     const app = buildApp(db);
     const res = await app.request("/auth/saml/metadata/tenant-pro");
-    expect([401, 402]).toContain(res.status);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.type).toBe("not_configured");
+  });
+
+  it("returns 404 when SSO is not configured at all", async () => {
+    await grantIntelligenceAccess(db, "tenant-ent", { tier: "enterprise" });
+    const app = buildApp(db);
+    const res = await app.request("/auth/saml/metadata/tenant-ent");
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /auth/saml/acs/:tenantId (tier gate)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+    resetTierEnv();
+  });
+  afterEach(() => resetTierEnv());
+
+  it("redirects to /login?error=sso_tier_revoked when the URL-path tenant is not Enterprise", async () => {
+    await seedSso(db, "tenant-pro");
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const form = new URLSearchParams({ SAMLResponse: "anything" });
+    const res = await app.request("/auth/saml/acs/tenant-pro", {
+      method: "POST",
+      body: form.toString(),
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("error=sso_tier_revoked");
+  });
+
+  it("does NOT require a Provara session (unauthenticated IdP POST is the whole flow)", async () => {
+    // With the bug: the middleware would 401 here because no session →
+    // no getTenantId. With the fix: the URL-path tenant is what gates.
+    // The forged SAMLResponse will fail validation after the gate passes,
+    // so expect redirect to an sso_invalid_response error, not a 401.
+    await seedSso(db, "tenant-ent");
+    await grantIntelligenceAccess(db, "tenant-ent", { tier: "enterprise" });
+    const app = buildApp(db);
+    const form = new URLSearchParams({ SAMLResponse: "forged-not-a-real-response" });
+    const res = await app.request("/auth/saml/acs/tenant-ent", {
+      method: "POST",
+      body: form.toString(),
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toContain("error=sso_invalid_response");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a blocker hit during live UAT: POST /auth/saml/acs/:tenantId returned 401 \`auth_error\` because the tier-gate middleware tried to derive tenant from the caller's session — but the caller is mid-login and has no session. ACS is where sessions get CREATED; it can't require one to run.

## What changed

- `tenantHasEnterpriseAccess(db, tenantId)` — new non-middleware tier helper that takes an explicit tenantId. Mirrors operator bypass + self-host-passes semantics.
- ACS and metadata routes drop the \`requireEnterpriseTier\` middleware and check the URL-path tenant inline. ACS 302s to \`/login?error=sso_tier_revoked\`; metadata 404s with \`not_configured\`.
- Login error dictionary gets \`sso_tier_revoked\` and \`sso_missing_tenant\`.
- 3 new tests cover the new gating path.

## Test plan

- [x] \`npx vitest run tests/saml-routes.test.ts tests/saml.test.ts tests/tier-gate.test.ts\` — 64/64 pass
- [x] tsc --noEmit clean
- [ ] Post-merge UAT: retry the Google Workspace SSO flow — should now reach ACS and validate the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)