### PR TITLE
fix: cascade oauth_accounts + team_invites on team member removal

### DIFF
--- a/packages/gateway/src/routes/team.ts
+++ b/packages/gateway/src/routes/team.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { users, sessions, teamInvites } from "@provara/db";
+import { users, sessions, teamInvites, oauthAccounts } from "@provara/db";
 import { eq, and, isNull, gte, desc, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getAuthUser } from "../auth/admin.js";
@@ -94,7 +94,28 @@ export function createTeamRoutes(db: Db) {
       return c.json({ error: { message: "Member not found", type: "not_found" } }, 404);
     }
 
-    // Delete their sessions first
+    // Clean up rows that hold a FK into users so the final user delete
+    // doesn't trip SQLITE_CONSTRAINT. Surfaced during #209 SSO UAT: a
+    // member who previously signed in via Google OAuth had an
+    // oauth_accounts row, and the original delete path only removed
+    // sessions + users → FK violation → 500 → dashboard shows "unknown
+    // error."
+    //
+    // Handled here, keyed by kind of relationship:
+    //   - oauth_accounts: linked logins (1-to-many by provider). Delete.
+    //   - team_invites.invited_by_user_id: NOT NULL FK; row can't
+    //     survive without the inviter, so delete their invites.
+    //   - team_invites.consumed_by_user_id: nullable FK; null it out
+    //     rather than delete so the audit trail ("this invite was
+    //     accepted, at what time") survives the user leaving.
+    //   - sessions: existing behavior, kept.
+    await db.delete(oauthAccounts).where(eq(oauthAccounts.userId, targetId)).run();
+    await db.delete(teamInvites).where(eq(teamInvites.invitedByUserId, targetId)).run();
+    await db
+      .update(teamInvites)
+      .set({ consumedByUserId: null })
+      .where(eq(teamInvites.consumedByUserId, targetId))
+      .run();
     await db.delete(sessions).where(eq(sessions.userId, targetId)).run();
     await db.delete(users).where(eq(users.id, targetId)).run();
 

--- a/packages/gateway/tests/team-invites.test.ts
+++ b/packages/gateway/tests/team-invites.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Hono } from "hono";
 import { eq } from "drizzle-orm";
 import type { Db } from "@provara/db";
-import { users, teamInvites } from "@provara/db";
+import { users, teamInvites, oauthAccounts } from "@provara/db";
 import { makeTestDb } from "./_setup/db.js";
 import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
 
