### PR TITLE
fix: accept assertion-only SAML signing for Google Workspace

### DIFF
--- a/packages/gateway/src/auth/saml.ts
+++ b/packages/gateway/src/auth/saml.ts
@@ -149,9 +149,14 @@ export function makeSamlClient(
     // mean anyone who can reach the ACS can impersonate anyone — that's
     // how the samlify CVE worked.
     wantAssertionsSigned: true,
-    // Response signing is optional in the SAML 2.0 spec; most IdPs do
-    // it anyway. Require it.
-    wantAuthnResponseSigned: true,
+    // Response signing is optional in the SAML 2.0 spec, and several
+    // common IdPs (Google Workspace by default, some Okta configs) only
+    // sign the inner assertion. Accept assertion-only signing — the
+    // assertion signature still proves authenticity of the identity
+    // claim, which is the thing that matters for authentication. An
+    // unsigned response envelope can't meaningfully mislead us when the
+    // signed assertion inside is the load-bearing artifact.
+    wantAuthnResponseSigned: false,
     // "never" is a pragmatic choice until we land a DB-backed replay
     // cache. node-saml's default cache is per-SAML-instance and in-memory;
     // our route handlers build a new SAML instance per request, so the


### PR DESCRIPTION
## Summary

Google Workspace signs the SAML <Assertion> but not the outer <Response> by default. Our config required both via \`wantAuthnResponseSigned: true\`, which produced "Invalid document signature" on every UAT attempt. Spec-wise, response signing is optional; the signed assertion is the load-bearing artifact. Flipping to \`wantAuthnResponseSigned: false\`.

Stacked on top of #214 (InResponseTo fix).

## Test plan

- [x] 35/35 SAML tests pass
- [ ] Post-merge: Google SSO UAT should reach /dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)