### PR TITLE
chore: route legal / privacy / security email to CoreLumen domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Provara is a self-hostable LLM operations platform. Contributions are welcome ac
 Provara is licensed under the **Business Source License 1.1** (BSL). In short:
 
 - **Non-production use** (evaluation, development, internal experimentation): free and unrestricted.
-- **Production use:** free for individuals and small organizations. Commercial production use by larger organizations requires a license from CoreLumen, LLC (legal@provara.xyz).
+- **Production use:** free for individuals and small organizations. Commercial production use by larger organizations requires a license from CoreLumen, LLC (legal@corelumen.io).
 - **Change date:** each release converts to Apache 2.0 four years after its release date.
 
 If this model isn't compatible with how you want to use Provara, reach out — there's a path for most cases.
@@ -85,9 +85,9 @@ See the root `README.md` for the full picture. The elevator version:
 
 ## Reporting security issues
 
-**Do not open a public issue for security vulnerabilities.** Email security@provara.xyz instead. We'll acknowledge within 48 hours, fix, and coordinate disclosure.
+**Do not open a public issue for security vulnerabilities.** Email security@corelumen.io instead. We'll acknowledge within 48 hours, fix, and coordinate disclosure.
 
 ## Questions
 
-- General: open a discussion or hit the team email at legal@provara.xyz (yes, legal is currently the catch-all — this will split out as volume grows)
+- General: open a discussion or hit the team email at legal@corelumen.io (yes, legal is currently the catch-all — this will split out as volume grows)
 - Real-time: we don't currently run a public Slack/Discord; watch the releases page for updates.