@@ -580,5 +580,112 @@ describe("OAuth invite claim (#177)", () => {
     const user = await upsertUser(db, "google", profile());
     expect(user.tenantId).not.toBe("team-alpha");
     expect(user.role).toBe("owner");
+  });
+});
+
+
+describe("DELETE /v1/admin/team/:id (member removal)", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+    resetTierEnv();
+  });
+  afterEach(() => resetTierEnv());
+
+  it("removes a member whose user row has an attached oauth_accounts (regression for #209 UAT)", async () => {
+    // Repro of the live edge case: a member who authenticated via
+    // Google OAuth before their tenant enabled SSO carries an
+    // oauth_accounts row. The original remove path deleted sessions +
+    // users but not oauth_accounts → SQLite refused the user DELETE
+    // with a FOREIGN KEY constraint → 500 → dashboard generic error.
+    const ownerId = "owner-1";
+    const memberId = "member-1";
+    await seedUser(db, { id: ownerId, tenantId: "t-1", email: "owner@example.com", role: "owner" });
+    await seedUser(db, { id: memberId, tenantId: "t-1", email: "member@example.com", role: "member" });
+    await db.insert(oauthAccounts).values({
+      id: "oauth-1",
+      userId: memberId,
+      provider: "google",
+      providerAccountId: "google-acct-xyz",
+      email: "member@example.com",
+      createdAt: new Date(),
+    }).run();
+
+    const app = buildApp(db);
+    const res = await app.request(`/v1/admin/team/${memberId}`, {
+      method: "DELETE",
+      headers: {
+        "x-test-user": authHeader({ id: ownerId, tenantId: "t-1", role: "owner" }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted).toBe(true);
+
+    // All three rows gone — user and the oauth_accounts that referenced it.
+    const usersLeft = await db.select().from(users).where(eq(users.id, memberId)).all();
+    expect(usersLeft).toHaveLength(0);
+    const oauthLeft = await db.select().from(oauthAccounts).where(eq(oauthAccounts.userId, memberId)).all();
+    expect(oauthLeft).toHaveLength(0);
+  });
+
+  it("preserves team_invites history — consumed_by_user_id is nulled, not cascaded", async () => {
+    const ownerId = "owner-1";
+    const memberId = "member-1";
+    await seedUser(db, { id: ownerId, tenantId: "t-1", email: "owner@example.com", role: "owner" });
+    await seedUser(db, { id: memberId, tenantId: "t-1", email: "member@example.com", role: "member" });
+    await db.insert(teamInvites).values({
+      token: "inv-1",
+      tenantId: "t-1",
+      invitedEmail: "member@example.com",
+      invitedRole: "member",
+      invitedByUserId: ownerId,
+      consumedByUserId: memberId,
+      consumedAt: new Date(Date.now() - 60_000),
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    }).run();
+
+    const app = buildApp(db);
+    const res = await app.request(`/v1/admin/team/${memberId}`, {
+      method: "DELETE",
+      headers: {
+        "x-test-user": authHeader({ id: ownerId, tenantId: "t-1", role: "owner" }),
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const invite = await db.select().from(teamInvites).where(eq(teamInvites.token, "inv-1")).get();
+    expect(invite).toBeTruthy();
+    expect(invite?.consumedByUserId).toBeNull();
+    expect(invite?.consumedAt).toBeTruthy(); // audit trail preserved
+  });
+
+  it("deletes team_invites where the removed user was the inviter (NOT NULL FK)", async () => {
+    const ownerId = "owner-1";
+    const inviterId = "member-inviter";
+    await seedUser(db, { id: ownerId, tenantId: "t-1", email: "owner@example.com", role: "owner" });
+    await seedUser(db, { id: inviterId, tenantId: "t-1", email: "inviter@example.com", role: "member" });
+    await db.insert(teamInvites).values({
+      token: "inv-2",
+      tenantId: "t-1",
+      invitedEmail: "pending@example.com",
+      invitedRole: "member",
+      invitedByUserId: inviterId,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + 60_000),
+    }).run();
+
+    const app = buildApp(db);
+    const res = await app.request(`/v1/admin/team/${inviterId}`, {
+      method: "DELETE",
+      headers: {
+        "x-test-user": authHeader({ id: ownerId, tenantId: "t-1", role: "owner" }),
+      },
+    });
+    expect(res.status).toBe(200);
+
+    const inviteLeft = await db.select().from(teamInvites).where(eq(teamInvites.token, "inv-2")).all();
+    expect(inviteLeft).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the "Could not remove member: unknown error" surfaced during #209 SSO UAT. The team-remove handler was only deleting \`sessions\` + \`users\`, which trips SQLite's FK constraint for any member with attached \`oauth_accounts\` rows or outbound \`team_invites\`.

## What changed

DELETE /v1/admin/team/:id now also:
- Deletes \`oauth_accounts\` rows linked to the target (cascade)
- Deletes \`team_invites\` where the target is the inviter (NOT NULL FK)
- Nulls \`team_invites.consumed_by_user_id\` where the target consumed (preserves audit trail)

3 new regression tests cover each cleanup path.

## Test plan

- [x] \`npx vitest run tests/team-invites.test.ts\` — 28/28 pass
- [x] tsc clean
- [ ] Post-merge UAT: retry removing nblanchard@corelumen.io as syndicalt@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)