### PR TITLE
feat(#189): detect wrong-OAuth-account on invite claim

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { Suspense, useEffect, useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
 import { formatCost, formatLatency, formatNumber, formatTokens } from "../../lib/format";
 import { DataTable, type Column } from "../../components/data-table";
 import { Badge } from "../../components/badge";
-import { gatewayClientFetch } from "../../lib/gateway-client";
+import { gatewayClientFetch, gatewayFetchRaw } from "../../lib/gateway-client";
+import { useAuth } from "../../lib/auth-context";
 
 interface Overview {
   totalRequests: number;
@@ -163,7 +165,58 @@ interface CacheSavings {
   hitRate: number;
 }
 
-export default function Dashboard() {
+/**
+ * Wrong-OAuth-account banner (#189). Rendered when the OAuth callback
+ * redirects with `invite_status=wrong_email&expected=<email>` — the
+ * user signed in with a Google/GitHub account whose email doesn't
+ * match the invite they came from, so they landed in their own fresh
+ * workspace instead of joining the inviting team. Non-dismissible;
+ * one-click sign-out + reload brings them back to /login with the
+ * invite still pending so they can try again with the right account.
+ */
+function InviteMismatchBanner() {
+  const searchParams = useSearchParams();
+  const { user } = useAuth();
+  const [signingOut, setSigningOut] = useState(false);
+
+  if (searchParams.get("invite_status") !== "wrong_email") return null;
+  const expected = searchParams.get("expected") ?? "";
+
+  async function signOutAndRetry() {
+    setSigningOut(true);
+    try {
+      await gatewayFetchRaw("/auth/logout", { method: "POST" });
+    } catch {
+      // Best-effort — fall through to the reload regardless.
+    }
+    window.location.href = "/login?reason=invite";
+  }
+
+  return (
+    <div className="border-b border-amber-900/60 bg-amber-950/40 text-amber-100">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col sm:flex-row sm:items-center gap-3">
+        <div className="flex-1 text-sm">
+          <p className="font-medium text-amber-50">
+            You signed in{user?.email ? (<> as <span className="font-mono">{user.email}</span></>) : null},
+            but the invite was sent to <span className="font-mono text-amber-50">{expected}</span>.
+          </p>
+          <p className="text-amber-200/80 mt-1">
+            Sign out and sign back in with {expected ? <span className="font-mono">{expected}</span> : "the invited email"} to join that team.
+          </p>
+        </div>
+        <button
+          onClick={signOutAndRetry}
+          disabled={signingOut}
+          className="shrink-0 px-4 py-2 rounded-md text-sm font-medium bg-white text-zinc-900 hover:bg-zinc-100 disabled:opacity-60"
+        >
+          {signingOut ? "Signing out…" : "Sign out and retry"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DashboardContent() {
   const [overview, setOverview] = useState<Overview | null>(null);
   const [costsByModel, setCostsByModel] = useState<CostByModel[]>([]);
   const [recentRequests, setRecentRequests] = useState<RequestRow[]>([]);
@@ -233,13 +286,18 @@ export default function Dashboard() {
 
   if (loading) {
     return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <p className="text-zinc-400">Loading dashboard...</p>
-      </div>
+      <>
+        <InviteMismatchBanner />
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <p className="text-zinc-400">Loading dashboard...</p>
+        </div>
+      </>
     );
   }
 
   return (
+    <>
+    <InviteMismatchBanner />
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
       <div className="flex items-center gap-3">
         <h1 className="text-2xl font-bold">Dashboard</h1>
@@ -326,5 +384,17 @@ export default function Dashboard() {
         </>
       )}
     </div>
+    </>
+  );
+}
+
+export default function Dashboard() {
+  // useSearchParams (inside InviteMismatchBanner) requires a Suspense
+  // boundary in Next 15 — without one the page opts into dynamic
+  // rendering for every request.
+  return (
+    <Suspense>
+      <DashboardContent />
+    </Suspense>
   );
 }

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -20,9 +20,16 @@ export default async function InviteLandingPage({
 }: {
   params: Promise<{ token: string }>;
 }) {
-  // Await to satisfy Next 15's Promise-based params contract, even
-  // though we don't use the value — the token is already in the URL
-  // bar for the user to visually confirm.
-  await params;
-  redirect(`/login?return=${encodeURIComponent("/dashboard")}&reason=invite`);
+  // Forward the invite token to /login so it can thread through the
+  // OAuth flow. The server-side callback uses it (#189) to detect a
+  // "signed in with the wrong Google/GitHub account" mismatch and
+  // surface an actionable banner instead of silently creating a fresh
+  // solo workspace.
+  const { token } = await params;
+  const params_ = new URLSearchParams({
+    return: "/dashboard",
+    reason: "invite",
+    invite_token: token,
+  });
+  redirect(`/login?${params_.toString()}`);
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -56,11 +56,18 @@ function LoginContent() {
   const error = searchParams.get("error");
   const reason = searchParams.get("reason");
   const returnTo = searchParams.get("return") || "/dashboard";
+  const inviteToken = searchParams.get("invite_token");
   const errorText = errorMessage(error);
   const isInvite = reason === "invite";
 
-  // Append the return path onto the OAuth start URL so the callback can honor it.
-  const oauthReturn = returnTo === "/dashboard" ? "" : `?return=${encodeURIComponent(returnTo)}`;
+  // Append the return path + invite token (if present) onto the OAuth
+  // start URL so the callback can honor the return and detect an email
+  // mismatch between the OAuth account and the invited email (#189).
+  const oauthParams = new URLSearchParams();
+  if (returnTo !== "/dashboard") oauthParams.set("return", returnTo);
+  if (inviteToken) oauthParams.set("invite_token", inviteToken);
+  const oauthQuery = oauthParams.toString();
+  const oauthReturn = oauthQuery ? `?${oauthQuery}` : "";
 
   useEffect(() => {
     // An already-signed-in user clicking an invite link is almost

--- a/packages/gateway/src/auth/invite-mismatch.ts
+++ b/packages/gateway/src/auth/invite-mismatch.ts
@@ -1,0 +1,69 @@
+import type { Db } from "@provara/db";
+import { teamInvites } from "@provara/db";
+import { eq } from "drizzle-orm";
+
+/**
+ * OAuth invite-email mismatch detection (#189). Given a (nullable)
+ * invite token — threaded through the OAuth flow via the
+ * `provara_oauth_invite` cookie — compare the invite's
+ * `invited_email` to the email the OAuth provider returned.
+ *
+ * Returns:
+ *   - `null` — no token, or invite is missing / already consumed /
+ *     malformed, or emails match. Callback should proceed as if the
+ *     mismatch check weren't there.
+ *   - `{ expected }` — the emails don't match. Callback should still
+ *     sign the user in (their own fresh workspace) but redirect with
+ *     `invite_status=wrong_email&expected=<email>` so the dashboard
+ *     banner (#189/T4) can tell the user what happened.
+ *
+ * Already-consumed invites return null: whoever this OAuth account
+ * belongs to, the invite has served its purpose. No point surfacing a
+ * mismatch banner for a stale invite.
+ *
+ * Comparison is case-insensitive because OAuth providers don't
+ * guarantee email casing matches what was originally invited.
+ */
+export async function detectInviteEmailMismatch(
+  db: Db,
+  token: string | undefined | null,
+  profileEmail: string | undefined | null,
+): Promise<{ expected: string } | null> {
+  if (!token) return null;
+  if (!profileEmail) return null;
+
+  const invite = await db
+    .select({
+      invitedEmail: teamInvites.invitedEmail,
+      consumedAt: teamInvites.consumedAt,
+    })
+    .from(teamInvites)
+    .where(eq(teamInvites.token, token))
+    .get();
+  if (!invite) return null;
+  if (invite.consumedAt) return null;
+
+  if (invite.invitedEmail.toLowerCase() === profileEmail.toLowerCase()) {
+    return null;
+  }
+  return { expected: invite.invitedEmail };
+}
+
+/**
+ * Builds the post-OAuth redirect URL. When there's no mismatch, the
+ * caller's requested `returnTo` path is honored; on mismatch we clamp
+ * to `/dashboard` so the banner is visible (sending the user to a
+ * deep link would hide the feedback).
+ */
+export function buildPostOauthRedirect(
+  dashboardBaseUrl: string,
+  returnTo: string,
+  mismatch: { expected: string } | null,
+): string {
+  if (!mismatch) return `${dashboardBaseUrl}${returnTo}`;
+  const params = new URLSearchParams({
+    invite_status: "wrong_email",
+    expected: mismatch.expected,
+  });
+  return `${dashboardBaseUrl}/dashboard?${params.toString()}`;
+}

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -26,6 +26,10 @@ import {
 import { sendEmail } from "../email/index.js";
 import { welcomeEmail, magicLinkEmail } from "../email/templates.js";
 import { ssoRequiredForEmail } from "../auth/saml.js";
+import {
+  detectInviteEmailMismatch,
+  buildPostOauthRedirect,
+} from "../auth/invite-mismatch.js";
 import { emitAudit } from "../audit/emit.js";
 import {
   AUDIT_AUTH_LOGIN_SUCCESS,
@@ -40,6 +44,14 @@ const DASHBOARD_URL = () => process.env.DASHBOARD_URL || "http://localhost:3000"
 const GATEWAY_PUBLIC_URL = () => process.env.OAUTH_REDIRECT_BASE || "http://localhost:4000";
 const STATE_COOKIE = "provara_oauth_state";
 const RETURN_COOKIE = "provara_oauth_return";
+/**
+ * Invite token threaded from /invite/[token] → /login → OAuth start
+ * (#189). Read in the callback to detect a mismatch between the
+ * signed-in OAuth account's email and the invite's `invited_email`.
+ * Same short TTL as the state/return cookies — the entire OAuth
+ * round-trip is measured in seconds.
+ */
+const INVITE_COOKIE = "provara_oauth_invite";
 
 // Only allow redirecting to in-app paths (never external URLs)
 function sanitizeReturn(raw: string | undefined | null): string {
@@ -64,16 +76,20 @@ export function createAuthRoutes(db: Db) {
   app.get("/login/google", (c) => {
     const state = generateState();
     const returnTo = sanitizeReturn(c.req.query("return"));
+    const inviteToken = c.req.query("invite_token");
     setCookie(c, STATE_COOKIE, state, cookieOpts);
     setCookie(c, RETURN_COOKIE, returnTo, cookieOpts);
+    if (inviteToken) setCookie(c, INVITE_COOKIE, inviteToken, cookieOpts);
     return c.redirect(buildGoogleAuthUrl(state));
   });
 
   app.get("/login/github", (c) => {
     const state = generateState();
     const returnTo = sanitizeReturn(c.req.query("return"));
+    const inviteToken = c.req.query("invite_token");
     setCookie(c, STATE_COOKIE, state, cookieOpts);
     setCookie(c, RETURN_COOKIE, returnTo, cookieOpts);
+    if (inviteToken) setCookie(c, INVITE_COOKIE, inviteToken, cookieOpts);
     return c.redirect(buildGitHubAuthUrl(state));
   });
 
@@ -86,6 +102,24 @@ export function createAuthRoutes(db: Db) {
   function successRedirect(c: Parameters<typeof getCookie>[0]): string {
     const returnTo = sanitizeReturn(getCookie(c, RETURN_COOKIE));
     return `${DASHBOARD_URL()}${returnTo}`;
+  }
+
+  /** Read the invite cookie and delegate to the mismatch detector. */
+  async function checkInviteMismatch(
+    c: Parameters<typeof getCookie>[0],
+    profileEmail: string | undefined | null,
+  ): Promise<{ expected: string } | null> {
+    const token = getCookie(c, INVITE_COOKIE);
+    return detectInviteEmailMismatch(db, token, profileEmail);
+  }
+
+  /** Build the post-OAuth redirect, honoring an invite-email mismatch. */
+  function successRedirectWithMismatch(
+    c: Parameters<typeof getCookie>[0],
+    mismatch: { expected: string } | null,
+  ): string {
+    const returnTo = sanitizeReturn(getCookie(c, RETURN_COOKIE));
+    return buildPostOauthRedirect(DASHBOARD_URL(), returnTo, mismatch);
   }
 
   app.get("/callback/google", async (c) => {
@@ -115,6 +149,12 @@ export function createAuthRoutes(db: Db) {
           return c.redirect(loginRedirect("sso_required"));
         }
       }
+      // Invite-email mismatch check (#189): compare the profile email
+      // to the invite the caller came from; if they differ, we still
+      // sign the user in (their own workspace) but surface a banner
+      // on /dashboard so they know the invite went unclaimed and can
+      // sign out + back in with the right account.
+      const inviteMismatch = await checkInviteMismatch(c, profile.email);
       const user = await upsertUser(db, "google", profile);
       const sessionId = await createSession(db, user.id);
       setSessionCookie(c, sessionId);
@@ -125,7 +165,7 @@ export function createAuthRoutes(db: Db) {
         action: AUDIT_AUTH_LOGIN_SUCCESS,
         metadata: { method: "google" },
       });
-      return c.redirect(successRedirect(c));
+      return c.redirect(successRedirectWithMismatch(c, inviteMismatch));
     } catch (err) {
       if (err instanceof OAuthMergeRefusedError) {
         return c.redirect(loginRedirect("email_unverified"));
@@ -152,6 +192,10 @@ export function createAuthRoutes(db: Db) {
     try {
       const accessToken = await exchangeGitHubCode(code);
       const profile = await getGitHubUser(accessToken);
+      // Invite-email mismatch check (#189). See the Google callback for
+      // why we still sign the user in on a mismatch — we surface a
+      // dashboard banner rather than silently dropping the invite.
+      const inviteMismatch = await checkInviteMismatch(c, profile.email);
       const user = await upsertUser(db, "github", profile);
       const sessionId = await createSession(db, user.id);
       setSessionCookie(c, sessionId);
@@ -162,7 +206,7 @@ export function createAuthRoutes(db: Db) {
         action: AUDIT_AUTH_LOGIN_SUCCESS,
         metadata: { method: "github" },
       });
-      return c.redirect(successRedirect(c));
+      return c.redirect(successRedirectWithMismatch(c, inviteMismatch));
     } catch (err) {
       if (err instanceof OAuthMergeRefusedError) {
         return c.redirect(loginRedirect("email_unverified"));

--- a/packages/gateway/tests/invite-mismatch.test.ts
+++ b/packages/gateway/tests/invite-mismatch.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Db } from "@provara/db";
+import { teamInvites, users } from "@provara/db";
+import { makeTestDb } from "./_setup/db.js";
+import {
+  detectInviteEmailMismatch,
+  buildPostOauthRedirect,
+} from "../src/auth/invite-mismatch.js";
+
+async function seedInviter(db: Db) {
+  await db.insert(users).values({
+    id: "u-owner",
+    email: "owner@acme.com",
+    tenantId: "t-acme",
+    role: "owner",
+    createdAt: new Date(),
+  }).run();
+}
+
+async function seedInvite(
+  db: Db,
+  overrides: Partial<{
+    token: string;
+    invitedEmail: string;
+    consumedAt: Date | null;
+  }> = {},
+) {
+  await db.insert(teamInvites).values({
+    token: overrides.token ?? "inv-token-1",
+    tenantId: "t-acme",
+    invitedEmail: overrides.invitedEmail ?? "bob@acme.com",
+    invitedRole: "member",
+    invitedByUserId: "u-owner",
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    consumedAt: overrides.consumedAt ?? null,
+    createdAt: new Date(),
+  }).run();
+}
+
+describe("#189 — invite-email mismatch detector", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+    await seedInviter(db);
+  });
+
+  it("returns null when no token was threaded through the flow", async () => {
+    await seedInvite(db);
+    const result = await detectInviteEmailMismatch(db, null, "alice@example.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the token is unknown", async () => {
+    await seedInvite(db);
+    const result = await detectInviteEmailMismatch(db, "bogus-token", "alice@example.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the invite was already consumed", async () => {
+    await seedInvite(db, { consumedAt: new Date() });
+    const result = await detectInviteEmailMismatch(db, "inv-token-1", "alice@example.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the emails match (case-insensitive)", async () => {
+    await seedInvite(db, { invitedEmail: "Bob@Acme.com" });
+    const result = await detectInviteEmailMismatch(db, "inv-token-1", "BOB@acme.com");
+    expect(result).toBeNull();
+  });
+
+  it("returns the expected email when OAuth email differs from invited email", async () => {
+    await seedInvite(db, { invitedEmail: "bob@acme.com" });
+    const result = await detectInviteEmailMismatch(db, "inv-token-1", "alice@example.com");
+    expect(result).toEqual({ expected: "bob@acme.com" });
+  });
+
+  it("returns null when profile email is missing (provider didn't return one)", async () => {
+    await seedInvite(db);
+    const result = await detectInviteEmailMismatch(db, "inv-token-1", null);
+    expect(result).toBeNull();
+  });
+});
+
+describe("#189 — post-OAuth redirect builder", () => {
+  it("honors returnTo when there's no mismatch", () => {
+    const url = buildPostOauthRedirect("http://app.local", "/dashboard/audit", null);
+    expect(url).toBe("http://app.local/dashboard/audit");
+  });
+
+  it("clamps to /dashboard and encodes the mismatch state when present", () => {
+    const url = buildPostOauthRedirect("http://app.local", "/dashboard/audit", {
+      expected: "bob@acme.com",
+    });
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/dashboard");
+    expect(parsed.searchParams.get("invite_status")).toBe("wrong_email");
+    expect(parsed.searchParams.get("expected")).toBe("bob@acme.com");
+  });
+
+  it("URL-encodes special characters in the expected email", () => {
+    const url = buildPostOauthRedirect("http://app.local", "/dashboard", {
+      expected: "bob+invite@acme.com",
+    });
+    expect(url).toContain("expected=bob%2Binvite%40acme.com");
+  });
+});


### PR DESCRIPTION
## Summary

Ships the "signed in with the wrong Google/GitHub account" detector for invite claims (#189). When an invitee clicks their invite link and then completes OAuth as a different identity, they still get a workspace — but now a non-dismissible banner on `/dashboard` tells them the invite went unclaimed and offers a one-click sign-out + retry. Closes #189.

## Changes

- **Web:** `/invite/[token]/page.tsx` forwards `invite_token` onto `/login`; `/login/page.tsx` threads it onto the gateway OAuth start URL.
- **Gateway:** `/auth/login/{google,github}` store the token in a short-TTL `provara_oauth_invite` cookie alongside the existing state/return cookies.
- **Detector** (`auth/invite-mismatch.ts`): pure, testable, case-insensitive comparison. Treats already-consumed invites as no-mismatch (invite served its purpose; whoever signed in, they're not the invitee).
- **Both OAuth callbacks** invoke the detector after fetching the profile; on mismatch, the redirect is clamped to `/dashboard?invite_status=wrong_email&expected=<email>` so the banner is visible (not swallowed by a deep `return`).
- **Dashboard banner** reads the URL state, shows the expected email, provides "Sign out and retry" that POSTs `/auth/logout` and reloads at `/login?reason=invite`. `useSearchParams` required wrapping the dashboard in a Suspense boundary.

## Explicitly out of scope (per plan)

- Auto-rolling-back the fresh signup when the user chose the wrong account — would complicate the tenant model; "sign out, try again" recovery is adequate.
- Showing the banner anywhere other than `/dashboard` — if the user navigates away before seeing it, they miss it. Acceptable v1 tradeoff.
- Mid-flow invite revocation/expiry — falls through to existing error paths.

## Test plan

- [ ] Send yourself an invite, click the link from an incognito window, sign in via Google with an account whose email doesn't match → expect to land on `/dashboard` with the yellow banner visible and "Sign out and retry" wiring up a fresh `/login?reason=invite` load.
- [ ] Same flow but sign in with the matching account → no banner, invite consumed, user lands in the inviting tenant.
- [ ] Regular (non-invite) OAuth sign-in → unchanged behavior, no banner, no `invite_status` on the URL.
- [ ] Click an already-consumed invite link then sign in with a different email → no banner (invite was already served).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
