### PR TITLE
docs: README + runbooks cleanup pass (phase a)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to Provara
+
+Provara is a self-hostable LLM operations platform. Contributions are welcome across three surfaces: the gateway, the web dashboard, and docs. This doc covers what you need to know.
+
+## License
+
+Provara is licensed under the **Business Source License 1.1** (BSL). In short:
+
+- **Non-production use** (evaluation, development, internal experimentation): free and unrestricted.
+- **Production use:** free for individuals and small organizations. Commercial production use by larger organizations requires a license from CoreLumen, LLC (legal@provara.xyz).
+- **Change date:** each release converts to Apache 2.0 four years after its release date.
+
+If this model isn't compatible with how you want to use Provara, reach out — there's a path for most cases.
+
+By submitting a pull request, you agree that your contribution will be licensed under the same BSL terms as the rest of the project.
+
+## Ways to contribute
+
+| You want to… | Go here |
+|---|---|
+| Report a bug | [GitHub Issues](https://github.com/syndicalt/provara/issues/new) — include repro steps, logs, and `provara --version` if you self-host |
+| Propose a feature | Open an issue first with the `[shiplog/plan]` prefix and include context / alternatives / open questions — see `.shiplog/routing.md` for the brainstorm protocol |
+| Fix a bug or ship a small feature | Send a PR directly (see below) |
+| Add a provider | See [`docs/runbooks/adding-a-provider.md`](docs/runbooks/adding-a-provider.md) |
+| Improve docs | PRs directly against the README, `docs/runbooks/`, or the OpenAPI spec |
+
+## Development setup
+
+```sh
+git clone https://github.com/syndicalt/provara.git
+cd provara
+npm install
+
+# Set up environment
+cp .env.example .env
+# Edit: PROVARA_MASTER_KEY + at least one provider API key
+
+# Run DB migrations on a local SQLite (default)
+npm run db:migrate -w packages/db
+
+# Start everything
+npx turbo dev
+```
+
+- **Gateway:** http://localhost:4000
+- **Dashboard:** http://localhost:3000
+- **DB Studio** (Drizzle's UI): `npm run db:studio -w packages/db`
+
+## Test expectations
+
+- **Gateway tests must pass** before opening a PR: `npm test -w packages/gateway` (503+ tests, runs in ~25–45s).
+- **Web typecheck must pass**: `cd apps/web && npx tsc --noEmit`.
+- **Gateway typecheck must pass**: `npx tsc --noEmit -p packages/gateway`.
+- **New features should ship with tests.** The existing suite has strong coverage patterns — use the nearest-neighbor test file as a template.
+
+The CI workflow runs typecheck + tests on every PR (`.github/workflows/ci.yml`). GitGuardian also scans for committed secrets.
+
+## Commit + PR conventions
+
+Provara follows the **shiplog** workflow — the full protocol lives at [`.shiplog/routing.md`](.shiplog/routing.md) but the short version:
+
+- **Branch:** `issue/<N>-<slug>` (e.g. `issue/189-oauth-invite-mismatch`)
+- **Commit title:** `<type>(#<N>): <message>` (e.g. `feat(#189): detect wrong-OAuth-account on invite claim`)
+- **Commit body:** explain the *why*, not the *what*. Include design decisions, tradeoffs considered, and what's explicitly out of scope. See the recent merged PRs for examples.
+- **PR body:** summary + changes + test plan + any deferred follow-ups. Link the issue with `Closes #<N>`.
+- **Authorship signatures** at the bottom of commits/PRs: `Authored-by: <name>`, `Last-code-by: <name>`.
+
+Pre-commit hooks check typecheck + tests. Don't skip them (`--no-verify`) unless you have a very good reason documented in the PR.
+
+## Code style
+
+- **TypeScript everywhere.** The gateway is ESM + `type: "module"`; the web app is Next.js App Router.
+- **No unnecessary comments.** Most of the codebase follows the convention that comments explain *why* (hidden constraints, surprising behavior, design tradeoffs) — not *what* the code does. See any file under `packages/gateway/src/routing/` for the style.
+- **Prefer editing existing files over creating new ones.** Small features usually belong in the nearest module.
+- **No premature abstractions.** Three similar lines beat a premature helper.
+- **No feature flags or backwards-compatibility shims** when you can just change the code. Self-hosters get bumped by the migration; that's fine.
+
+## Architecture recap
+
+See the root `README.md` for the full picture. The elevator version:
+
+- **`packages/gateway`** — Hono proxy on port 4000. Provider adapters auto-register from env + DB-stored keys. Routing, auth, scheduler, audit, spend, rate limit, budgets all live here.
+- **`packages/db`** — Drizzle ORM + libSQL/SQLite. Migrations in `packages/db/drizzle/`.
+- **`apps/web`** — Next.js + Tailwind dashboard. Uses the gateway's REST API via `lib/gateway-client.ts`.
+
+## Reporting security issues
+
+**Do not open a public issue for security vulnerabilities.** Email security@provara.xyz instead. We'll acknowledge within 48 hours, fix, and coordinate disclosure.
+
+## Questions
+
+- General: open a discussion or hit the team email at legal@provara.xyz (yes, legal is currently the catch-all — this will split out as volume grows)
+- Real-time: we don't currently run a public Slack/Discord; watch the releases page for updates.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ Intelligent multi-provider LLM gateway with adaptive routing, A/B testing, and c
 - **Streaming** — Full SSE streaming support with first-chunk fallback detection
 - **Response Caching** — In-memory cache for deterministic requests (temperature=0)
 - **Multi-Tenant** — OAuth (Google + GitHub), role-based access (owner/member), tenant-scoped data
-- **Team Invites** — Owner-invite flow with seat quotas per tier, atomic email-verified claim on OAuth callback, and transactional invite + welcome email via Resend
-- **Encrypted Key Storage** — AES-256-GCM encryption for provider API keys at rest
+- **SAML SSO** — Enterprise-tier identity-provider integration (Okta, Azure AD, Google Workspace) with IdP-metadata autoconfig and email-domain enforcement
+- **Team Invites** — Owner-invite flow with seat quotas per tier, atomic email-verified claim on OAuth callback, transactional invite + welcome email via Resend, and wrong-OAuth-account detection with a sign-out-and-retry banner
+- **Audit Logs** — Append-only per-tenant record of security- and admin-relevant events (logins, API-key rotations, subscription changes) with tier-based retention (90 d Free/Pro, 365 d Team, 730 d Enterprise), dashboard viewer, CSV export, and SIEM-friendly cursor-paginated API
+- **Spend Intelligence** — Team+/Enterprise dashboard covering per-user/per-token attribution, MTD + run-rate forecast, 7-vs-28-day spend anomaly detection, quality-adjusted spend (p25/median/p75 judge scores next to every cost row), routing-weight drift correlation, and quality-comparable savings recommendations
+- **Budgets & Alerts** — Monthly or quarterly caps with per-threshold email alerts (50/75/90/100%) and an optional hard-stop that refuses chat completions with HTTP 402 once the cap is hit
+- **Per-IP Rate Limiting** — Flat abuse-protection limits on public auth routes (20/min) and a global DoS floor on `/v1/chat/completions` (200 rps), with per-token `rateLimit` as the separate programmatic-API lever
+- **Encrypted Key Storage** — AES-256-GCM encryption for provider API keys at rest, with a documented rotation CLI (`npm run key:rotate`) and operator runbook
 - **Web Dashboard** — Sidebar navigation with grouped sections: Monitor, Test, Configure, Admin
 
 ### Screenshots
@@ -457,6 +462,126 @@ On a hit from either layer, the `requests` row records `cached = true`, `cache_s
 | `PROVARA_EMBEDDING_MODEL` | `text-embedding-3-small` | OpenAI embedding model. Must be one of `text-embedding-3-small`, `text-embedding-3-large`, `text-embedding-ada-002`. |
 | `PROVARA_EMBEDDING_PROVIDER` | `openai` | Only `openai` is supported in the MVP. Unknown values disable semantic cache. |
 
+## Audit Logs
+
+Every security- and admin-relevant event is written to an append-only per-tenant log. Used for compliance (SOC 2, ISO 27001, internal policy) and for operational "who revoked our API key last Friday?" questions.
+
+### What gets logged
+
+- **Auth** — `auth.login.success` (method: magic_link / google / saml), `auth.login.failed`, `auth.session.revoked`, `auth.sso_config.updated`
+- **Users & team** — `user.invited`, `user.joined`, `user.removed`, `user.role_changed`
+- **Access surface** — `api_key.created`, `api_key.revoked`, `token.created`, `token.revoked`, `token.rotated`
+- **Billing** — `billing.subscription.created/updated/canceled`, `billing.checkout.started`
+- **Abuse signals** — `rate_limit.exceeded` (emitted only when the blocked caller has a resolvable tenant; suppressed at 1 audit row per `(scope, ip, tenant)` per minute so bursts don't flood the log)
+
+Each row carries `tenantId`, `actorUserId` (nullable for system events), `actorEmail` (denormalized so "Alice deleted API key X" survives Alice being removed), `resourceType`, `resourceId`, and free-form JSON `metadata`.
+
+### Retention
+
+| Tier | Window |
+|---|---|
+| Free / Pro | 90 days |
+| Team | 365 days |
+| Enterprise / Self-host Enterprise | 730 days |
+
+A scheduler job (`audit-retention`) deletes rows past the per-tier cutoff daily, chunked 10k at a time. The app layer is the only UPDATE/DELETE writer on `audit_logs` — no app code path issues UPDATE.
+
+### Access
+
+- **Dashboard** — `/dashboard/audit` (Team+). Filter by actor email / action / date range, paginated cursor, one-click CSV export.
+- **SIEM pull** — `GET /v1/audit-logs?action=...&actor=...&since=...&until=...&cursor=...&format=json|csv&limit=...`. Cursor-paginated, 500-row page ceiling. Tenant-scoped; operators can view cross-tenant via the admin UI.
+
+### Emission pattern
+
+Audit writes are **fire-and-forget**: an audit-write failure must never block the underlying action. Calls use `emitAudit(db, event)`, which wraps a `.catch()` around the insert and logs write failures to stdout. Tests needing to observe the row use `emitAuditSync`.
+
+## Spend Intelligence (Team+ / Enterprise)
+
+A dedicated `/dashboard/spend` surface that goes beyond plain cost attribution. Answers Finance/FinOps questions Provara's router is uniquely positioned to answer:
+
+1. **Who spent it?** — per-user + per-token attribution (Enterprise)
+2. **On what?** — per-provider / per-model / per-category (Team+)
+3. **Is the quality worth it?** — every spend row carries the judge-score envelope (`quality_median`, `quality_p25`, `quality_p75`, `cost_per_quality_point`)
+4. **Where is it trending?** — MTD total, linear-run-rate projection, 7-vs-28-day anomaly flag
+5. **Did my last routing change save money?** — weight-snapshot diff events joined with the per-provider spend mix in the 14-day attribution window after each change (Enterprise)
+6. **Where's my biggest savings opportunity?** — ranked recommendations from same-quality cheaper alternates using the adaptive router's `model_scores.qualityScore` (Enterprise)
+7. **Stay within budget** — monthly/quarterly caps with threshold emails and an optional hard-stop
+
+### API endpoints (tenant-scoped, under `/v1/spend/*`)
+
+| Path | Tier | What it returns |
+|---|---|---|
+| `GET /by?dim=provider\|model\|user\|token\|category&from=&to=&compare=prior\|yoy` | Team+ (user/token → Enterprise) | Spend rows with the full quality envelope and period-over-period delta |
+| `GET /trajectory?period=month\|quarter` | Team+ | MTD, projected, prior-period total, anomaly flag with reason |
+| `GET /drift?from=&to=&window=<days>` | Enterprise | Weight-change events with per-provider spend-mix in the attribution window after each (default 14 d, max 90) |
+| `GET /recommendations` | Enterprise | Ranked from → to swaps with estimated monthly savings and confidence samples |
+| `GET /budgets`, `PUT /budgets` | Team+ | Budget CRUD (period, cap, alert thresholds, alert emails, hard_stop flag) |
+| `GET /export?dim=&from=&to=&format=csv` | Same as `/by` per dim | CSV export with `currency=USD` column, filename encodes tenant + dim + dates |
+
+### Budget hard-stop
+
+When `hard_stop=true` is set on a budget and current-period spend has hit the cap, every `/v1/chat/completions` call returns:
+
+```json
+{ "error": { "message": "Spend budget exceeded: 250.00 / 250.00 USD (monthly).", "type": "budget_exceeded" } }
+```
+
+with HTTP 402. The soft path (email-only) fires as thresholds are crossed regardless of the `hard_stop` setting.
+
+### Data model
+
+- **Attribution** — `requests.user_id` and `requests.api_token_id` (nullable, populated at ingest from the auth context); denormalized onto `cost_logs` so per-user / per-token aggregations hit a covering index without a join.
+- **Weight snapshots** — `routing_weight_snapshots(tenant_id, task_type, complexity, weights, captured_at)`, one row per tenant per day, only written when weights differ from the prior snapshot.
+- **Budgets** — `spend_budgets(tenant_id PK, period, cap_usd, alert_thresholds JSON, alert_emails JSON, hard_stop, alerted_thresholds JSON, period_started_at, ...)`.
+
+## Rate Limiting
+
+Two independent layers, by design:
+
+| Layer | Scope | Default | Purpose |
+|---|---|---|---|
+| Per-IP on `/auth/*` | IP | 20 / min | Credential stuffing + invite-token brute force |
+| Per-IP on `/v1/chat/completions` | IP | 200 rps | Global DoS floor |
+| Per-token on `/v1/chat/completions` | API token | `apiTokens.rateLimit` (nullable) | Programmatic budget lever, tenant-configurable per token |
+
+Exhaustion returns `HTTP 429` with `Retry-After` (seconds) and `X-RateLimit-Limit` / `X-RateLimit-Remaining` headers. Blocked calls from **authenticated** callers emit a `rate_limit.exceeded` audit event (suppressed at 1 / minute / tenant / endpoint so sustained bursts don't flood audit_logs); unauthenticated blocks log to stdout only.
+
+Pricing-tier quotas (Free 10k / Pro 100k / Team 500k / Ent custom requests per month) are a separate layer enforced by `requireQuota` + `usage-metering` — rate limit is per-second, quota is per-month.
+
+### Tuning
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `RATE_LIMIT_AUTH_PER_MIN` | `20` | Per-IP cap on `/auth/*` |
+| `RATE_LIMIT_CHAT_RPS` | `200` | Per-IP global DoS floor on `/v1/chat/completions` |
+| `RATE_LIMIT_INVITE_PER_MIN` | `20` | Per-IP cap on invite endpoints |
+
+## Invite-Mismatch Detection
+
+When a user clicks an invite link and then signs in with an OAuth account whose email doesn't match the invited email, the flow previously looked successful from Google/GitHub's side — but the invite stayed pending and the user landed in a fresh solo workspace.
+
+Now: the invite token is threaded from `/invite/[token]` → `/login` → gateway OAuth start (stored in a short-TTL `provara_oauth_invite` cookie alongside state/return). Both OAuth callbacks compare the invited email against the profile email case-insensitively. On mismatch, the user still gets signed up (their own workspace) but is redirected to `/dashboard?invite_status=wrong_email&expected=<email>` where a non-dismissible banner offers a one-click sign-out and retry. Already-consumed invites are treated as no-mismatch.
+
+## Master-Key Rotation
+
+`PROVARA_MASTER_KEY` encrypts one thing: the provider API keys stored via `/dashboard/api-keys` (table: `api_keys`, AES-256-GCM). Env-var-driven providers never touch it. A documented rotation CLI + runbook live under `docs/runbooks/master-key-rotation.md` — the short version:
+
+```sh
+# 1. Generate a new 32-byte hex key (store in your secrets manager)
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+
+# 2. Dry-run against prod (verifies every row decrypts with the old key)
+DATABASE_URL=... DATABASE_AUTH_TOKEN=... \
+  npm run key:rotate -w packages/gateway -- \
+    --old "$CURRENT_KEY" --new "$NEW_KEY" --dry-run
+
+# 3. Real rotation (same command, no --dry-run)
+# 4. Update PROVARA_MASTER_KEY env var on Railway and redeploy
+# 5. Verify a stored provider key still decrypts on the dashboard
+```
+
+The CLI uses a two-phase-with-decrypt-gate pattern: phase 1 decrypts every row with the old key into memory (aborts if any row fails), phase 2 re-encrypts with the new key row-by-row. See the runbook for failure-mode recovery.
+
 ## A/B Testing Guide
 
 ![A/B Tests](public/abtests.png)
@@ -661,13 +786,39 @@ curl -X POST http://localhost:4000/v1/chat/completions \
 | **Scheduler** (owner only) | |
 | `GET /v1/admin/scheduler/jobs` | List registered jobs with last-run state |
 | `POST /v1/admin/scheduler/jobs/:name/run` | Trigger a job immediately |
+| **Audit** (#210) | |
+| `GET /v1/audit-logs` | Tenant-scoped audit events with filters (`action`, `actor`, `since`, `until`, `cursor`, `format=json\|csv`, `limit`) — Team+ |
+| **Spend** (#219) | |
+| `GET /v1/spend/by` | Spend aggregation across `dim=provider\|model\|user\|token\|category` with the cross-cutting quality envelope and period-over-period delta |
+| `GET /v1/spend/trajectory` | MTD + linear-run-rate projection + prior-period total + anomaly flag (Team+) |
+| `GET /v1/spend/drift` | Weight-snapshot change events with per-provider spend mix in the attribution window after each (Enterprise) |
+| `GET /v1/spend/recommendations` | Same-quality cheaper-alternate recommendations ranked by estimated monthly savings (Enterprise) |
+| `GET /v1/spend/budgets`, `PUT /v1/spend/budgets` | Tenant budget CRUD |
+| `GET /v1/spend/export` | CSV export with the same filters as `/by` |
+| **Team** | |
+| `GET /v1/admin/team/members` | List tenant members |
+| `GET /v1/admin/team/invites` | List pending invites |
+| `POST /v1/admin/team/invites` | Create an invite (owner-only, seat-limit enforced) |
+| `DELETE /v1/admin/team/invites/:token` | Revoke a pending invite |
+| **Billing** | |
+| `POST /v1/billing/checkout-session` | Start a Stripe Checkout session |
+| `POST /v1/billing/portal-session` | Start a Stripe Customer Portal session |
+| `GET /v1/billing/subscription` | Current tenant subscription mirror |
+| `POST /v1/webhooks/stripe` | Stripe webhook receiver (HMAC-authenticated via `STRIPE_WEBHOOK_SECRET`) |
 | **Auth** (multi-tenant only) | |
-| `GET /auth/login/google` | Google OAuth login |
-| `GET /auth/login/github` | GitHub OAuth login |
+| `GET /auth/login/google` | Google OAuth login (accepts `?return=&invite_token=`) |
+| `GET /auth/login/github` | GitHub OAuth login (accepts `?return=&invite_token=`) |
+| `POST /auth/magic-link/request` | Request a magic-link email |
+| `POST /auth/magic-link/verify` | Consume a magic-link token and establish session |
+| `GET /auth/saml/discover` | SSO-discover for an email's domain (returns `{sso, startUrl?}`) |
+| `GET /auth/saml/:tenantId/start` | Begin SAML SSO flow for a tenant |
+| `POST /auth/saml/:tenantId/acs` | SAML ACS endpoint (IdP assertion consumer) |
 | `POST /auth/logout` | Sign out |
 | `GET /auth/me` | Current user |
 | **System** | |
 | `GET /health` | Health check + mode |
+
+The authoritative machine-readable spec lives at [`packages/gateway/openapi.yaml`](packages/gateway/openapi.yaml) — import into Yaak, Postman, or Insomnia.
 
 ## Providers
 

--- a/docs/runbooks/adding-a-provider.md
+++ b/docs/runbooks/adding-a-provider.md
@@ -1,0 +1,58 @@
+# Operator runbook: adding a new LLM provider
+
+Two paths depending on how much the new provider looks like OpenAI:
+
+- **OpenAI-compatible provider** (e.g. Fireworks, Together, Groq, DeepSeek, Z.ai) — no code change needed. Add keys via the dashboard, optionally set `baseURL` env, done.
+- **Native-API provider** (e.g. new Anthropic-shape endpoint, new streaming protocol) — requires a new adapter under `packages/gateway/src/providers/`. Estimate: 1–2 hours.
+
+## Path A — OpenAI-compatible
+
+1. **Add the API key** via `/dashboard/api-keys` on the affected tenant. Name it after the provider (e.g. `FIREWORKS_API_KEY`). The key is AES-256-GCM encrypted at rest with `PROVARA_MASTER_KEY`.
+
+2. **Set the base URL** via env if it's not `api.openai.com`. Example for Fireworks:
+
+   ```sh
+   # Railway env var on provara-gateway
+   FIREWORKS_BASE_URL=https://api.fireworks.ai/inference/v1
+   ```
+
+3. **Register the provider** by name. If it's not already in `packages/gateway/src/providers/index.ts` autoregister list, add an entry:
+
+   ```ts
+   registerOpenAICompatible({
+     name: "fireworks",
+     apiKeyEnv: "FIREWORKS_API_KEY",
+     baseUrlEnv: "FIREWORKS_BASE_URL",
+     defaultBaseUrl: "https://api.fireworks.ai/inference/v1",
+   });
+   ```
+
+4. **Add pricing** in `packages/gateway/src/cost/pricing.ts` (`MODEL_PRICING` record). Use per-1M-token `[input, output]` in USD. Missing entries default to `$0` cost which will break analytics rollups — don't skip this.
+
+5. **Deploy.** The provider's models are discovered at startup via the registry's `refreshModels` hook.
+
+6. **Verify.** Send a completion pinned to the new provider:
+
+   ```sh
+   curl -X POST https://gateway.provara.xyz/v1/chat/completions \
+     -H "Authorization: Bearer <your-token>" \
+     -H "Content-Type: application/json" \
+     -d '{"model":"accounts/fireworks/models/llama-v3p3-70b","messages":[{"role":"user","content":"hi"}]}'
+   ```
+
+## Path B — Native-API provider
+
+Use `packages/gateway/src/providers/anthropic.ts` as the cleanest template; it's a native adapter that also handles streaming + token counting.
+
+1. **Create `packages/gateway/src/providers/<provider>.ts`** implementing the `Provider` interface from `./types.ts` (`complete`, `completeStream`, optional `discoverModels`).
+2. **Handle streaming** — this is the trickiest part. Watch for first-chunk-fallback (empty chunks from the upstream API shouldn't be forwarded as SSE). The adapter must synthesize the `_provara` meta event at the end so the gateway knows the stream finished cleanly.
+3. **Add to the registry** in `packages/gateway/src/providers/index.ts` under the same `register(...)` pattern other native adapters use.
+4. **Pricing** in `cost/pricing.ts` as with Path A.
+5. **Tests** under `packages/gateway/tests/providers/<provider>.test.ts` — at minimum, assert the adapter handles `200 OK`, `4xx error`, and stream-aborted cases.
+6. **Deploy and verify** as Path A step 6.
+
+## Common gotchas
+
+- **Dashboard shows the provider but routing never picks it.** Adaptive router requires `MIN_SAMPLES` (default 5) of feedback before a cell routes to a model. Force traffic via a pinned `model` / `provider` for a few completions + judge sample to bootstrap. Set `PROVARA_MIN_SAMPLES=2` temporarily for faster cold-start.
+- **Tokens reported wrong.** The OpenAI-compatible adapter trusts the `usage` block in the upstream response. If a provider returns `null` for `input_tokens`, Provara falls back to counting characters / 4 — which is approximate. Patch the provider-specific adapter to do better counting if accurate cost attribution matters.
+- **Streaming cuts off early.** Often a keepalive timeout at Railway's edge. Either shorten `PROVARA_STREAM_TIMEOUT_MS` so client-side retry kicks in earlier, or disable streaming for that provider until it's debugged.

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,82 @@
+# Operator runbook: database backup & restore
+
+Provara's state lives in a single libSQL / Turso database. Nothing else on disk, no external caches, no secondary stores. This makes backup/restore straightforward.
+
+## Routine backups
+
+Turso runs point-in-time recovery (PITR) on all paid plans — the Scaler tier retains **14 days**, Starter retains **24 hours**. You generally don't need to take your own backups unless you want longer retention or off-provider copies.
+
+### Manual snapshot (for rotations, migrations, anything that writes many rows)
+
+Before anything risky, dump the state you're about to touch to a local file:
+
+```sh
+# Whole DB dump (Turso CLI)
+turso db shell provara-railway ".dump" > ./backups/provara_$(date +%Y%m%d_%H%M).sql
+
+# Specific table (e.g. the one you're about to migrate)
+railway run --service provara-gateway --environment production -- \
+  node -e "
+    const { createClient } = require('@libsql/client');
+    const c = createClient({ url: process.env.DATABASE_URL, authToken: process.env.DATABASE_AUTH_TOKEN });
+    c.execute('SELECT * FROM api_keys').then(r => console.log(JSON.stringify(r.rows, null, 2)));
+  " > ./backups/api_keys_$(date +%Y%m%d_%H%M).json
+```
+
+Keep snapshots under a **gitignored** path — the repo's `.gitignore` has `.local/` and `./backups/` isn't tracked by default, but verify before you commit anything.
+
+## Restore from Turso PITR
+
+When something goes wrong and you need to roll back:
+
+1. **Don't keep writing to prod.** Every new write narrows your PITR window. Take the gateway offline by scaling the Railway service to 0 replicas if you have time.
+2. **Pick the target timestamp.** Via Turso dashboard → Databases → `provara-railway` → Restore, or CLI:
+
+   ```sh
+   turso db restore provara-railway --timestamp "2026-04-18T22:30:00Z" --name provara-railway-restored
+   ```
+
+   Restoring creates a **new database**; it doesn't overwrite the original. The original stays intact while you validate.
+3. **Validate.** Point a local gateway at the restored DB URL and verify the rows you care about are in the expected state:
+
+   ```sh
+   DATABASE_URL=libsql://provara-railway-restored-<org>.aws-us-east-2.turso.io \
+   DATABASE_AUTH_TOKEN=... \
+     npm run dev -w packages/gateway
+   ```
+4. **Swap.** Two options:
+   - **Rename swap (canonical):** rename `provara-railway` to `provara-railway-corrupted-<date>`, then rename `provara-railway-restored` to `provara-railway`. The gateway's env-var URL stays the same; no redeploy needed if Turso keeps the hostname stable (it does, the hostname is derived from the DB name).
+   - **Config swap:** update `DATABASE_URL` on Railway to the restored DB's URL; redeploy. Simpler but leaves a non-obvious dependency on env var state.
+5. **Bring traffic back.** Scale replicas up, run smoke tests.
+
+## Restore from local dump
+
+If Turso PITR isn't available (e.g. Starter plan past the 24h window), fall back to a local `.sql` dump you took manually:
+
+```sh
+# Create a new blank DB
+turso db create provara-railway-restored
+
+# Stream the dump into it
+turso db shell provara-railway-restored < ./backups/provara_20260418_2230.sql
+```
+
+Then proceed as with PITR step 3 onward.
+
+## What the backup does and doesn't cover
+
+- **In backup:** all tenant data, subscriptions, audit logs, encrypted provider keys, model scores, requests, cost logs, budgets, routing-weight snapshots.
+- **Not in backup:**
+  - `PROVARA_MASTER_KEY` (env var on Railway — if you restore a DB encrypted under an old key, you **must** also restore the matching master key, or every provider key in `api_keys` will fail to decrypt)
+  - In-memory scheduler state (`running` set, interval timers) — rebuilds on next process start
+  - Semantic-cache embeddings (in-memory only; re-hydrate as traffic arrives)
+  - Upstream provider data (chat histories live on OpenAI/Anthropic/etc.; Provara only logs prompts + responses on its own side via the `requests` table)
+
+## Disaster scenarios we've actually hit
+
+| Scenario | First move |
+|---|---|
+| "Rotated `PROVARA_MASTER_KEY` but forgot to update the Railway env var" | Revert the env var to the old value — the DB is fine, only the running process is using the wrong key. No DB restore needed. |
+| "Accidentally deleted every row in `subscriptions`" | PITR restore to 5 minutes before. Keep the original; move the restored DB into place with rename-swap. |
+| "Turso region outage" | Can't restore during an outage — the provider is down. If you've been taking local `.sql` dumps (recommended before any risky op), bring up a dev gateway pointed at a local libSQL DB seeded from the dump, and flip `DATABASE_URL` / `DATABASE_AUTH_TOKEN` on Railway when Turso returns. |
+| "Write quota exhausted mid-deployment" | Enable overages (or upgrade plan) in the Turso dashboard. DB is intact; no restore needed. Redeploy the gateway to clear the crash loop. See `incident-response.md` §4. |

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -1,0 +1,113 @@
+# Operator runbook: incident response
+
+Top-level playbook for "the gateway is broken". Work top-down — most recent incidents have had simple causes. Specific cross-cutting runbooks (master-key rotation, DB backup/restore) are linked at the end.
+
+## 1. Confirm scope
+
+Before you troubleshoot anything, confirm blast radius.
+
+```sh
+# Does the gateway respond to /health?
+curl -sS -o /dev/null -w "%{http_code} %{time_total}s\n" https://gateway.provara.xyz/health
+
+# Is the dashboard up?
+curl -sS -o /dev/null -w "%{http_code}\n" https://www.provara.xyz
+```
+
+- Both return `200` → the platform is up, the incident is likely feature-level (a specific provider is down, a customer-specific query). Go to §5.
+- Gateway 5xx / timeout → §2.
+- Dashboard 5xx but gateway fine → §6.
+- Both down → §3.
+
+## 2. Gateway is down
+
+**Check Railway deploy status first.** The most common cause is that the latest deployment crashed and Railway stopped retrying.
+
+```sh
+railway status --json | grep -E '"status"|"commitMessage"' | head -10
+```
+
+- `"status": "SUCCESS"` and recent `createdAt` → deploy is live, something else is wrong; check logs in §2.3.
+- `"status": "CRASHED"` with `deploymentStopped: true` → §2.1.
+- `"status": "DEPLOYING"` for >5 min → §2.2.
+
+### 2.1 Gateway crashed and Railway gave up
+
+```sh
+railway logs --service provara-gateway --deployment | tail -50
+```
+
+Common crash causes (April 2026 dataset):
+
+| Log contains | Root cause | Fix |
+|---|---|---|
+| `SQL write operations are forbidden (writes are blocked, do you need to upgrade your plan?)` | Turso write-quota exhausted | Enable overages or upgrade plan in [app.turso.tech](https://app.turso.tech/account/billing) — then redeploy |
+| `PROVARA_MASTER_KEY is required` | Env var was removed or emptied on Railway | Restore the env var, redeploy |
+| `Error: listen EADDRINUSE` | Port collision (shouldn't happen on Railway, but can happen mid-rollout) | Redeploy — it'll grab a fresh container |
+| `Cannot find module` / `Error: Could not resolve` | Bad build (usually a missing dep in `package.json`) | Look at the most recent merged PR; roll it back if you can't fix forward in <5 min |
+
+Once fixed, redeploy:
+
+```sh
+railway redeploy --service provara-gateway --environment production
+```
+
+### 2.2 Gateway stuck deploying
+
+- Look at the build log in the Railway dashboard. A hanging `npm ci` usually means a registry outage; wait 10 min and retry.
+- If a test is running as part of CI and hanging: kill the deploy in the dashboard and check the failing test locally first.
+
+### 2.3 Gateway serving 5xx but process looks healthy
+
+```sh
+railway logs --service provara-gateway | tail -100
+```
+
+Look for:
+
+- **Repeated `LibsqlError`** — DB is down or blocked. Check Turso status page + quota.
+- **Repeated `[provider] ... failed`** — an upstream provider is down. Router's fallback should handle it; if it isn't, check whether all candidate providers for a common cell are down at once.
+- **Memory leak** — rare, but a slow RAM climb over hours can cause OOM restarts. Railway shows restart count; if >5 in the last hour, restart manually and open an issue.
+
+## 3. Full platform outage
+
+If both the gateway and dashboard are down, check upstream providers first:
+
+- [Turso status](https://status.turso.tech) — if their API is down, nothing we write or read works
+- [Railway status](https://status.railway.app) — deploys and serves everything
+- [Vercel status](https://status.vercel.com) — not currently used for web, but OAuth redirect URLs can traverse their CDN
+- [Resend status](https://resend.com/status) — email-only, doesn't affect gateway availability but blocks new signups
+
+If everything upstream is green and we're still fully down, it's probably a Railway networking issue with our project specifically — open a Railway support ticket with the project + deployment IDs from `railway status --json`.
+
+## 4. Database quota exhausted
+
+**Symptom:** gateway crash-loop, logs show `SQL write operations are forbidden`.
+
+**Fix in place:** go to [Turso org billing](https://app.turso.tech/account/billing) and either (a) enable overages on the current plan, or (b) upgrade to the next tier. Overages unblock instantly. Then redeploy the gateway:
+
+```sh
+railway redeploy --service provara-gateway --environment production
+```
+
+**Follow-up:** file (or reuse) the write-hot-paths audit issue. Hitting the Starter quota on near-zero traffic is a signal of over-writing elsewhere in the code.
+
+## 5. Feature-level incident
+
+Platform up, specific feature broken. Examples from past incidents:
+
+- **"Chat completions return 402 budget_exceeded unexpectedly"** — `GET /v1/spend/budgets` for the affected tenant; check if `hard_stop=true` and spend >= cap.
+- **"Invite flow silently drops"** — ask the user whether they signed in with the email the invite was sent to; if not, they should see the `/dashboard?invite_status=wrong_email` banner. If they don't, the token may not have threaded through — check the `/auth/login/*` handler stored `provara_oauth_invite` cookie.
+- **"Dashboard provider-key decrypt fails"** — either the DB was restored without the matching `PROVARA_MASTER_KEY`, or rotation completed but the env var wasn't swapped. See `master-key-rotation.md` failure modes.
+- **"Rate-limit 429s on normal traffic"** — look at `RATE_LIMIT_*` env vars; if someone tightened them mid-incident, they may still be tight. Defaults: `AUTH_PER_MIN=20`, `CHAT_RPS=200`, `INVITE_PER_MIN=20`.
+
+## 6. Dashboard down, gateway fine
+
+- Check the web service's Railway status; it's a separate service (`provara-web`).
+- Most dashboard outages are build failures — the Next app is stateless and recovers cleanly on redeploy.
+
+## Related runbooks
+
+- [Master-key rotation](master-key-rotation.md)
+- [Adding a provider](adding-a-provider.md)
+- [Backup & restore](backup-restore.md)

--- a/docs/self-host-vs-cloud.md
+++ b/docs/self-host-vs-cloud.md
@@ -1,0 +1,72 @@
+# Self-host vs. Provara Cloud — picking your path
+
+Provara ships two ways. This page helps you pick.
+
+## The short answer
+
+| You… | Pick |
+|---|---|
+| Want the gateway + dashboard running on your own infrastructure, single-tenant, no third-party hop | **Self-host** |
+| Want a managed URL to point your SDK at, dashboard pre-configured, we handle ops | **Provara Cloud** (Team+ tier for full feature set) |
+| Have a compliance/data-residency requirement that prevents prompts from traversing a third party | **Self-host**, period |
+| Are an individual or small team evaluating the product | **Self-host for free** or **Cloud Free tier** — pick whichever's faster for you |
+
+## Feature parity
+
+Both paths run the same codebase. The intelligence features (adaptive routing, A/B tests, silent-regression detection, cost migration, semantic cache, audit logs, spend intelligence) are in the OSS gateway and work on both. Tier-gated features on Cloud are gated on self-host too, but with different enforcement — see "Licensing & tier gates" below.
+
+| Feature | Self-host | Cloud Free | Cloud Pro | Cloud Team | Cloud Enterprise |
+|---|---|---|---|---|---|
+| Gateway + dashboard | ✅ | ✅ | ✅ | ✅ | ✅ |
+| BYOK providers | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Adaptive routing | ✅ | ✅ | ✅ | ✅ | ✅ |
+| A/B tests (manual + auto) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Silent-regression detection | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Auto cost migration | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Guardrails (PII, content, regex) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Audit logs | ✅ (unlimited retention) | ❌ | ❌ | ✅ (365 d) | ✅ (730 d) |
+| Spend intelligence (provider/model/category) | ✅ | ❌ | ❌ | ✅ | ✅ |
+| Per-user/per-token spend attribution | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Weight-drift analysis | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Savings recommendations | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Budgets + alerts + hard-stop | ✅ | ❌ | ❌ | ✅ | ✅ |
+| SAML SSO | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Managed ops (we handle uptime, scaling) | ❌ | ✅ | ✅ | ✅ | ✅ |
+| Monthly request quota | Your infra | 10,000 | 100,000 | 500,000 | Custom |
+| Overage billing | — | Hard cutoff | $0.50 / 1k | $0.50 / 1k | Custom |
+
+The "Cloud Free" restrictions on intelligence features are the **monetization boundary**, not a capability gap. The code to run adaptive routing + regression + cost migration exists in every deployment; Cloud enforces tier gates via `requireIntelligenceTier` / `requireEnterpriseTier` middleware and a live Stripe subscription. Self-host deployments skip these gates entirely — run everything.
+
+## When self-host wins
+
+- **Data residency / compliance.** Prompts and responses never leave your perimeter. This is load-bearing for healthcare, finance, public sector, and many EU buyers.
+- **Cost at scale.** If your monthly request volume is large enough that the Cloud overage rate ($0.50 / 1k) exceeds your fully-loaded ops cost for running a gateway, self-host is cheaper.
+- **Custom providers.** Self-host lets you wire up any OpenAI-compatible endpoint (including on-prem or open-weights inference you're running yourself). Cloud supports BYOK to any public provider, but not on-prem endpoints on our network.
+- **Full audit retention.** Self-host can keep audit logs indefinitely — retention is an app-level policy you control. Cloud tiers cap retention per plan.
+- **Modify the code.** BSL allows non-production modification freely; commercial production modification requires a conversation with us. Either way you have the source.
+
+## When Cloud wins
+
+- **Fast to "hello world."** Sign up → click "Add Google OAuth key" → send your first completion through a gateway we're operating. No infra to set up.
+- **No ops burden.** Turso, Railway, Stripe, Resend — all configured. You get the URL, dashboard, invites flow, SSO config, email template, and webhook pipeline for free.
+- **Intelligence features pre-tuned.** Regression thresholds, migration safety windows, replay bank sampling — all defaulted sensibly with monitored infra so we can tune if we see weirdness. Self-hosters tune their own.
+- **Upgrades handled.** When we ship `feat(#N)` we deploy it; you get it. Self-host upgrades are a `git pull` + migrate + redeploy you have to do yourself.
+- **Compliance story.** Cloud ships with a documented SOC 2-aligned audit log, encrypted key storage, and tier-gated retention. Useful for buyers whose procurement will ask.
+
+## Moving between them
+
+- **Cloud → self-host.** Export your data: dashboard → Settings → Export Data (dumps tenant rows + subscription snapshot). Run the gateway locally, import the dump, point SDK clients at your URL. We don't lock your data in.
+- **Self-host → Cloud.** Create a Cloud account, use the same Export → Import flow in reverse. Because the schemas are identical, the import is a straight row copy under a new `tenant_id`.
+
+## Licensing & tier gates
+
+Self-host and Cloud use the same BSL-licensed source. The difference is enforcement:
+
+- **Self-host** checks `PROVARA_CLOUD=false` (default) and bypasses tier gates. Everything is available. Modification is permitted for non-production use; commercial production use requires a license.
+- **Cloud** runs with `PROVARA_CLOUD=true` and enforces `requireIntelligenceTier` / `requireEnterpriseTier` based on the tenant's Stripe subscription.
+
+Code architecture: there's no split repo and no license gate at build time. The tier checks are `if (isCloudDeployment()) { enforce; } else { pass; }`. This means self-hosters get every intelligence feature unlocked by default.
+
+## Still not sure?
+
+Spin up self-host in 5 minutes (see `README.md` → Quick Start), kick the tires, and if you decide you'd rather we operate it — open a Cloud account. Your data migrates cleanly.


### PR DESCRIPTION
## Summary

Cleanup pass to backfill docs for everything that shipped over the last ~dozen PRs. Phase (a) of the docs initiative — phase (b) is scaffolding a proper docs site at `docs.provara.xyz`, deferred to a follow-up session.

## What's new

### README
New sections covering features that landed since the last doc update:
- **Audit logs (#210)** — event vocabulary, retention tiers, access surfaces, emission pattern
- **Spend intelligence (#219)** — the seven analytical views, endpoint table, budget hard-stop contract, data model
- **Rate limiting (#192)** — two-layer design, env vars, 429 contract, note on relationship to monthly quotas
- **Invite-mismatch detection (#189)** — token threading, wrong-OAuth-account banner flow
- **Master-key rotation (#190)** — pointer to the runbook + short-version CLI
- Feature bullet list grew SAML SSO, wrong-OAuth-account detection, budgets, per-IP rate limiting

API endpoint table extended: `/v1/audit-logs`, all six `/v1/spend/*`, `/v1/admin/team/*`, `/v1/billing/*`, full `/auth/*` surface (magic-link + OAuth + SAML). Pointer to `openapi.yaml` as canonical spec.

### New runbooks under `docs/runbooks/`
- **`incident-response.md`** — top-level "gateway is broken" playbook with §1 triage → §2 gateway crash → §3 full outage → §4 DB quota → §5 feature-level → §6 dashboard-only decision tree. Fixtable of past-incident signatures (Turso write-block, missing env var, port collision, bad build).
- **`adding-a-provider.md`** — Path A (OpenAI-compatible) and Path B (native adapter) walkthroughs, plus common gotchas.
- **`backup-restore.md`** — Turso PITR, manual `.dump`, disaster scenarios we've actually hit.

### Cross-cutting docs
- **`CONTRIBUTING.md`** — BSL terms, dev setup, test expectations, commit conventions (shiplog workflow), code style, security disclosure path.
- **`docs/self-host-vs-cloud.md`** — feature parity matrix, when each path wins, migration in both directions, the licensing/tier-gate model explained.

## What I deferred

- **Phase (b) docs site** at `docs.provara.xyz` (Fumadocs or Nextra as `apps/docs`) — separate session. Scope estimate in the earlier conversation stood at ~1 day for scaffold + initial content port.
- **Dashboard user guide** (per-page walkthrough) — belongs in the docs site with screenshots, not in the README.
- **Fresh screenshots of `/dashboard/audit` and `/dashboard/spend`** — existing `public/*.png` covers most of the UI; new ones will land when we do the docs site + playwright.

## Test plan

- [ ] Read `README.md` top-to-bottom; confirm no broken anchors and every new feature's section reads clean.
- [ ] Skim each new runbook; verify the commands (where relevant) are safe to reference from an incident.
- [ ] `CONTRIBUTING.md` — confirm the BSL summary is accurate and commit/PR conventions match current practice.
- [ ] `docs/self-host-vs-cloud.md` — confirm the tier parity matrix matches what Stripe's catalog actually exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