--- a/README.md
+++ b/README.md
@@ -928,4 +928,4 @@ Provara is source-available under the **Business Source License 1.1**. See [`LIC
 
 The BSL auto-converts to the MIT License four years after each version is published. Individual versions become fully permissive over time; the commercial-competition restriction applies only during the window.
 
-Provara is operated by CoreLumen, LLC. For commercial licensing questions, contact legal@provara.xyz.
+Provara is operated by CoreLumen, LLC. For commercial licensing questions, contact legal@corelumen.io.

--- a/apps/web/src/app/dashboard/billing/page.tsx
+++ b/apps/web/src/app/dashboard/billing/page.tsx
@@ -343,7 +343,7 @@ function BillingPageInner() {
           </div>
 
           <div className="mt-4 text-xs text-zinc-500">
-            Need more? <a href="mailto:legal@provara.xyz" className="text-blue-400 hover:text-blue-300">Contact sales</a> for Enterprise pricing (unlimited seats, SLA, dedicated support).
+            Need more? <a href="mailto:legal@corelumen.io" className="text-blue-400 hover:text-blue-300">Contact sales</a> for Enterprise pricing (unlimited seats, SLA, dedicated support).
           </div>
         </section>
       )}

--- a/apps/web/src/app/enterprise-data-handling/page.tsx
+++ b/apps/web/src/app/enterprise-data-handling/page.tsx
@@ -78,7 +78,7 @@ export default function EnterpriseDataHandlingPage() {
             <h2 className="text-lg font-semibold mb-3">Audit log</h2>
             <p className="text-zinc-400 leading-relaxed">
               Every change to your routing isolation toggles is recorded in an append-only audit log with a timestamp, the actor who made the change, the previous value, and the new value. Upon written request to{" "}
-              <a href="mailto:privacy@provara.xyz" className="text-blue-400 hover:text-blue-300">privacy@provara.xyz</a>
+              <a href="mailto:privacy@corelumen.io" className="text-blue-400 hover:text-blue-300">privacy@corelumen.io</a>
               , we will provide a report of toggle changes for your tenant within ten business days.
             </p>
           </section>
@@ -111,7 +111,7 @@ export default function EnterpriseDataHandlingPage() {
             <h2 className="text-lg font-semibold mb-3">Contact</h2>
             <p className="text-zinc-400 leading-relaxed">
               For questions about this addendum or to exercise any right described above, contact{" "}
-              <a href="mailto:legal@provara.xyz" className="text-blue-400 hover:text-blue-300">legal@provara.xyz</a>
+              <a href="mailto:legal@corelumen.io" className="text-blue-400 hover:text-blue-300">legal@corelumen.io</a>
               .
             </p>
           </section>

--- a/apps/web/src/app/pricing/pricing-table.tsx
+++ b/apps/web/src/app/pricing/pricing-table.tsx
@@ -62,7 +62,7 @@ function TierCard({ plan, annual }: { plan: PricingPlan; annual: boolean }) {
   const suffix = annual ? "/yr" : "/mo";
 
   function ctaHref(): string {
-    if (plan.ctaKind === "contact") return "mailto:legal@provara.xyz?subject=Provara%20Enterprise%20inquiry";
+    if (plan.ctaKind === "contact") return "mailto:legal@corelumen.io?subject=Provara%20Enterprise%20inquiry";
     if (plan.ctaKind === "signup") return user ? "/dashboard" : "/login";
     // checkout
     return user ? "/dashboard/billing" : `/login?return=${encodeURIComponent("/dashboard/billing")}`;

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -148,7 +148,7 @@ export default function PrivacyPage() {
             <h2 className="text-lg font-semibold mb-3">Your Rights</h2>
             <p className="text-zinc-400 leading-relaxed">
               You can access, export, or delete your data at any time. To request data deletion or if you have questions about this policy, contact CoreLumen, LLC at{" "}
-              <a href="mailto:privacy@provara.xyz" className="text-blue-400 hover:text-blue-300">privacy@provara.xyz</a>.
+              <a href="mailto:privacy@corelumen.io" className="text-blue-400 hover:text-blue-300">privacy@corelumen.io</a>.
             </p>
           </section>
 

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -104,7 +104,7 @@ export default function TermsPage() {
             <h2 className="text-lg font-semibold mb-3">11. Contact</h2>
             <p className="text-zinc-400 leading-relaxed">
               Questions about these terms? Contact CoreLumen, LLC at{" "}
-              <a href="mailto:legal@provara.xyz" className="text-blue-400 hover:text-blue-300">legal@provara.xyz</a>.
+              <a href="mailto:legal@corelumen.io" className="text-blue-400 hover:text-blue-300">legal@corelumen.io</a>.
             </p>
           </section>
         </div>

--- a/apps/web/src/lib/pricing.ts
+++ b/apps/web/src/lib/pricing.ts
@@ -203,7 +203,7 @@ export const FAQS = [
   },
   {
     q: "How do I talk to a human about Enterprise pricing?",
-    a: "Email legal@provara.xyz — include your expected request volume, team size, and any compliance or SLA requirements. We'll get back within one business day with a tailored quote.",
+    a: "Email legal@corelumen.io — include your expected request volume, team size, and any compliance or SLA requirements. We'll get back within one business day with a tailored quote.",
   },
   {
     q: "How is my routing data isolated on Team and Enterprise?",

--- a/packages/gateway/src/email/templates.ts
+++ b/packages/gateway/src/email/templates.ts
@@ -40,7 +40,7 @@ function emailShell(title: string, body: string): string {
                 &nbsp;&middot;&nbsp;
                 <a href="https://www.provara.xyz/pricing" style="color:#60a5fa; text-decoration:none;">Pricing</a>
                 &nbsp;&middot;&nbsp;
-                <a href="mailto:legal@provara.xyz" style="color:#60a5fa; text-decoration:none;">Contact</a>
+                <a href="mailto:support@corelumen.io" style="color:#60a5fa; text-decoration:none;">Contact</a>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Bouncing mail hurts more than seeing @corelumen.io in the UI. CoreLumen is the parent entity anyway (Provara + Divita are products under it). Updates 9 files — README, CONTRIBUTING, 5 web pages, pricing lib, email template footer. Test fixture strings left unchanged (synthetic test data).