### PR TITLE
fix: /v1/billing/usage returns unlimited quota for operator tenants

### DIFF
--- a/packages/gateway/src/routes/billing.ts
+++ b/packages/gateway/src/routes/billing.ts
@@ -7,7 +7,7 @@ import { getSubscriptionForTenant } from "../stripe/subscriptions.js";
 import { getStripe } from "../stripe/index.js";
 import { getOperatorEmails } from "../config.js";
 import { users } from "@provara/db";
-import { listRecentUsageReports, TIER_QUOTAS } from "../billing/usage.js";
+import { isOperatorTenantForQuota, listRecentUsageReports, TIER_QUOTAS } from "../billing/usage.js";
 
 /**
  * Billing routes (#169). Dashboard-facing endpoints for reading the
@@ -103,6 +103,35 @@ export function createBillingRoutes(db: Db) {
     const tenantId = getTenantId(c.req.raw);
     if (!tenantId) {
       return c.json({ error: { message: "Authentication required.", type: "auth_error" } }, 401);
+    }
+
+    // Operator tenants bypass the subscription → tier → quota chain so
+    // the usage bar renders "unlimited" rather than capping at the Free-
+    // tier 10k. `/billing/me` already applies this same bypass; without
+    // the mirror here, the dashboard shows tier=operator + quota=10k,
+    // which is internally inconsistent and misreads the limit for
+    // employee accounts.
+    if (await isOperatorTenantForQuota(db, tenantId)) {
+      const now = new Date();
+      const periodStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+      const row = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(requestsTable)
+        .where(and(
+          eq(requestsTable.tenantId, tenantId),
+          gte(requestsTable.createdAt, periodStart),
+        ))
+        .get();
+      return c.json({
+        tier: "operator",
+        periodStart,
+        periodEnd: null,
+        used: row?.count ?? 0,
+        quota: Number.MAX_SAFE_INTEGER,
+        quotaUnlimited: true,
+        remaining: Number.MAX_SAFE_INTEGER,
+        percentUsed: 0,
+      });
     }
 
     const sub = await getSubscriptionForTenant(db, tenantId);

--- a/packages/gateway/tests/billing.test.ts
+++ b/packages/gateway/tests/billing.test.ts
@@ -138,16 +138,20 @@ describe("/v1/billing/usage", () => {
   });
 
   it("marks quota unlimited for operator tenants", async () => {
+    // Operator tenants don't have a `subscriptions` row, but they must
+    // still surface as tier=operator with an unlimited quota — otherwise
+    // the dashboard billing page displays tier=operator on the badge
+    // (from /billing/me) but quota=10,000 on the usage bar (from
+    // /billing/usage), which is internally inconsistent and misreads
+    // the limit for employee accounts.
     await seedOperatorUser(db, "op-tenant", "ops@corelumen.com");
     const app = buildApp(db);
     const res = await app.request("/v1/billing/usage", { headers: { "x-test-tenant": "op-tenant" } });
     const body = await res.json();
-    // Operator tier falls through subscription lookup; quota is "free" fallback
-    // since operators don't have subscription rows. The operator tier's
-    // includesIntelligence path lives in /me, but /usage uses the tier from
-    // the subscription which is absent → free. That's fine — operators
-    // aren't billed anyway.
-    expect(body.tier).toBe("free");
+    expect(body.tier).toBe("operator");
+    expect(body.quotaUnlimited).toBe(true);
+    expect(body.percentUsed).toBe(0);
+    expect(body.periodEnd).toBeNull();
   });
 });
 


### PR DESCRIPTION
UAT: operator account in `/dashboard/billing` showed tier=operator on the badge but max=10,000 on the usage bar. Mirrors the operator bypass /billing/me already applies. Existing test codified the bug as intentional — rewrote to assert correct contract. 510/510.