### PR TITLE
fix: disable SAML InResponseTo cache check for UAT unblock

### DIFF
--- a/packages/gateway/src/auth/saml.ts
+++ b/packages/gateway/src/auth/saml.ts
@@ -152,9 +152,23 @@ export function makeSamlClient(
     // Response signing is optional in the SAML 2.0 spec; most IdPs do
     // it anyway. Require it.
     wantAuthnResponseSigned: true,
-    // SP-initiated flows must replay-check via InResponseTo; IdP-initiated
-    // flows don't send InResponseTo, so "ifPresent" accepts both.
-    validateInResponseTo: ValidateInResponseTo.ifPresent,
+    // "never" is a pragmatic choice until we land a DB-backed replay
+    // cache. node-saml's default cache is per-SAML-instance and in-memory;
+    // our route handlers build a new SAML instance per request, so the
+    // AuthnRequest ID issued in /start is never visible to the /acs
+    // handler, causing every valid SP-initiated response to be rejected
+    // with "InResponseTo is not valid".
+    //
+    // Signature, timestamp (NotBefore / NotOnOrAfter), audience, and
+    // destination validation all still fire, so forged responses are
+    // still refused. The narrowed surface is replay of a valid captured
+    // response within its assertion lifetime (typically 5 minutes).
+    //
+    // Follow-up: replace the in-memory CacheProvider with a libSQL-
+    // backed one that persists AuthnRequest IDs across replicas and
+    // expires them at assertion lifetime. Then flip this back to
+    // `ValidateInResponseTo.ifPresent`.
+    validateInResponseTo: ValidateInResponseTo.never,
     // EmailAddress is the universally-supported NameID format; some IdPs
     // (notably Entra by default) emit it as the unspecified format, so
     // leaving this `null` lets the library accept whatever the IdP sends.


### PR DESCRIPTION
## Summary

Unblocks Google SSO UAT. node-saml's default InResponseTo replay cache is per-SAML-instance in memory; our routes build a fresh instance each request so every SP-initiated response fails with \`InResponseTo is not valid\`. Flipping to \`ValidateInResponseTo.never\` until we ship a DB-backed CacheProvider.

Signature, timestamp, audience, and destination validation all still enforce — forged responses continue to be refused. The weakened surface is capture-and-replay within the assertion's ~5-minute lifetime.

## Follow-up

TODO: ship a libSQL-backed CacheProvider (new \`saml_in_response_to\` table with TTL cleanup), flip back to \`ifPresent\`.

## Test plan

- [x] Tests green (35/35 on saml + saml-routes)
- [x] tsc clean
- [ ] Post-merge UAT: Google SSO login should now reach the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)