### PR TITLE
chore: gitignore .local/ (operator-only state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ apps/web/test-results/
 apps/web/playwright-report/
 apps/web/blob-report/
 apps/web/playwright/.cache/
+
+# Operator-local state (master-key rotation snapshots, etc.)
+.local/


### PR DESCRIPTION
Small follow-up from the master-key rotation session — adds `.local/` to .gitignore so future rotation snapshots and scratch operator files don't risk getting committed.