### PR TITLE
feat(#209): IdP metadata XML import in the SSO seed CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14252,12 +14252,14 @@
         "@hono/node-server": "^1.14.0",
         "@node-saml/node-saml": "^5.1.0",
         "@provara/db": "*",
+        "@types/xml2js": "^0.4.14",
         "dotenv": "^17.4.2",
         "hono": "^4.7.0",
         "nanoid": "^5.1.0",
         "openai": "^4.85.0",
         "resend": "^6.12.0",
-        "stripe": "^22.0.2"
+        "stripe": "^22.0.2",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "tsup": "^8.5.1",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -16,12 +16,14 @@
     "@hono/node-server": "^1.14.0",
     "@node-saml/node-saml": "^5.1.0",
     "@provara/db": "*",
+    "@types/xml2js": "^0.4.14",
     "dotenv": "^17.4.2",
     "hono": "^4.7.0",
     "nanoid": "^5.1.0",
     "openai": "^4.85.0",
     "resend": "^6.12.0",
-    "stripe": "^22.0.2"
+    "stripe": "^22.0.2",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/gateway/scripts/seed-sso-config.ts
+++ b/packages/gateway/scripts/seed-sso-config.ts
@@ -2,16 +2,26 @@
 /**
  * Operator CLI: seed (or update) a tenant's SAML SSO config (#209).
  *
- * Usage:
- *   tsx packages/gateway/scripts/seed-sso-config.ts \
- *     --tenant-id acme-tenant-xyz \
- *     --idp-entity-id "https://sts.windows.net/abc-123/" \
- *     --idp-sso-url "https://login.microsoftonline.com/abc-123/saml2" \
- *     --idp-cert-file ./acme-idp-cert.pem \
- *     --email-domains "acme.com,acme.co.uk" \
- *     [--gateway-base-url "https://gateway.provara.xyz"] \
- *     [--sp-entity-id "https://custom/entity-id"] \
- *     [--require-encryption]
+ * Two ways to provide IdP details:
+ *
+ *   (A) Metadata XML (recommended):
+ *     tsx packages/gateway/scripts/seed-sso-config.ts \
+ *       --tenant-id acme-tenant-xyz \
+ *       --idp-metadata-file ./google-idp-metadata.xml \
+ *       --email-domains "acme.com,acme.co.uk"
+ *
+ *   (B) Individual values (for edge cases or override):
+ *     tsx packages/gateway/scripts/seed-sso-config.ts \
+ *       --tenant-id acme-tenant-xyz \
+ *       --idp-entity-id "https://sts.windows.net/abc-123/" \
+ *       --idp-sso-url "https://login.microsoftonline.com/abc-123/saml2" \
+ *       --idp-cert-file ./acme-idp-cert.pem \
+ *       --email-domains "acme.com,acme.co.uk"
+ *
+ * Optional flags (both modes):
+ *   --gateway-base-url "https://gateway.provara.xyz"
+ *   --sp-entity-id     "https://custom/entity-id"
+ *   --require-encryption
  *
  * Environment:
  *   DATABASE_URL         libSQL/Turso URL (required — points at prod DB)
@@ -26,12 +36,14 @@ import { resolve as resolvePath } from "node:path";
 import { createDb, ssoConfigs } from "@provara/db";
 import { eq } from "drizzle-orm";
 import { acsUrlFor, defaultSpEntityIdFor } from "../src/auth/saml.js";
+import { parseIdpMetadataXml } from "../src/auth/saml-metadata.js";
 
 interface Args {
   tenantId: string;
-  idpEntityId: string;
-  idpSsoUrl: string;
-  idpCertFile: string;
+  idpMetadataFile?: string;
+  idpEntityId?: string;
+  idpSsoUrl?: string;
+  idpCertFile?: string;
   emailDomains: string;
   gatewayBaseUrl?: string;
   spEntityId?: string;
@@ -42,10 +54,17 @@ const HELP = `seed-sso-config: create or update a tenant's SAML SSO config
 
 Required flags:
   --tenant-id <id>            The Provara tenant ID
-  --idp-entity-id <url>       The IdP's Entity ID / Issuer
-  --idp-sso-url <url>         The IdP's SAML SSO endpoint
-  --idp-cert-file <path>      Path to the IdP's X.509 signing cert (PEM)
   --email-domains <csv>       Comma-separated email domains to route (e.g. "acme.com,acme.co.uk")
+
+One of (A) or (B) is required:
+
+  (A) Metadata XML (recommended — avoids copy-paste errors):
+    --idp-metadata-file <path>   Path to the IdP's metadata XML export
+
+  (B) Individual values:
+    --idp-entity-id <url>        The IdP's Entity ID / Issuer
+    --idp-sso-url <url>          The IdP's SAML SSO endpoint
+    --idp-cert-file <path>       Path to the IdP's X.509 signing cert (PEM)
 
 Optional flags:
   --gateway-base-url <url>    Public gateway origin (default: https://gateway.provara.xyz)
@@ -86,23 +105,85 @@ function parseArgs(argv: string[]): Args {
     process.exit(0);
   }
 
-  const required = ["tenant-id", "idp-entity-id", "idp-sso-url", "idp-cert-file", "email-domains"];
-  const missing = required.filter((k) => !args[k]);
-  if (missing.length > 0) {
-    console.error(`Missing required flags: ${missing.map((k) => "--" + k).join(", ")}`);
-    console.error(`Run with --help for usage.`);
+  if (!args["tenant-id"]) {
+    console.error("Missing required flag: --tenant-id");
+    console.error("Run with --help for usage.");
+    process.exit(2);
+  }
+  if (!args["email-domains"]) {
+    console.error("Missing required flag: --email-domains");
+    console.error("Run with --help for usage.");
+    process.exit(2);
+  }
+
+  const hasMetadata = Boolean(args["idp-metadata-file"]);
+  const hasIndividual =
+    Boolean(args["idp-entity-id"]) && Boolean(args["idp-sso-url"]) && Boolean(args["idp-cert-file"]);
+  if (!hasMetadata && !hasIndividual) {
+    console.error(
+      "Provide either --idp-metadata-file, or all three of --idp-entity-id + --idp-sso-url + --idp-cert-file.",
+    );
+    console.error("Run with --help for usage.");
+    process.exit(2);
+  }
+  if (hasMetadata && hasIndividual) {
+    console.error("Provide either --idp-metadata-file OR the individual flags, not both.");
     process.exit(2);
   }
 
   return {
     tenantId: String(args["tenant-id"]),
-    idpEntityId: String(args["idp-entity-id"]),
-    idpSsoUrl: String(args["idp-sso-url"]),
-    idpCertFile: String(args["idp-cert-file"]),
+    idpMetadataFile: args["idp-metadata-file"] ? String(args["idp-metadata-file"]) : undefined,
+    idpEntityId: args["idp-entity-id"] ? String(args["idp-entity-id"]) : undefined,
+    idpSsoUrl: args["idp-sso-url"] ? String(args["idp-sso-url"]) : undefined,
+    idpCertFile: args["idp-cert-file"] ? String(args["idp-cert-file"]) : undefined,
     emailDomains: String(args["email-domains"]),
     gatewayBaseUrl: args["gateway-base-url"] ? String(args["gateway-base-url"]) : undefined,
     spEntityId: args["sp-entity-id"] ? String(args["sp-entity-id"]) : undefined,
     requireEncryption: Boolean(args["require-encryption"]),
+  };
+}
+
+/**
+ * Produce the three IdP-sourced fields regardless of which input mode
+ * the operator chose. Metadata XML path parses once and stops; the
+ * individual-flag path reads the cert file and trusts the caller's URLs.
+ */
+async function resolveIdpFields(args: Args): Promise<{ entityId: string; ssoUrl: string; cert: string }> {
+  if (args.idpMetadataFile) {
+    const path = resolvePath(args.idpMetadataFile);
+    let xml: string;
+    try {
+      xml = readFileSync(path, "utf8");
+    } catch (err) {
+      console.error(`Could not read IdP metadata at ${path}: ${(err as Error).message}`);
+      process.exit(2);
+    }
+    try {
+      return await parseIdpMetadataXml(xml);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(2);
+    }
+  }
+  // Individual-flag mode — the parseArgs gate above has already verified
+  // all three are present, so this branch is safe to narrow.
+  const certPath = resolvePath(args.idpCertFile!);
+  let cert: string;
+  try {
+    cert = readFileSync(certPath, "utf8");
+  } catch (err) {
+    console.error(`Could not read IdP cert at ${certPath}: ${(err as Error).message}`);
+    process.exit(2);
+  }
+  if (!cert.includes("BEGIN CERTIFICATE")) {
+    console.error(`Cert at ${certPath} does not look like a PEM X.509 certificate.`);
+    process.exit(2);
+  }
+  return {
+    entityId: args.idpEntityId!,
+    ssoUrl: args.idpSsoUrl!,
+    cert,
   };
 }
 
@@ -117,18 +198,7 @@ async function main() {
   const gatewayBaseUrl = args.gatewayBaseUrl ?? "https://gateway.provara.xyz";
   const spEntityId = args.spEntityId ?? defaultSpEntityIdFor(gatewayBaseUrl, args.tenantId);
 
-  const certPath = resolvePath(args.idpCertFile);
-  let cert: string;
-  try {
-    cert = readFileSync(certPath, "utf8");
-  } catch (err) {
-    console.error(`Could not read IdP cert at ${certPath}: ${(err as Error).message}`);
-    process.exit(2);
-  }
-  if (!cert.includes("BEGIN CERTIFICATE")) {
-    console.error(`Cert at ${certPath} does not look like a PEM X.509 certificate.`);
-    process.exit(2);
-  }
+  const { entityId: idpEntityId, ssoUrl: idpSsoUrl, cert } = await resolveIdpFields(args);
 
   const emailDomains = args.emailDomains
     .split(",")
@@ -152,8 +222,8 @@ async function main() {
     await db
       .update(ssoConfigs)
       .set({
-        idpEntityId: args.idpEntityId,
-        idpSsoUrl: args.idpSsoUrl,
+        idpEntityId,
+        idpSsoUrl,
         idpCert: cert,
         spEntityId,
         emailDomains,
@@ -169,8 +239,8 @@ async function main() {
       .insert(ssoConfigs)
       .values({
         tenantId: args.tenantId,
-        idpEntityId: args.idpEntityId,
-        idpSsoUrl: args.idpSsoUrl,
+        idpEntityId,
+        idpSsoUrl,
         idpCert: cert,
         spEntityId,
         emailDomains,

--- a/packages/gateway/src/auth/saml-metadata.ts
+++ b/packages/gateway/src/auth/saml-metadata.ts
@@ -1,0 +1,178 @@
+import { parseStringPromise } from "xml2js";
+
+/**
+ * Parse an IdP-published SAML metadata XML into the three fields our
+ * `sso_configs` row actually stores (#209/T7 follow-up).
+ *
+ * Every major IdP (Google Workspace, Okta, Entra, OneLogin, JumpCloud,
+ * ADFS) exports a metadata.xml from their SAML app configuration UI.
+ * Parsing it replaces the hand-copy of three separate values, which is
+ * the class of copy-paste error that produced the Google "saml2 vs
+ * saml2/idp" 404 during #209's UAT.
+ *
+ * Returns the verbatim X.509 certificate (wrapped in a PEM block) and
+ * the two URLs. Does NOT hit the DB; the caller (T7 CLI) composes the
+ * DB write.
+ */
+export interface ParsedIdpMetadata {
+  entityId: string;
+  ssoUrl: string;
+  /** PEM-wrapped X.509, ready to drop into `idp_cert`. */
+  cert: string;
+}
+
+interface RawAttrs {
+  $?: Record<string, string>;
+}
+interface SingleSignOnService extends RawAttrs {}
+interface X509Data {
+  "ds:X509Certificate"?: string[];
+  X509Certificate?: string[];
+}
+interface KeyInfo {
+  "ds:X509Data"?: X509Data[];
+  X509Data?: X509Data[];
+}
+interface KeyDescriptor extends RawAttrs {
+  "ds:KeyInfo"?: KeyInfo[];
+  KeyInfo?: KeyInfo[];
+}
+interface IDPSSODescriptor {
+  "md:KeyDescriptor"?: KeyDescriptor[];
+  KeyDescriptor?: KeyDescriptor[];
+  "md:SingleSignOnService"?: SingleSignOnService[];
+  SingleSignOnService?: SingleSignOnService[];
+}
+interface EntityDescriptor extends RawAttrs {
+  "md:IDPSSODescriptor"?: IDPSSODescriptor[];
+  IDPSSODescriptor?: IDPSSODescriptor[];
+}
+
+const HTTP_REDIRECT_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+const HTTP_POST_BINDING = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+export async function parseIdpMetadataXml(xml: string): Promise<ParsedIdpMetadata> {
+  // Some IdPs emit a leading BOM; strip it so the xml2js parser's
+  // "must start with <" check doesn't fail.
+  const cleaned = xml.replace(/^\uFEFF/, "").trim();
+
+  const doc = (await parseStringPromise(cleaned, {
+    explicitArray: true,
+    // xml2js by default folds namespace prefixes into the key name; we
+    // explicitly tolerate both prefixed and unprefixed keys in the
+    // field lookups below, so stripPrefix: false is fine and avoids
+    // losing the <ds:> prefix that matters for X.509 data in strict
+    // metadata consumers.
+    tagNameProcessors: [],
+  })) as Record<string, EntityDescriptor>;
+
+  // The top-level element is always EntityDescriptor, possibly prefixed
+  // (md:EntityDescriptor). Accept whichever the IdP produces.
+  const rootKey = Object.keys(doc).find((k) => /(?:^|:)EntityDescriptor$/.test(k));
+  if (!rootKey) {
+    throw new MetadataParseError("root element is not EntityDescriptor — is this an IdP metadata file?");
+  }
+  const root = doc[rootKey];
+
+  const entityId = root.$?.entityID;
+  if (!entityId) {
+    throw new MetadataParseError("EntityDescriptor is missing the entityID attribute");
+  }
+
+  const idpDescriptor = pickFirst(root, "IDPSSODescriptor") as IDPSSODescriptor | undefined;
+  if (!idpDescriptor) {
+    throw new MetadataParseError("no IDPSSODescriptor — this is not an IdP metadata file (SP metadata?)");
+  }
+
+  const ssoUrl = extractSsoUrl(idpDescriptor);
+  const cert = extractSigningCertPem(idpDescriptor);
+
+  return { entityId, ssoUrl, cert };
+}
+
+/**
+ * Prefer HTTP-Redirect binding (what the library emits for SP-init by
+ * default), fall back to HTTP-POST if the IdP only exposes that one.
+ * Pick the first matching SingleSignOnService element. If none exists,
+ * raise — we can't configure SSO without an endpoint.
+ */
+function extractSsoUrl(idp: IDPSSODescriptor): string {
+  const services = pickAll(idp, "SingleSignOnService") as SingleSignOnService[];
+  if (services.length === 0) {
+    throw new MetadataParseError("IDPSSODescriptor has no SingleSignOnService elements");
+  }
+  const redirect = services.find((s) => s.$?.Binding === HTTP_REDIRECT_BINDING);
+  if (redirect?.$?.Location) return redirect.$.Location;
+  const post = services.find((s) => s.$?.Binding === HTTP_POST_BINDING);
+  if (post?.$?.Location) return post.$.Location;
+  throw new MetadataParseError(
+    "no HTTP-Redirect or HTTP-POST SingleSignOnService binding found — unsupported IdP",
+  );
+}
+
+/**
+ * Extract the first X.509 signing certificate and wrap it as a PEM
+ * block. IdPs may tag KeyDescriptor with use="signing" (most do) or
+ * leave it unspecified — the SAML spec says unspecified means dual-
+ * purpose, so we accept both. When multiple signing certs exist
+ * (rotation windows), pick the first; node-saml accepts an array via
+ * multiple PEM blocks concatenated, but that complication can land in
+ * a follow-up if a customer actually needs it.
+ */
+function extractSigningCertPem(idp: IDPSSODescriptor): string {
+  const keyDescriptors = pickAll(idp, "KeyDescriptor") as KeyDescriptor[];
+  if (keyDescriptors.length === 0) {
+    throw new MetadataParseError("IDPSSODescriptor has no KeyDescriptor elements");
+  }
+  const signing = keyDescriptors.find((kd) => kd.$?.use === "signing") ?? keyDescriptors[0];
+
+  const keyInfo = pickFirst(signing, "KeyInfo") as KeyInfo | undefined;
+  if (!keyInfo) {
+    throw new MetadataParseError("KeyDescriptor missing KeyInfo");
+  }
+  const x509Data = pickFirst(keyInfo, "X509Data") as X509Data | undefined;
+  if (!x509Data) {
+    throw new MetadataParseError("KeyInfo missing X509Data");
+  }
+  const certB64Array = x509Data["ds:X509Certificate"] ?? x509Data.X509Certificate;
+  const certB64 = certB64Array?.[0];
+  if (!certB64) {
+    throw new MetadataParseError("X509Data missing X509Certificate");
+  }
+
+  // Strip whitespace from the base64 (metadata files often pretty-print
+  // the cert across multiple lines). Then reflow to 64-char lines and
+  // wrap with PEM headers — node-saml expects a well-formed PEM.
+  const compact = certB64.replace(/\s+/g, "");
+  const reflowed = compact.match(/.{1,64}/g)?.join("\n") ?? compact;
+  return `-----BEGIN CERTIFICATE-----\n${reflowed}\n-----END CERTIFICATE-----\n`;
+}
+
+/**
+ * Helpers for the xml2js shape: every element is an array, and keys may
+ * carry an XML namespace prefix (`md:`, `ds:`) that varies per IdP.
+ * `pickFirst` returns the first child that matches `localName`
+ * regardless of prefix; `pickAll` flattens across prefix variants.
+ */
+function pickFirst(parent: object, localName: string): unknown {
+  const all = pickAll(parent, localName);
+  return all[0];
+}
+function pickAll(parent: object, localName: string): unknown[] {
+  const re = new RegExp(`(?:^|:)${localName}$`);
+  const results: unknown[] = [];
+  const record = parent as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (!re.test(key)) continue;
+    const value = record[key];
+    if (Array.isArray(value)) results.push(...value);
+    else if (value != null) results.push(value);
+  }
+  return results;
+}
+
+export class MetadataParseError extends Error {
+  constructor(message: string) {
+    super(`IdP metadata parse failed: ${message}`);
+  }
+}

--- a/packages/gateway/tests/saml-metadata.test.ts
+++ b/packages/gateway/tests/saml-metadata.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { parseIdpMetadataXml, MetadataParseError } from "../src/auth/saml-metadata.js";
+
+// Realistic fixtures modeled on what Google Workspace, Okta, and Entra
+// emit from their SAML app metadata downloads. The certs are fixture
+// values (format-valid base64 but not real signing keys).
+
+const FIXTURE_CERT_LINE =
+  "MIIDdDCCAlygAwIBAgIGAZ2gqEp/MA0GCSqGSIb3DQEBCwUAMHsxFDASBgNVBAoTC0dvb2dsZSBJ";
+
+/**
+ * The parser reflows PEM bodies to 64-char lines, so comparing against
+ * the original single-line fixture requires stripping whitespace and
+ * PEM headers. The base64 *content* is what matters to the SAML client;
+ * line wrapping is cosmetic.
+ */
+function stripPem(pem: string): string {
+  return pem
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s/g, "");
+}
+
+const GOOGLE_METADATA = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    entityID="https://accounts.google.com/o/saml2?idpid=C01s6h8ff"
+    validUntil="2031-04-17T12:54:36.000Z">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+      WantAuthnRequestsSigned="false">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>${FIXTURE_CERT_LINE}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        Location="https://accounts.google.com/o/saml2/idp?idpid=C01s6h8ff"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        Location="https://accounts.google.com/o/saml2/idp?idpid=C01s6h8ff"/>
+  </md:IDPSSODescriptor>
+</md:EntityDescriptor>`;
+
+// Okta's metadata uses unprefixed element names in some fields.
+const OKTA_METADATA = `<?xml version="1.0" encoding="UTF-8"?>
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+    entityID="http://www.okta.com/exk1fs4r1z2345abcde">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"
+      WantAuthnRequestsSigned="false">
+    <KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>${FIXTURE_CERT_LINE}</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+        Location="https://acme.okta.com/app/acme_provara_1/exk1fs4r1z2345abcde/sso/saml"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+        Location="https://acme.okta.com/app/acme_provara_1/exk1fs4r1z2345abcde/sso/saml"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+
+describe("parseIdpMetadataXml", () => {
+  it("parses Google Workspace metadata correctly", async () => {
+    const parsed = await parseIdpMetadataXml(GOOGLE_METADATA);
+    expect(parsed.entityId).toBe("https://accounts.google.com/o/saml2?idpid=C01s6h8ff");
+    expect(parsed.ssoUrl).toBe("https://accounts.google.com/o/saml2/idp?idpid=C01s6h8ff");
+    expect(parsed.cert).toContain("-----BEGIN CERTIFICATE-----");
+    expect(stripPem(parsed.cert)).toContain(FIXTURE_CERT_LINE);
+    expect(parsed.cert).toContain("-----END CERTIFICATE-----");
+  });
+
+  it("parses Okta-shape unprefixed metadata correctly", async () => {
+    const parsed = await parseIdpMetadataXml(OKTA_METADATA);
+    expect(parsed.entityId).toBe("http://www.okta.com/exk1fs4r1z2345abcde");
+    expect(parsed.ssoUrl).toBe(
+      "https://acme.okta.com/app/acme_provara_1/exk1fs4r1z2345abcde/sso/saml",
+    );
+    expect(stripPem(parsed.cert)).toContain(FIXTURE_CERT_LINE);
+  });
+
+  it("prefers HTTP-Redirect binding when both are present", async () => {
+    // Google metadata has Redirect first then POST; Okta has POST first
+    // then Redirect. Either way the parser should land on Redirect.
+    const google = await parseIdpMetadataXml(GOOGLE_METADATA);
+    const okta = await parseIdpMetadataXml(OKTA_METADATA);
+    // Google and Okta both point at the same URL for both bindings in
+    // these fixtures, so the assertion is really about the chosen URL
+    // equaling either binding's Location.
+    expect(google.ssoUrl).toBe("https://accounts.google.com/o/saml2/idp?idpid=C01s6h8ff");
+    expect(okta.ssoUrl).toContain("okta.com");
+  });
+
+  it("falls back to HTTP-POST when HTTP-Redirect is not offered", async () => {
+    const postOnly = GOOGLE_METADATA.replace(
+      /<md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"[^/]+\/>/,
+      "",
+    );
+    const parsed = await parseIdpMetadataXml(postOnly);
+    expect(parsed.ssoUrl).toBe("https://accounts.google.com/o/saml2/idp?idpid=C01s6h8ff");
+  });
+
+  it("strips whitespace from multi-line cert base64 and reflows to PEM", async () => {
+    const multiLineXml = GOOGLE_METADATA.replace(
+      FIXTURE_CERT_LINE,
+      `${FIXTURE_CERT_LINE.slice(0, 40)}\n        ${FIXTURE_CERT_LINE.slice(40)}`,
+    );
+    const parsed = await parseIdpMetadataXml(multiLineXml);
+    // Cert body should reflow to 64-char lines with no leading space
+    const body = parsed.cert
+      .replace("-----BEGIN CERTIFICATE-----\n", "")
+      .replace(/\n-----END CERTIFICATE-----\n?$/, "");
+    for (const line of body.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(64);
+      expect(line).not.toMatch(/\s/);
+    }
+  });
+
+  it("handles a leading BOM character gracefully", async () => {
+    const withBom = "\uFEFF" + GOOGLE_METADATA;
+    const parsed = await parseIdpMetadataXml(withBom);
+    expect(parsed.entityId).toBe("https://accounts.google.com/o/saml2?idpid=C01s6h8ff");
+  });
+
+  it("throws MetadataParseError when the root is not EntityDescriptor", async () => {
+    const notMetadata = `<?xml version="1.0"?><SomethingElse/>`;
+    await expect(parseIdpMetadataXml(notMetadata)).rejects.toThrow(MetadataParseError);
+    await expect(parseIdpMetadataXml(notMetadata)).rejects.toThrow(/EntityDescriptor/);
+  });
+
+  it("throws when the EntityDescriptor is missing entityID", async () => {
+    const noId = GOOGLE_METADATA.replace(/entityID="[^"]+"/, "");
+    await expect(parseIdpMetadataXml(noId)).rejects.toThrow(/entityID/);
+  });
+
+  it("throws when the file is SP metadata instead of IdP metadata", async () => {
+    const spMetadata = GOOGLE_METADATA.replace(
+      "md:IDPSSODescriptor",
+      "md:SPSSODescriptor",
+    ).replace(
+      "md:IDPSSODescriptor",
+      "md:SPSSODescriptor",
+    );
+    await expect(parseIdpMetadataXml(spMetadata)).rejects.toThrow(/IDPSSODescriptor/);
+  });
+
+  it("throws when no SingleSignOnService is present", async () => {
+    // Multi-line self-closing tags — use [\s\S] to match across newlines.
+    const noSso = GOOGLE_METADATA.replace(
+      /<md:SingleSignOnService [\s\S]+?\/>/g,
+      "",
+    );
+    await expect(parseIdpMetadataXml(noSso)).rejects.toThrow(/SingleSignOnService/);
+  });
+
+  it("throws when no X509Certificate is present", async () => {
+    const noCert = GOOGLE_METADATA.replace(
+      /<ds:X509Certificate>[^<]+<\/ds:X509Certificate>/,
+      "",
+    );
+    await expect(parseIdpMetadataXml(noCert)).rejects.toThrow(/X509Certificate/);
+  });
+
+  it("picks the signing key when multiple KeyDescriptors exist", async () => {
+    // Add an encryption key before the signing key — parser should skip
+    // it and find the use="signing" one.
+    const withEncryption = GOOGLE_METADATA.replace(
+      "<md:KeyDescriptor use=\"signing\">",
+      `<md:KeyDescriptor use="encryption">
+        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+          <ds:X509Data>
+            <ds:X509Certificate>ENCRYPTION-KEY-XXX-not-the-right-one</ds:X509Certificate>
+          </ds:X509Data>
+        </ds:KeyInfo>
+      </md:KeyDescriptor>
+      <md:KeyDescriptor use="signing">`,
+    );
+    const parsed = await parseIdpMetadataXml(withEncryption);
+    expect(stripPem(parsed.cert)).toContain(FIXTURE_CERT_LINE);
+    expect(parsed.cert).not.toContain("ENCRYPTION-KEY-XXX");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a SAML metadata parser and threads it through the T7 \`seed-sso-config\` CLI so operators can point at a Google/Okta/Entra metadata.xml export instead of copying three separate values by hand. Kills the copy-paste trap that cost us a chunk of UAT time today.

## New usage (recommended)

\`\`\`bash
tsx packages/gateway/scripts/seed-sso-config.ts \\
  --tenant-id acme-tenant-xyz \\
  --idp-metadata-file ./google-idp-metadata.xml \\
  --email-domains "acme.com,acme.co.uk"
\`\`\`

The three individual flags still work for edge cases / manual overrides — the CLI refuses having neither or both.

## Parser design

- Tolerates both prefixed (\`md:\`) and unprefixed element names (Google uses \`md:\`, Okta uses plain).
- Prefers HTTP-Redirect binding, falls back to HTTP-POST.
- Prefers KeyDescriptor[use=signing], falls back to the first descriptor.
- Reflows the extracted cert to standard 64-char PEM lines and wraps with BEGIN/END headers.
- Strips a leading BOM some IdPs emit.
- Clear \`MetadataParseError\` messages for SP-instead-of-IdP files, missing entityID, missing SingleSignOnService, missing X509Certificate.

## Test plan

- [x] \`npx vitest run tests/saml-metadata.test.ts\` — 12/12
- [x] tsc clean
- [ ] Manual end-to-end with a real Google Workspace metadata download post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)