### PR TITLE
feat(#192): per-IP rate limiting on auth + chat-completions

### DIFF
--- a/packages/gateway/src/audit/actions.ts
+++ b/packages/gateway/src/audit/actions.ts
@@ -47,6 +47,12 @@ export const AUDIT_BILLING_SUBSCRIPTION_UPDATED = "billing.subscription.updated"
 export const AUDIT_BILLING_SUBSCRIPTION_CANCELED = "billing.subscription.canceled";
 export const AUDIT_BILLING_CHECKOUT_STARTED = "billing.checkout.started";
 
+// Abuse / security signals (#192). Emitted only when the blocked caller
+// has a resolvable tenant (bearer token or session); unauthenticated
+// rate-limit hits log to stdout and stay out of audit_logs to keep the
+// compliance view uncluttered.
+export const AUDIT_RATE_LIMIT_EXCEEDED = "rate_limit.exceeded";
+
 /**
  * Convenience union of every canonical action. Runtime validators can
  * use this via `Object.values(AUDIT_ACTIONS).includes(x)`.
@@ -75,6 +81,7 @@ export const AUDIT_ACTIONS = {
   AUDIT_BILLING_SUBSCRIPTION_UPDATED,
   AUDIT_BILLING_SUBSCRIPTION_CANCELED,
   AUDIT_BILLING_CHECKOUT_STARTED,
+  AUDIT_RATE_LIMIT_EXCEEDED,
 } as const;
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[keyof typeof AUDIT_ACTIONS];

--- a/packages/gateway/src/middleware/rate-limit.ts
+++ b/packages/gateway/src/middleware/rate-limit.ts
@@ -1,0 +1,205 @@
+import type { Context, MiddlewareHandler, Next } from "hono";
+import type { Db } from "@provara/db";
+import { emitAudit } from "../audit/emit.js";
+import { AUDIT_RATE_LIMIT_EXCEEDED } from "../audit/actions.js";
+import { getTenantId } from "../auth/tenant.js";
+
+/**
+ * IP-keyed rate limiting (#192). Fixed-window counter, single-replica
+ * in-memory — fine for v1. Multi-replica shared-state rides on #50.
+ *
+ * Separate concern from the existing token-scoped `checkRateLimit` in
+ * `auth/rate-limiter.ts`: that limiter enforces per-token `rateLimit`
+ * on authenticated programmatic callers. This module adds the missing
+ * layer — per-IP abuse protection on public + unauthenticated routes
+ * plus a global DoS floor on the chat-completions hot path.
+ *
+ * Scope keys are ("auth" | "chat" | "invite" | ...) so the counter
+ * maps for different route groups don't collide. A single request may
+ * pass through multiple rate-limit middlewares when both a group-level
+ * and route-level limit apply; each middleware consumes one increment
+ * in its own scope.
+ *
+ * Audit emission: when the blocked caller has a tenant resolvable from
+ * the existing auth context, we emit `rate_limit.exceeded` via the
+ * #210 audit infrastructure — one row per (scope, key, tenantId)
+ * burst, suppressed for `AUDIT_SUPPRESS_MS` so sustained hits don't
+ * flood `audit_logs`. Unauthenticated hits log to stdout only
+ * (operators notice them via infra metrics).
+ */
+
+const AUDIT_SUPPRESS_MS = 60_000;
+
+export interface WindowLimit {
+  /** Limit within the window. */
+  limit: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+export interface WindowCheck {
+  allowed: boolean;
+  remaining: number;
+  resetMs: number;
+}
+
+const counters = new Map<string, { count: number; windowStart: number }>();
+const lastAuditAt = new Map<string, number>();
+
+/** Test-only reset. Never call from production code. */
+export function __resetRateLimitStateForTests(): void {
+  counters.clear();
+  lastAuditAt.clear();
+}
+
+/**
+ * Fixed-window counter check. Keyed by `${scope}:${key}`. Pure w.r.t.
+ * I/O (only mutates the module-local counters Map) so tests can drive
+ * it directly without spinning up a Hono app.
+ */
+export function checkWindowLimit(
+  scope: string,
+  key: string,
+  config: WindowLimit,
+  now: number = Date.now(),
+): WindowCheck {
+  const fullKey = `${scope}:${key}`;
+  const entry = counters.get(fullKey);
+
+  if (!entry || now - entry.windowStart >= config.windowMs) {
+    counters.set(fullKey, { count: 1, windowStart: now });
+    return { allowed: true, remaining: config.limit - 1, resetMs: config.windowMs };
+  }
+
+  if (entry.count >= config.limit) {
+    return {
+      allowed: false,
+      remaining: 0,
+      resetMs: config.windowMs - (now - entry.windowStart),
+    };
+  }
+
+  entry.count++;
+  return {
+    allowed: true,
+    remaining: config.limit - entry.count,
+    resetMs: config.windowMs - (now - entry.windowStart),
+  };
+}
+
+function clientIp(c: Context): string {
+  const fwd = c.req.header("x-forwarded-for") || c.req.header("cf-connecting-ip") || "";
+  return fwd.split(",")[0]?.trim() || "unknown";
+}
+
+export interface RateLimitMiddlewareOptions extends WindowLimit {
+  /** Logical scope label, e.g. "auth", "chat", "invite". */
+  scope: string;
+  /** Custom key resolver. Default: client IP from x-forwarded-for / cf-connecting-ip. */
+  keyFn?: (c: Context) => string;
+  /**
+   * Emit audit events for rate-limit hits from authenticated callers.
+   * Pass the `Db` handle to turn this on; omit to stay silent
+   * (unauthenticated-only routes should omit — stdout only).
+   */
+  audit?: { db: Db };
+}
+
+/**
+ * Build a Hono middleware that enforces the given rate limit. Returns
+ * 429 with `Retry-After` (seconds) and `X-RateLimit-*` headers when
+ * the caller's bucket is full.
+ */
+export function createRateLimitMiddleware(opts: RateLimitMiddlewareOptions): MiddlewareHandler {
+  const { scope, limit, windowMs, keyFn, audit } = opts;
+  const resolveKey = keyFn ?? clientIp;
+
+  return async (c: Context, next: Next) => {
+    const key = resolveKey(c);
+    const check = checkWindowLimit(scope, key, { limit, windowMs });
+
+    c.header("X-RateLimit-Limit", String(limit));
+    c.header("X-RateLimit-Remaining", String(check.remaining));
+
+    if (!check.allowed) {
+      const retryAfterSec = Math.max(1, Math.ceil(check.resetMs / 1000));
+      c.header("Retry-After", String(retryAfterSec));
+
+      if (audit) {
+        const tenantId = getTenantId(c.req.raw);
+        if (tenantId) {
+          const auditKey = `${scope}:${key}:${tenantId}`;
+          const now = Date.now();
+          const last = lastAuditAt.get(auditKey) ?? 0;
+          if (now - last >= AUDIT_SUPPRESS_MS) {
+            lastAuditAt.set(auditKey, now);
+            emitAudit(audit.db, {
+              tenantId,
+              action: AUDIT_RATE_LIMIT_EXCEEDED,
+              metadata: {
+                scope,
+                key,
+                limit,
+                window_ms: windowMs,
+                path: c.req.path,
+                method: c.req.method,
+              },
+            });
+          }
+        }
+      }
+
+      console.warn(
+        `[rate-limit] 429 scope=${scope} key=${key} path=${c.req.path} retry_after_s=${retryAfterSec}`,
+      );
+
+      return c.json(
+        {
+          error: {
+            message: "Rate limit exceeded. Try again shortly.",
+            type: "rate_limit_error",
+          },
+        },
+        429,
+      );
+    }
+
+    return next();
+  };
+}
+
+/**
+ * Env-driven config (#192/T5). Sensible defaults so nothing needs env
+ * variables to work out of the box; operators can tune per-environment
+ * without redeploys.
+ */
+export interface RateLimitConfig {
+  authPerMinute: WindowLimit;
+  invitePerMinute: WindowLimit;
+  chatPerSecond: WindowLimit;
+}
+
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = parseInt(raw, 10);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return fallback;
+}
+
+export function loadRateLimitConfig(): RateLimitConfig {
+  return {
+    authPerMinute: {
+      limit: positiveIntFromEnv("RATE_LIMIT_AUTH_PER_MIN", 20),
+      windowMs: 60_000,
+    },
+    invitePerMinute: {
+      limit: positiveIntFromEnv("RATE_LIMIT_INVITE_PER_MIN", 20),
+      windowMs: 60_000,
+    },
+    chatPerSecond: {
+      limit: positiveIntFromEnv("RATE_LIMIT_CHAT_RPS", 200),
+      windowMs: 1_000,
+    },
+  };
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -46,6 +46,10 @@ import { createWebhookRoutes } from "./routes/webhooks.js";
 import { createBillingRoutes } from "./routes/billing.js";
 import { requireIntelligenceTier } from "./auth/tier.js";
 import { requireQuota } from "./auth/quota.js";
+import {
+  createRateLimitMiddleware,
+  loadRateLimitConfig,
+} from "./middleware/rate-limit.js";
 
 interface RouterContext {
   registry: ProviderRegistry;
@@ -100,11 +104,35 @@ export async function createRouter(ctx: RouterContext) {
     exposeHeaders: ["X-Provara-Guardrail", "X-Provara-Model", "X-Provara-Provider", "X-Provara-Request-Id", "X-Provara-Errors", "X-Provara-Cost", "X-Provara-Latency", "X-Provara-Cache", "X-RateLimit-Limit", "X-RateLimit-Remaining"],
   }));
 
-  // Mount OAuth routes (public, only in multi_tenant mode)
+  // Per-IP rate limiting (#192). Flat limits for abuse protection;
+  // tier-based promises are handled upstream via monthly quota
+  // enforcement (`requireQuota` + TIER_QUOTAS), not here.
+  const rateLimits = loadRateLimitConfig();
+
+  // Mount OAuth routes (public, only in multi_tenant mode). Auth
+  // endpoints are public + unauthenticated, so rate-limit-hit audit
+  // emission is disabled — stdout logging only. Sign-in / invite-claim
+  // / OAuth callback are all under /auth/*.
   if (getMode() === "multi_tenant") {
+    const authRateLimit = createRateLimitMiddleware({
+      scope: "auth",
+      ...rateLimits.authPerMinute,
+    });
+    app.use("/auth/*", authRateLimit);
     app.route("/auth", createAuthRoutes(ctx.db));
     app.route("/auth/saml", createSamlAuthRoutes(ctx.db));
   }
+
+  // Global DoS floor on the chat-completions hot path. Per-token
+  // `apiTokens.rateLimit` remains the programmatic lever for
+  // fine-grained limits; this is the flat DoS ceiling that protects
+  // the process regardless of token count.
+  const chatRateLimit = createRateLimitMiddleware({
+    scope: "chat",
+    ...rateLimits.chatPerSecond,
+    audit: { db: ctx.db },
+  });
+  app.use("/v1/chat/completions", chatRateLimit);
 
   // Public share read — uses a distinct path (/v1/shared/:token, past tense)
   // so the `/v1/shares/*` admin-auth middleware registered below doesn't

--- a/packages/gateway/tests/rate-limit.test.ts
+++ b/packages/gateway/tests/rate-limit.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { auditLogs } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import {
+  checkWindowLimit,
+  createRateLimitMiddleware,
+  __resetRateLimitStateForTests,
+} from "../src/middleware/rate-limit.js";
+import { __testSetTenant } from "../src/auth/tenant.js";
+
+describe("#192 — rate-limit primitive", () => {
+  beforeEach(() => __resetRateLimitStateForTests());
+
+  it("allows up to `limit` requests in the window, then rejects", () => {
+    const cfg = { limit: 3, windowMs: 60_000 };
+    const now = 1_700_000_000_000;
+    expect(checkWindowLimit("s", "k", cfg, now).allowed).toBe(true);
+    expect(checkWindowLimit("s", "k", cfg, now).allowed).toBe(true);
+    expect(checkWindowLimit("s", "k", cfg, now).allowed).toBe(true);
+    const fourth = checkWindowLimit("s", "k", cfg, now);
+    expect(fourth.allowed).toBe(false);
+    expect(fourth.remaining).toBe(0);
+    expect(fourth.resetMs).toBeGreaterThan(0);
+  });
+
+  it("resets after the window elapses", () => {
+    const cfg = { limit: 2, windowMs: 1000 };
+    const t0 = 1_700_000_000_000;
+    checkWindowLimit("s", "k", cfg, t0);
+    checkWindowLimit("s", "k", cfg, t0);
+    expect(checkWindowLimit("s", "k", cfg, t0).allowed).toBe(false);
+    // Jump past the window.
+    expect(checkWindowLimit("s", "k", cfg, t0 + 1001).allowed).toBe(true);
+  });
+
+  it("isolates buckets by scope and key", () => {
+    const cfg = { limit: 1, windowMs: 60_000 };
+    const now = 1_700_000_000_000;
+    expect(checkWindowLimit("scope-a", "ip1", cfg, now).allowed).toBe(true);
+    // Different scope, same key → separate bucket.
+    expect(checkWindowLimit("scope-b", "ip1", cfg, now).allowed).toBe(true);
+    // Different key, same scope → separate bucket.
+    expect(checkWindowLimit("scope-a", "ip2", cfg, now).allowed).toBe(true);
+  });
+});
+
+describe("#192 — rate-limit Hono middleware", () => {
+  let db: Db;
+  let app: Hono;
+
+  beforeEach(async () => {
+    __resetRateLimitStateForTests();
+    db = await makeTestDb();
+    app = new Hono();
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns 429 with Retry-After once the limit is hit", async () => {
+    app.use(
+      "/x",
+      createRateLimitMiddleware({ scope: "test", limit: 2, windowMs: 60_000 }),
+    );
+    app.get("/x", (c) => c.text("ok"));
+
+    const headers = { "x-forwarded-for": "9.9.9.9" };
+    expect((await app.request("/x", { headers })).status).toBe(200);
+    expect((await app.request("/x", { headers })).status).toBe(200);
+    const res = await app.request("/x", { headers });
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBeTruthy();
+  });
+
+  it("isolates limits by client IP", async () => {
+    app.use(
+      "/x",
+      createRateLimitMiddleware({ scope: "test", limit: 1, windowMs: 60_000 }),
+    );
+    app.get("/x", (c) => c.text("ok"));
+
+    expect((await app.request("/x", { headers: { "x-forwarded-for": "1.1.1.1" } })).status).toBe(200);
+    // Same-IP second hit → 429.
+    expect((await app.request("/x", { headers: { "x-forwarded-for": "1.1.1.1" } })).status).toBe(429);
+    // Different IP → fresh bucket, 200.
+    expect((await app.request("/x", { headers: { "x-forwarded-for": "2.2.2.2" } })).status).toBe(200);
+  });
+
+  it("emits one audit event per (ip, tenant) burst and suppresses subsequent hits", async () => {
+    // Tenant populated by tenant middleware normally; use the test setter here.
+    app.use("/x", async (c, next) => {
+      __testSetTenant(c.req.raw, "t-ent");
+      return next();
+    });
+    app.use(
+      "/x",
+      createRateLimitMiddleware({
+        scope: "chat",
+        limit: 1,
+        windowMs: 60_000,
+        audit: { db },
+      }),
+    );
+    app.get("/x", (c) => c.text("ok"));
+
+    const headers = { "x-forwarded-for": "5.5.5.5" };
+    expect((await app.request("/x", { headers })).status).toBe(200);
+    expect((await app.request("/x", { headers })).status).toBe(429);
+    expect((await app.request("/x", { headers })).status).toBe(429);
+
+    // Give the fire-and-forget emitAudit write a tick to flush.
+    await new Promise((r) => setTimeout(r, 25));
+
+    const rows = await db.select().from(auditLogs).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].action).toBe("rate_limit.exceeded");
+    expect(rows[0].tenantId).toBe("t-ent");
+    const metadata = rows[0].metadata as Record<string, unknown>;
+    expect(metadata.scope).toBe("chat");
+    expect(metadata.key).toBe("5.5.5.5");
+  });
+
+  it("does not emit audit events for unauthenticated rate-limit hits", async () => {
+    // No tenant middleware attached → getTenantId returns null.
+    app.use(
+      "/x",
+      createRateLimitMiddleware({
+        scope: "auth",
+        limit: 1,
+        windowMs: 60_000,
+        audit: { db },
+      }),
+    );
+    app.get("/x", (c) => c.text("ok"));
+
+    const headers = { "x-forwarded-for": "6.6.6.6" };
+    await app.request("/x", { headers });
+    expect((await app.request("/x", { headers })).status).toBe(429);
+    await new Promise((r) => setTimeout(r, 25));
+    const rows = await db.select().from(auditLogs).all();
+    expect(rows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Ships flat-first per-IP rate limiting (#192): abuse protection on public auth routes + a global DoS floor on `/v1/chat/completions`. Closes #192.

**Not** per-tier — the pricing page only references **monthly request quotas**, not per-second throughput, and those quotas are already enforced by the existing `requireQuota` + `usage-metering` stack (Free 10k / Pro 100k / Team 500k / Ent ∞). Rate limit and quota are intentionally different layers: per-second vs per-month.

## Changes

- `middleware/rate-limit.ts` — fixed-window counter, Hono middleware factory, env-configurable defaults
- `/auth/*` → 20/min per IP (covers sign-in + OAuth callback + magic-link verify + SAML ACS + invite claim)
- `/v1/chat/completions` → 200 rps per IP (global DoS floor)
- Existing `apiTokens.rateLimit` stays as the per-token programmatic lever — untouched
- New `rate_limit.exceeded` audit action (via #210 infra), emitted only when tenant is resolvable, suppressed per (scope, ip, tenant) for 60s so bursts don't flood `audit_logs`
- Unauthenticated rate-limit hits log to stdout only — keeps the compliance log uncluttered
- Env vars: `RATE_LIMIT_AUTH_PER_MIN`, `RATE_LIMIT_CHAT_RPS`, `RATE_LIMIT_INVITE_PER_MIN` (all have working defaults)

## Deferred per the plan

- **T8 multi-replica shared state** — in-memory per-replica is fine for single-replica Cloud; this rides on #50 (multi-instance EMA sync) if/when we scale horizontally.
- **Invite-creation route rate-limit** — `/v1/admin/team/invites` POST is behind session-auth already, so brute-force risk is minimal; filed as a follow-up consideration if invite-bomb abuse shows up.

## Test plan

- [ ] Run the gateway locally, hit `/auth/magic-link/request` 21 times in under a minute — expect 429 with `Retry-After` after the 20th.
- [ ] Send 201 parallel `/v1/chat/completions` requests from the same IP — expect 200 → 429 transition around the 200-rps ceiling.
- [ ] Confirm a valid Bearer token still works — the per-token `rateLimit` pathway is independent.
- [ ] As an authenticated tenant, trigger a chat-completions 429 repeatedly; check `/dashboard/audit` — expect exactly one `rate_limit.exceeded` event in the first minute, none on subsequent 429s in that window.
- [ ] Set `RATE_LIMIT_CHAT_RPS=5` in env, restart, verify the floor reflects the override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
