### PR TITLE
fix(#225): stop scheduler tick storm + clamp misconfigured intervalMs

### DIFF
--- a/packages/gateway/src/scheduler/index.ts
+++ b/packages/gateway/src/scheduler/index.ts
@@ -104,8 +104,15 @@ export function createScheduler(db: Db) {
     // Atomic check-and-set before any await so concurrent calls cannot both
     // pass the guard. Without this, two runNow() calls both see an empty
     // `running` set, then both enter the async body and double-fire.
+    //
+    // When the guard blocks, we intentionally DON'T call `recordRun` — doing
+    // so would write to `scheduled_jobs` on every blocked tick, which at
+    // high firing rates (e.g. a misconfigured `intervalMs=7` fires ~143x/sec)
+    // amplifies DB writes catastrophically. The previous run is still alive
+    // and its final status will be recorded when it finishes; the in-memory
+    // `running` set is the authoritative "is this busy?" signal anyway.
+    // See #225 for the incident that motivated this.
     if (running.has(name)) {
-      await recordRun(name, "skipped", 0, "previous run still in progress");
       return;
     }
     running.add(name);
@@ -141,10 +148,26 @@ export function createScheduler(db: Db) {
     if (started) armTimer(job);
   }
 
+  /**
+   * Minimum acceptable `intervalMs`. Any value below this is treated as a
+   * misconfiguration (see #225: `PROVARA_REPLAY_CYCLE_INTERVAL_MS=7` was set
+   * thinking "7 days" and the scheduler fired ~143x/sec until Turso cut off
+   * writes). Clamping + loud warn is safer than honoring the value.
+   */
+  const MIN_INTERVAL_MS = 60_000;
+
   function armTimer(job: JobRegistration): void {
     if (timers.has(job.name)) {
       clearTimeout(timers.get(job.name)!);
       clearInterval(timers.get(job.name)!);
+    }
+    if (job.intervalMs < MIN_INTERVAL_MS) {
+      console.warn(
+        `[scheduler] job "${job.name}" configured with intervalMs=${job.intervalMs} ` +
+        `(below ${MIN_INTERVAL_MS}ms minimum) — likely misconfigured. Clamping to ${MIN_INTERVAL_MS}ms. ` +
+        `If you meant days, multiply by 86_400_000.`,
+      );
+      job = { ...job, intervalMs: MIN_INTERVAL_MS };
     }
     const delay = job.initialDelayMs ?? job.intervalMs;
     const first = setTimeout(() => {

--- a/packages/gateway/tests/scheduler.test.ts
+++ b/packages/gateway/tests/scheduler.test.ts
@@ -101,7 +101,11 @@ describe("scheduler", () => {
     await expect(scheduler.runNow("nope")).rejects.toThrow(/unknown job/);
   });
 
-  it("skips overlapping runs of the same job", async () => {
+  it("skips overlapping runs of the same job without writing to scheduled_jobs", async () => {
+    // #225 regression: when a tick fires while the previous run is still
+    // in progress, we silently skip and DO NOT call recordRun. Writing on
+    // every blocked tick amplified by a misconfigured intervalMs caused
+    // the Turso 10M-writes-in-a-month quota burn.
     const scheduler = createScheduler(db);
     let running = 0;
     let maxConcurrent = 0;
@@ -126,8 +130,39 @@ describe("scheduler", () => {
 
     expect(maxConcurrent).toBe(1);
     const row = await db.select().from(scheduledJobs).where(eq(scheduledJobs.name, "slow-job")).get();
-    // Second call recorded as skipped
-    expect(["ok", "skipped"]).toContain(row?.lastStatus);
+    // First call completes as "ok"; second call silently no-ops and does
+    // not overwrite the row with a "skipped" status.
+    expect(row?.lastStatus).toBe("ok");
+    expect(row?.runCount).toBe(1);
+  });
+
+  it("clamps intervalMs below 60s to the minimum — #225 misconfiguration guard", async () => {
+    // Ops set `PROVARA_REPLAY_CYCLE_INTERVAL_MS=7` thinking "7 days" but
+    // the var is milliseconds. Scheduler fired ~143 times/sec until Turso
+    // cut off writes. This test encodes that a too-small intervalMs is
+    // clamped rather than honored.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const scheduler = createScheduler(db);
+    let runs = 0;
+    await scheduler.schedule({
+      name: "misconfigured-job",
+      intervalMs: 7,           // the bug
+      initialDelayMs: 0,
+      handler: () => { runs++; },
+    });
+    scheduler.start();
+
+    await wait(200);
+    scheduler.stop();
+
+    // At the 7ms setting there would be ~28 firings in 200ms. With the
+    // 60s clamp, only the initial immediate-fire runs.
+    expect(runs).toBeLessThanOrEqual(2);
+    expect(warnSpy).toHaveBeenCalled();
+    const msg = warnSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(msg).toMatch(/intervalMs=7/);
+    expect(msg).toMatch(/below 60000ms minimum/i);
+    warnSpy.mockRestore();
   });
 
   it("getJobs returns persisted state", async () => {


### PR DESCRIPTION
## Summary

Root-caused the 10M-writes-per-month Turso quota burn (issue #225): a single misconfigured env var (`PROVARA_REPLAY_CYCLE_INTERVAL_MS=7`) was firing the scheduler ~143x/second, and each blocked attempt wrote to `scheduled_jobs` via the `"skipped"` branch of `recordRun`. Total DB size is still only ~700 rows; the writes were the UPDATE churn amplified by the tick storm.

## Empirical evidence (from prod)

```
runCount  intervalMs  lastStatus  name
    3003           7  skipped     replay-execute       ← the bug
      70    86400000  ok          auto-ab
      67    86400000  ok          replay-bank-populate
       ...
```

Every other job's `intervalMs` is 86,400,000 (24h). `replay-execute`'s is 7 — literal milliseconds. The `skipped` runCount of 3003 is only the non-skipped counter; actual skips were ~1.2M/day.

## Fix layers

**1. Write-path fix** — don't write to `scheduled_jobs` when the busy-guard blocks a tick. The `running: Set<string>` is already the authoritative "busy?" signal; DB writes on every blocked tick just amplified the damage.

**2. Config guard** — `armTimer` now clamps `intervalMs < 60_000` to 60s and logs a loud warning with guidance (`"If you meant days, multiply by 86_400_000"`). Makes the same mistake impossible to exploit again.

## Required ops action alongside merge

**On Railway, delete `PROVARA_REPLAY_CYCLE_INTERVAL_MS` env var** (or set to `604800000` / 7 days explicitly — code default also = 7 days).

Without that, the clamp keeps the firing rate sane (60s minimum) but the stored value in `scheduled_jobs` will still read `7` until the gateway restarts and `upsertState` rewrites it with the clamped value.

## Test plan

- [x] `npm test -w packages/gateway` — 511/511 (new test + updated overlapping-runs test)
- [ ] Deploy, verify the Railway logs show `[scheduler] started with 8 job(s)` and **no** `intervalMs=7 ... Clamping` warning once the env var is removed
- [ ] After a 24h soak, re-run the table count query — `scheduled_jobs.run_count` for `replay-execute` should barely increment (weekly cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
