### PR TITLE
fix: honor complexityHint on the classification routing path

### DIFF
--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -154,10 +154,13 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
       }
     }
 
-    // Classify the request
+    // Classify the request. Caller-supplied `routingHint` / `complexityHint`
+    // always win over the classifier — the hints are an explicit claim that
+    // the caller knows better than the heuristic (e.g. a schema-heavy
+    // request where a short user message still demands a capable model).
     const classification = await classifyRequest(request.messages, config.registry);
     const taskType: TaskType = request.routingHint || classification.taskType;
-    const complexity: Complexity = classification.complexity;
+    const complexity: Complexity = request.complexityHint || classification.complexity;
 
     const { abTestPreempts } = getRoutingConfig();
     const profile = request.routingProfile || "balanced";

--- a/packages/gateway/tests/router.test.ts
+++ b/packages/gateway/tests/router.test.ts
@@ -51,6 +51,29 @@ describe("routing engine", () => {
       expect(result.complexity).toBe("complex");
     });
 
+    it("honors complexityHint on the CLASSIFICATION path (no provider pin) — regression for the dropped-hint bug", async () => {
+      // Short user message that the heuristic classifier would normally
+      // label `simple`. With a `complexityHint: "complex"` the hint must
+      // override so the caller's explicit claim ("I know this needs a
+      // capable model") routes to the complex cell.
+      const db = await makeTestDb();
+      const registry = makeFakeRegistry([
+        makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+        makeFakeProvider({ name: "anthropic", models: ["claude-sonnet-4-6"] }),
+      ]);
+      const engine = await createRoutingEngine({ registry, db });
+
+      const result = await engine.route({
+        messages: [{ role: "user", content: "hi" }],
+        routingHint: "coding",
+        complexityHint: "complex",
+        // no provider / model pin → hits the classification path
+      });
+
+      expect(result.taskType).toBe("coding");
+      expect(result.complexity).toBe("complex");
+    });
+
     it("resolves model-only pin through getForModel to the correct provider", async () => {
       const db = await makeTestDb();
       const registry = makeFakeRegistry([


### PR DESCRIPTION
## Summary

Hot-fix: `request.complexityHint` was dropped on the classification routing path. Caller sends `complexity_hint: "complex"` → classifier sees a short message → labels it `simple` → adaptive router sends to gpt-4.1-nano → model fails to follow schema → UI breaks.

One-line change + a regression test. The user-override branch already honored the hint; this just mirrors the symmetric `routingHint || classification.taskType` pattern for complexity.

## Test plan

- [x] `npm test -w packages/gateway` — 510/510 green
- [ ] Deploy and re-run the originating UAT flow with `complexity_hint: "complex"` — expect the routing meta to show `complexity: "complex"` and to route to a capable model, not gpt-4.1-nano

🤖 Generated with [Claude Code](https://claude.com/claude-code)
