### PR TITLE
feat(#229): public read-only demo tenant at /demo

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import { DashboardNav } from "../../components/dashboard-nav";
+import { DemoBanner } from "../../components/demo-banner";
 
 export default function DashboardLayout({
   children,
@@ -6,9 +7,12 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex min-h-screen">
-      <DashboardNav />
-      <main className="flex-1 ml-56">{children}</main>
+    <div className="flex min-h-screen flex-col">
+      <DemoBanner />
+      <div className="flex flex-1">
+        <DashboardNav />
+        <main className="flex-1 ml-56">{children}</main>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/demo-banner.tsx
+++ b/apps/web/src/components/demo-banner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useAuth } from "../lib/auth-context";
+
+/**
+ * Read-only demo banner (#229). Renders only when the caller's session
+ * is a demo session (`/auth/me` returns `isDemo: true`). Non-dismissible
+ * — a demo visitor losing this context and then wondering why write
+ * actions 403 is the worst UX outcome.
+ *
+ * Sits above the dashboard nav at `z-[60]` so it stays visible even if
+ * individual pages stack banners (e.g. the invite-mismatch banner).
+ */
+export function DemoBanner() {
+  const { isDemo } = useAuth();
+  if (!isDemo) return null;
+
+  return (
+    <div className="sticky top-0 z-[60] bg-gradient-to-r from-blue-700 to-violet-700 text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex items-center justify-between gap-3 flex-wrap">
+        <p className="text-sm">
+          <span className="font-semibold">You're in demo mode.</span>{" "}
+          <span className="text-white/80">
+            Data is pre-seeded and resets nightly. Writes are disabled on this session.
+          </span>
+        </p>
+        <a
+          href="/login"
+          className="shrink-0 px-3 py-1.5 rounded-md bg-white text-zinc-900 text-sm font-medium hover:bg-zinc-100 transition-colors"
+        >
+          Sign up →
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth-context.tsx
+++ b/apps/web/src/lib/auth-context.tsx
@@ -15,12 +15,15 @@ interface User {
 interface AuthContextValue {
   user: User | null;
   loading: boolean;
+  /** True when the current session is a public read-only demo session (#229). */
+  isDemo: boolean;
   logout: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   user: null,
   loading: true,
+  isDemo: false,
   logout: async () => {},
 });
 
@@ -53,10 +56,11 @@ const PG_USER_KEY = "pg:user_id";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [isDemo, setIsDemo] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    gatewayClientFetch<{ user: User | null }>("/auth/me")
+    gatewayClientFetch<{ user: User | null; isDemo?: boolean }>("/auth/me")
       .then((data) => {
         if (typeof window !== "undefined") {
           const stashedId = sessionStorage.getItem(PG_USER_KEY);
@@ -70,6 +74,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
         }
         setUser(data.user);
+        setIsDemo(data.isDemo === true);
       })
       .catch(() => setUser(null))
       .finally(() => setLoading(false));
@@ -87,7 +92,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout }}>
+    <AuthContext.Provider value={{ user, loading, isDemo, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/db/drizzle/0035_luxuriant_texas_twister.sql
+++ b/packages/db/drizzle/0035_luxuriant_texas_twister.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `read_only` integer DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0035_snapshot.json
+++ b/packages/db/drizzle/meta/0035_snapshot.json
@@ -1,0 +1,3240 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "22bf5478-f5a9-403f-b6f5-a1a2edbac7ee",
+  "prevId": "d28b7a89-2beb-413e-afe8-223e9f05ab0e",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "adaptive_isolation_preferences_log": {
+      "name": "adaptive_isolation_preferences_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_logs_tenant_created_idx": {
+          "name": "audit_logs_tenant_created_idx",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_tenant_action_created_idx": {
+          "name": "audit_logs_tenant_action_created_idx",
+          "columns": [
+            "tenant_id",
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cost_logs_tenant_user_created_idx": {
+          "name": "cost_logs_tenant_user_created_idx",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "cost_logs_tenant_token_created_idx": {
+          "name": "cost_logs_tenant_token_created_idx",
+          "columns": [
+            "tenant_id",
+            "api_token_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_first_name": {
+          "name": "pending_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_last_name": {
+          "name": "pending_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_email_idx": {
+          "name": "magic_link_tokens_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "magic_link_tokens_hash_idx": {
+          "name": "magic_link_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routing_weight_snapshots": {
+      "name": "routing_weight_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "weights": {
+          "name": "weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rws_tenant_captured_idx": {
+          "name": "rws_tenant_captured_idx",
+          "columns": [
+            "tenant_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spend_budgets": {
+      "name": "spend_budgets",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "cap_usd": {
+          "name": "cap_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_thresholds": {
+          "name": "alert_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_emails": {
+          "name": "alert_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hard_stop": {
+          "name": "hard_stop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "alerted_thresholds": {
+          "name": "alerted_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_started_at": {
+          "name": "period_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sso_configs": {
+      "name": "sso_configs",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_entity_id": {
+          "name": "sp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_domains": {
+          "name": "email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_encryption": {
+          "name": "require_encryption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_adaptive_isolation": {
+      "name": "tenant_adaptive_isolation",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumes_pool": {
+          "name": "consumes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contributes_pool": {
+          "name": "contributes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1776525836171,
       "tag": "0034_fantastic_legion",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1776610228392,
+      "tag": "0035_luxuriant_texas_twister",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -39,6 +39,14 @@ export const sessions = sqliteTable("sessions", {
     .notNull()
     .references(() => users.id),
   expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  /**
+   * Demo-tenant sessions (#229) are marked read-only so the hot path can
+   * refuse writes without tearing the tenant-scoping code apart. When
+   * set, every POST/PUT/PATCH/DELETE under `/v1/*` returns 403
+   * `demo_read_only` — the rest of the dashboard experience (reads,
+   * exports, chart renders) remains functional. Null = regular session.
+   */
+  readOnly: integer("read_only", { mode: "boolean" }).notNull().default(false),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),

--- a/packages/gateway/src/auth/session.ts
+++ b/packages/gateway/src/auth/session.ts
@@ -7,15 +7,31 @@ import { nanoid } from "nanoid";
 
 const SESSION_COOKIE = "provara_session";
 const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days in seconds
+/**
+ * Shorter TTL for demo sessions (#229). No point keeping an anonymous
+ * visitor's read-only session alive past the browsing window; an hour
+ * covers a long demo walk-through without bloating the sessions table.
+ */
+const DEMO_SESSION_MAX_AGE = 60 * 60; // 1 hour in seconds
 
-export async function createSession(db: Db, userId: string): Promise<string> {
+export interface CreateSessionOptions {
+  readOnly?: boolean;
+}
+
+export async function createSession(
+  db: Db,
+  userId: string,
+  options: CreateSessionOptions = {},
+): Promise<string> {
   const id = nanoid(32);
-  const expiresAt = new Date(Date.now() + SESSION_MAX_AGE * 1000);
+  const maxAge = options.readOnly ? DEMO_SESSION_MAX_AGE : SESSION_MAX_AGE;
+  const expiresAt = new Date(Date.now() + maxAge * 1000);
 
   await db.insert(sessions).values({
     id,
     userId,
     expiresAt,
+    readOnly: options.readOnly === true,
   }).run();
 
   return id;
@@ -49,13 +65,17 @@ export async function deleteSession(db: Db, sessionId: string): Promise<void> {
   await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
 }
 
-export function setSessionCookie(c: Context, sessionId: string): void {
+export function setSessionCookie(
+  c: Context,
+  sessionId: string,
+  options: { readOnly?: boolean } = {},
+): void {
   setCookie(c, SESSION_COOKIE, sessionId, {
     httpOnly: true,
     secure: true,
     sameSite: "None",
     path: "/",
-    maxAge: SESSION_MAX_AGE,
+    maxAge: options.readOnly ? DEMO_SESSION_MAX_AGE : SESSION_MAX_AGE,
   });
 }
 

--- a/packages/gateway/src/auth/tenant.ts
+++ b/packages/gateway/src/auth/tenant.ts
@@ -12,6 +12,9 @@ const tenantMap = new WeakMap<Request, string>();
 // token callers have no session user — their attribution comes from the
 // token via `getTokenInfo`.
 const sessionUserMap = new WeakMap<Request, string>();
+// Demo-tenant sessions (#229) carry a read-only flag. Writes under /v1/*
+// refuse when this is set. Missing from the map ≡ not a demo session.
+const sessionReadOnlyMap = new WeakMap<Request, boolean>();
 
 export function getTenantId(req: Request): string | null {
   return tenantMap.get(req) || null;
@@ -19,6 +22,10 @@ export function getTenantId(req: Request): string | null {
 
 export function getSessionUserId(req: Request): string | null {
   return sessionUserMap.get(req) || null;
+}
+
+export function isReadOnlySession(req: Request): boolean {
+  return sessionReadOnlyMap.get(req) === true;
 }
 
 /** Testing-only helper — sets the tenant on a Request for unit tests that
@@ -31,6 +38,11 @@ export function __testSetTenant(req: Request, tenantId: string): void {
 /** Testing-only helper — sets the session user id on a Request. */
 export function __testSetSessionUserId(req: Request, userId: string): void {
   sessionUserMap.set(req, userId);
+}
+
+/** Testing-only helper — marks a request's session as read-only. */
+export function __testSetReadOnlySession(req: Request, readOnly: boolean): void {
+  sessionReadOnlyMap.set(req, readOnly);
 }
 
 /**
@@ -105,6 +117,9 @@ export function createTenantMiddleware(db: Db) {
       if (result) {
         tenantMap.set(c.req.raw, result.user.tenantId);
         sessionUserMap.set(c.req.raw, result.user.id);
+        if (result.session.readOnly) {
+          sessionReadOnlyMap.set(c.req.raw, true);
+        }
         return next();
       }
     }

--- a/packages/gateway/src/demo/seed.ts
+++ b/packages/gateway/src/demo/seed.ts
@@ -1,0 +1,404 @@
+import type { Db } from "@provara/db";
+import {
+  apiKeys,
+  apiTokens,
+  auditLogs,
+  costLogs,
+  costMigrations,
+  feedback,
+  modelScores,
+  regressionEvents,
+  replayBank,
+  requests,
+  routingWeightSnapshots,
+  sessions,
+  spendBudgets,
+  subscriptions,
+  users,
+} from "@provara/db";
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+
+/**
+ * Demo-tenant seed (#229). Wipes and reseeds `t_demo` with data that
+ * exercises every narrative surface on the dashboard:
+ *
+ *   - Attribution: requests + cost_logs across 3 providers, 3 users,
+ *     2 api tokens, 30 days of history
+ *   - Quality envelope: ~30% of requests have judge feedback scores
+ *   - Regression detection: one unresolved event on a specific cell
+ *   - Auto cost migration: two completed migrations with savings
+ *   - Spend intelligence: enough volume for trajectory + drift views
+ *   - Budgets: monthly cap at 75% with the 50 + 75% thresholds fired
+ *   - Audit log: a representative set of auth / admin events
+ *   - Routing weight snapshots: one mid-window weight change so drift
+ *     endpoint returns a non-empty events array
+ *
+ * Subscription is seeded as Enterprise tier (`includesIntelligence=true`)
+ * so every gated feature — drift, recommendations, user/token
+ * attribution — renders for the demo visitor.
+ *
+ * Idempotent: the function DELETEs all t_demo-scoped rows first, then
+ * re-inserts from scratch. Running twice is a clean no-op in terms of
+ * final state.
+ *
+ * This file is tiny on purpose — the numbers are coarse and obvious so
+ * the demo data tells a clear story at a glance. A more "realistic"
+ * seed would obscure the features we're trying to showcase.
+ */
+
+export const DEMO_TENANT_ID = "t_demo";
+const DEMO_USER_IDS = ["u_demo_visitor", "u_demo_member_alice", "u_demo_member_bob"];
+const DEMO_PROVIDERS = ["openai", "anthropic", "google"] as const;
+const DEMO_MODELS: Record<(typeof DEMO_PROVIDERS)[number], string[]> = {
+  openai: ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"],
+  anthropic: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"],
+  google: ["gemini-2.5-flash", "gemini-2.0-flash"],
+};
+const DEMO_CELLS = [
+  { taskType: "coding", complexity: "complex" },
+  { taskType: "coding", complexity: "medium" },
+  { taskType: "qa", complexity: "simple" },
+  { taskType: "creative", complexity: "medium" },
+  { taskType: "general", complexity: "simple" },
+] as const;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function reseedDemoTenant(db: Db, now: Date = new Date()): Promise<void> {
+  const tenantId = DEMO_TENANT_ID;
+
+  await wipe(db, tenantId);
+
+  // 1. Users — a demo "visitor" who holds the session plus two team members
+  //    to make per-user attribution interesting.
+  for (const id of DEMO_USER_IDS) {
+    await db.insert(users).values({
+      id,
+      email: `${id.replace("u_demo_", "")}@demo.provara.xyz`,
+      name: id.replace("u_demo_", "").replace("_", " "),
+      firstName: id.split("_")[2] ?? "Demo",
+      lastName: "Demo",
+      tenantId,
+      role: id === "u_demo_visitor" ? "owner" : "member",
+      createdAt: new Date(now.getTime() - 60 * DAY_MS),
+    }).run();
+  }
+
+  // 2. Enterprise subscription so every tier-gated view unlocks.
+  await db.insert(subscriptions).values({
+    stripeSubscriptionId: "sub_demo_enterprise",
+    tenantId,
+    stripeCustomerId: "cus_demo_enterprise",
+    stripePriceId: "price_demo_enterprise",
+    stripeProductId: "prod_demo_enterprise",
+    tier: "enterprise",
+    includesIntelligence: true,
+    status: "active",
+    currentPeriodStart: new Date(now.getTime() - 14 * DAY_MS),
+    currentPeriodEnd: new Date(now.getTime() + 16 * DAY_MS),
+    cancelAtPeriodEnd: false,
+    trialEnd: null,
+    createdAt: new Date(now.getTime() - 60 * DAY_MS),
+    updatedAt: new Date(now.getTime() - 14 * DAY_MS),
+  }).run();
+
+  // 3. API tokens so per-token attribution has >1 key.
+  const tokenProd = "tok_demo_production";
+  const tokenStaging = "tok_demo_staging";
+  for (const [id, name] of [
+    [tokenProd, "Production (demo)"],
+    [tokenStaging, "Staging (demo)"],
+  ]) {
+    await db.insert(apiTokens).values({
+      id,
+      name,
+      tenant: tenantId,
+      hashedToken: `h_${id}`,
+      tokenPrefix: "pvra_dem",
+      enabled: true,
+      createdAt: new Date(now.getTime() - 45 * DAY_MS),
+    }).run();
+  }
+
+  // 4. Requests + cost_logs across 30 days. Rotate through cells,
+  //    providers, users, tokens so every attribution dim has signal.
+  const totalRequests = 200;
+  const seenCosts: Record<string, number> = {};
+  for (let i = 0; i < totalRequests; i++) {
+    const cell = DEMO_CELLS[i % DEMO_CELLS.length];
+    const provider = DEMO_PROVIDERS[i % DEMO_PROVIDERS.length];
+    const model = DEMO_MODELS[provider][i % DEMO_MODELS[provider].length];
+    const user = DEMO_USER_IDS[i % DEMO_USER_IDS.length];
+    const apiTokenId = i % 2 === 0 ? tokenProd : tokenStaging;
+    const dayOffset = Math.floor((i / totalRequests) * 30);
+    const createdAt = new Date(now.getTime() - (30 - dayOffset) * DAY_MS + (i % 24) * 60 * 60 * 1000);
+    const inputTokens = 400 + (i * 37) % 800;
+    const outputTokens = 200 + (i * 53) % 600;
+    const cost = Number(((inputTokens * 0.0000025) + (outputTokens * 0.00001)).toFixed(6));
+    seenCosts[provider] = (seenCosts[provider] ?? 0) + cost;
+
+    const reqId = `req_demo_${i}`;
+    await db.insert(requests).values({
+      id: reqId,
+      provider,
+      model,
+      prompt: JSON.stringify([{ role: "user", content: `demo prompt ${i}` }]),
+      response: `demo response ${i}`,
+      inputTokens,
+      outputTokens,
+      latencyMs: 300 + (i * 11) % 1400,
+      cost,
+      taskType: cell.taskType,
+      complexity: cell.complexity,
+      routedBy: "adaptive",
+      usedFallback: false,
+      cached: false,
+      cacheSource: null,
+      tokensSavedInput: null,
+      tokensSavedOutput: null,
+      fallbackErrors: null,
+      tenantId,
+      userId: user,
+      apiTokenId,
+      abTestId: null,
+      createdAt,
+    }).run();
+
+    await db.insert(costLogs).values({
+      id: `cl_demo_${i}`,
+      requestId: reqId,
+      tenantId,
+      provider,
+      model,
+      inputTokens,
+      outputTokens,
+      cost,
+      userId: user,
+      apiTokenId,
+      createdAt,
+    }).run();
+
+    // Judge feedback on ~30% of requests, scores 2-5, weighted toward
+    // good. One cell gets systematically low scores to support the
+    // regression-detection narrative below.
+    if (i % 3 === 0) {
+      const isRegressingCell = cell.taskType === "coding" && cell.complexity === "complex";
+      const score = isRegressingCell && i % 6 === 0 ? 2 : Math.min(5, 3 + (i % 3));
+      await db.insert(feedback).values({
+        id: `fb_demo_${i}`,
+        requestId: reqId,
+        tenantId,
+        score,
+        comment: null,
+        source: "judge",
+        createdAt,
+      }).run();
+    }
+  }
+
+  // 5. Model scores: EMA-ish values so the adaptive matrix renders with
+  //    plausible winners per cell.
+  const scoreRows: Array<{
+    taskType: string; complexity: string; provider: string; model: string; qualityScore: number; sampleCount: number;
+  }> = [
+    { taskType: "coding", complexity: "complex", provider: "anthropic", model: "claude-sonnet-4-6", qualityScore: 0.86, sampleCount: 42 },
+    { taskType: "coding", complexity: "complex", provider: "openai", model: "gpt-4.1", qualityScore: 0.81, sampleCount: 38 },
+    { taskType: "coding", complexity: "complex", provider: "openai", model: "gpt-4.1-mini", qualityScore: 0.72, sampleCount: 36 },
+    { taskType: "coding", complexity: "medium", provider: "openai", model: "gpt-4.1-mini", qualityScore: 0.82, sampleCount: 55 },
+    { taskType: "coding", complexity: "medium", provider: "anthropic", model: "claude-haiku-4-5-20251001", qualityScore: 0.79, sampleCount: 48 },
+    { taskType: "qa", complexity: "simple", provider: "openai", model: "gpt-4.1-nano", qualityScore: 0.88, sampleCount: 70 },
+    { taskType: "qa", complexity: "simple", provider: "google", model: "gemini-2.0-flash", qualityScore: 0.86, sampleCount: 62 },
+    { taskType: "creative", complexity: "medium", provider: "anthropic", model: "claude-sonnet-4-6", qualityScore: 0.91, sampleCount: 40 },
+    { taskType: "general", complexity: "simple", provider: "openai", model: "gpt-4.1-nano", qualityScore: 0.83, sampleCount: 65 },
+    { taskType: "general", complexity: "simple", provider: "google", model: "gemini-2.5-flash", qualityScore: 0.80, sampleCount: 58 },
+  ];
+  for (const row of scoreRows) {
+    await db.insert(modelScores).values({
+      tenantId,
+      ...row,
+      updatedAt: new Date(now.getTime() - (7 * DAY_MS)),
+    }).run();
+  }
+
+  // 6. Replay bank entries so the judge narrative has something to
+  //    show in the dashboard.
+  for (let i = 0; i < 12; i++) {
+    await db.insert(replayBank).values({
+      id: `rb_demo_${i}`,
+      tenantId,
+      taskType: "coding",
+      complexity: "complex",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      prompt: JSON.stringify([{ role: "user", content: `golden prompt ${i}` }]),
+      response: `golden response ${i}`,
+      originalScore: 4.5,
+      originalScoreSource: "judge",
+      sourceRequestId: `req_demo_${i}`,
+      lastReplayedAt: new Date(now.getTime() - 2 * DAY_MS),
+      embedding: null,
+      embeddingDim: null,
+      embeddingModel: null,
+      createdAt: new Date(now.getTime() - 20 * DAY_MS),
+    }).run();
+  }
+
+  // 7. Regression event — one unresolved, on the cell we gave bad
+  //    judge scores to above.
+  await db.insert(regressionEvents).values({
+    id: "rev_demo_active",
+    tenantId,
+    taskType: "coding",
+    complexity: "complex",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    replayCount: 8,
+    originalMean: 4.5,
+    replayMean: 3.1,
+    delta: -1.4,
+    costUsd: 0.42,
+    detectedAt: new Date(now.getTime() - 3 * DAY_MS),
+    resolvedAt: null,
+    resolutionNote: null,
+  }).run();
+
+  // 8. Cost migrations — two active with reported savings.
+  await db.insert(costMigrations).values({
+    id: "cm_demo_1",
+    tenantId,
+    taskType: "qa",
+    complexity: "simple",
+    fromProvider: "openai",
+    fromModel: "gpt-4.1",
+    fromCostPer1M: 8,
+    fromQualityScore: 0.88,
+    toProvider: "openai",
+    toModel: "gpt-4.1-nano",
+    toCostPer1M: 0.5,
+    toQualityScore: 0.86,
+    projectedMonthlySavingsUsd: 28.5,
+    graceEndsAt: new Date(now.getTime() + 5 * DAY_MS),
+    executedAt: new Date(now.getTime() - 9 * DAY_MS),
+    rolledBackAt: null,
+    rollbackReason: null,
+  }).run();
+  await db.insert(costMigrations).values({
+    id: "cm_demo_2",
+    tenantId,
+    taskType: "general",
+    complexity: "simple",
+    fromProvider: "google",
+    fromModel: "gemini-2.5-pro",
+    fromCostPer1M: 11.25,
+    fromQualityScore: 0.82,
+    toProvider: "google",
+    toModel: "gemini-2.5-flash",
+    toCostPer1M: 0.75,
+    toQualityScore: 0.80,
+    projectedMonthlySavingsUsd: 14.7,
+    graceEndsAt: new Date(now.getTime() - 4 * DAY_MS),
+    executedAt: new Date(now.getTime() - 18 * DAY_MS),
+    rolledBackAt: null,
+    rollbackReason: null,
+  }).run();
+
+  // 9. Spend budget at 75% — enough to show the threshold alert fired
+  //    without triggering the hard stop.
+  await db.insert(spendBudgets).values({
+    tenantId,
+    period: "monthly",
+    capUsd: 500,
+    alertThresholds: [50, 75, 90, 100],
+    alertEmails: ["finance@demo.provara.xyz"],
+    hardStop: false,
+    alertedThresholds: [50, 75],
+    periodStartedAt: new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)),
+    createdAt: new Date(now.getTime() - 30 * DAY_MS),
+    updatedAt: new Date(now.getTime() - 2 * DAY_MS),
+  }).run();
+
+  // 10. Audit log — a representative set of events covering auth /
+  //     admin / billing surfaces so the /dashboard/audit table has
+  //     enough rows to feel real.
+  const auditEvents: Array<[string, string | null, string | null, string, Record<string, unknown>]> = [
+    ["auth.login.success", "u_demo_visitor", "visitor@demo.provara.xyz", "session", { method: "magic_link" }],
+    ["auth.login.success", "u_demo_member_alice", "alice@demo.provara.xyz", "session", { method: "google" }],
+    ["user.invited", "u_demo_visitor", "visitor@demo.provara.xyz", "user", { invitedEmail: "bob@demo.provara.xyz" }],
+    ["user.joined", "u_demo_member_bob", "bob@demo.provara.xyz", "user", { method: "invite_claim" }],
+    ["api_key.created", "u_demo_visitor", "visitor@demo.provara.xyz", "api_key", { provider: "openai" }],
+    ["token.created", "u_demo_visitor", "visitor@demo.provara.xyz", "api_token", { tokenName: "Production (demo)" }],
+    ["billing.subscription.created", null, null, "subscription", { tier: "enterprise" }],
+    ["billing.subscription.updated", null, null, "subscription", { event: "quarterly_renewal" }],
+  ];
+  for (let i = 0; i < auditEvents.length; i++) {
+    const [action, actor, email, resourceType, metadata] = auditEvents[i];
+    await db.insert(auditLogs).values({
+      id: `audit_demo_${i}`,
+      tenantId,
+      actorUserId: actor,
+      actorEmail: email,
+      action,
+      resourceType,
+      resourceId: null,
+      metadata,
+      createdAt: new Date(now.getTime() - (auditEvents.length - i) * DAY_MS),
+    }).run();
+  }
+
+  // 11. Routing-weight snapshots with a mid-window change so the
+  //     drift endpoint returns a non-empty event array.
+  await db.insert(routingWeightSnapshots).values({
+    id: "rws_demo_before",
+    tenantId,
+    taskType: "_all_",
+    complexity: "_all_",
+    weights: { quality: 0.4, cost: 0.4, latency: 0.2 },
+    profile: "balanced",
+    capturedAt: new Date(now.getTime() - 20 * DAY_MS),
+  }).run();
+  await db.insert(routingWeightSnapshots).values({
+    id: "rws_demo_after",
+    tenantId,
+    taskType: "_all_",
+    complexity: "_all_",
+    weights: { quality: 0.2, cost: 0.7, latency: 0.1 },
+    profile: "cost",
+    capturedAt: new Date(now.getTime() - 10 * DAY_MS),
+  }).run();
+
+  // 12. API key row so /dashboard/api-keys has something to render.
+  await db.insert(apiKeys).values({
+    id: "ak_demo_openai",
+    name: "OPENAI_API_KEY",
+    provider: "openai",
+    encryptedValue: "demo-encrypted-bytes",
+    iv: "demo-iv",
+    authTag: "demo-tag",
+    tenantId,
+    createdAt: new Date(now.getTime() - 40 * DAY_MS),
+    updatedAt: new Date(now.getTime() - 40 * DAY_MS),
+  }).run();
+}
+
+/** Wipe every row scoped to the demo tenant. Idempotent. */
+async function wipe(db: Db, tenantId: string): Promise<void> {
+  // Order matters: child tables first where an FK would complain.
+  await db.delete(costLogs).where(eq(costLogs.tenantId, tenantId)).run();
+  await db.delete(feedback).where(eq(feedback.tenantId, tenantId)).run();
+  await db.delete(replayBank).where(eq(replayBank.tenantId, tenantId)).run();
+  await db.delete(regressionEvents).where(eq(regressionEvents.tenantId, tenantId)).run();
+  await db.delete(requests).where(eq(requests.tenantId, tenantId)).run();
+  await db.delete(modelScores).where(eq(modelScores.tenantId, tenantId)).run();
+  await db.delete(auditLogs).where(eq(auditLogs.tenantId, tenantId)).run();
+  await db.delete(routingWeightSnapshots).where(eq(routingWeightSnapshots.tenantId, tenantId)).run();
+  await db.delete(spendBudgets).where(eq(spendBudgets.tenantId, tenantId)).run();
+  await db.delete(costMigrations).where(eq(costMigrations.tenantId, tenantId)).run();
+  await db.delete(apiKeys).where(eq(apiKeys.tenantId, tenantId)).run();
+  await db.delete(apiTokens).where(eq(apiTokens.tenant, tenantId)).run();
+  await db.delete(subscriptions).where(eq(subscriptions.tenantId, tenantId)).run();
+  // Delete sessions for demo users first (FK → users.id).
+  for (const uid of DEMO_USER_IDS) {
+    await db.delete(sessions).where(eq(sessions.userId, uid)).run();
+  }
+  await db.delete(users).where(eq(users.tenantId, tenantId)).run();
+}

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -212,6 +212,23 @@ await scheduler.schedule({
   },
 });
 
+// Public demo tenant reseed (#229). Daily wipe + reseed so demo
+// visitors see fresh, consistent data and no one-off mutations leak
+// across browsing sessions even though read-only middleware should
+// prevent them outright.
+if (process.env.PROVARA_DEMO_ENABLED === "true") {
+  await scheduler.schedule({
+    name: "demo-reseed",
+    intervalMs: 24 * 60 * 60 * 1000,
+    initialDelayMs: 30_000,
+    handler: async () => {
+      const { reseedDemoTenant } = await import("./demo/seed.js");
+      await reseedDemoTenant(db);
+      console.log("[demo-reseed] t_demo refreshed");
+    },
+  });
+}
+
 scheduler.start();
 
 // Discover available models from each provider's API at startup

--- a/packages/gateway/src/middleware/read-only.ts
+++ b/packages/gateway/src/middleware/read-only.ts
@@ -1,0 +1,39 @@
+import type { Context, MiddlewareHandler, Next } from "hono";
+import { isReadOnlySession } from "../auth/tenant.js";
+
+/**
+ * Read-only session enforcement (#229). Refuses write verbs for any
+ * caller whose session has `read_only=true` — specifically the public
+ * `/demo` flow that hands anonymous visitors a short-lived session on
+ * the pre-seeded `t_demo` tenant.
+ *
+ * The middleware is mounted on `/v1/*` and on `/v1/chat/completions`
+ * (since GET isn't used on that endpoint and even a POST to chat would
+ * burn real LLM tokens on the operator's dime). Reads pass through
+ * untouched so the full dashboard UX renders — tables, charts, CSV
+ * downloads, audit logs viewer, everything.
+ *
+ * Block shape mirrors the budget hard-stop contract: 402-style `type`
+ * that the UI can key off for a tailored message, paired with an
+ * obvious sign-up CTA in the dashboard banner (#229/T4).
+ */
+const WRITE_VERBS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function createReadOnlyMiddleware(): MiddlewareHandler {
+  return async (c: Context, next: Next) => {
+    if (!isReadOnlySession(c.req.raw)) return next();
+    if (!WRITE_VERBS.has(c.req.method)) return next();
+
+    return c.json(
+      {
+        error: {
+          message:
+            "This is a read-only demo session. Sign up to create your own tenant and start writing.",
+          type: "demo_read_only",
+          signupUrl: "https://www.provara.xyz/login",
+        },
+      },
+      403,
+    );
+  };
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -13,6 +13,8 @@ import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
 import { createAdminMiddleware, requireRole } from "./auth/admin.js";
 import { createTenantMiddleware } from "./auth/tenant.js";
+import { createReadOnlyMiddleware } from "./middleware/read-only.js";
+import { createDemoRoutes } from "./routes/demo.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createConversationRoutes } from "./routes/conversations.js";
@@ -177,6 +179,20 @@ export async function createRouter(ctx: RouterContext) {
 
   // Tenant middleware — enforces tenant context in multi_tenant mode
   app.use("/v1/*", createTenantMiddleware(ctx.db));
+
+  // Public demo tenant (#229). Read-only session for anonymous visitors.
+  // Mounted AFTER tenant middleware so /v1/* writes from demo sessions
+  // are blocked, but BEFORE any feature routes.
+  if (getMode() === "multi_tenant") {
+    app.route("/demo", createDemoRoutes(ctx.db));
+  }
+
+  // Read-only session enforcement (#229). Applies to all /v1/* writes
+  // and the chat-completions hot path — demo sessions can browse the
+  // seeded data freely but can't create, mutate, or burn LLM tokens.
+  const readOnly = createReadOnlyMiddleware();
+  app.use("/v1/*", readOnly);
+  app.use("/v1/chat/completions", readOnly);
 
   // Mount A/B test CRUD routes
   app.route("/v1/ab-tests", createAbTestRoutes(ctx.db));

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -260,6 +260,7 @@ export function createAuthRoutes(db: Db) {
         tenantId: result.user.tenantId,
         role: result.user.role,
       },
+      isDemo: result.session.readOnly === true,
     });
   });
 

--- a/packages/gateway/src/routes/demo.ts
+++ b/packages/gateway/src/routes/demo.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { users } from "@provara/db";
+import { eq } from "drizzle-orm";
+import { createSession, setSessionCookie } from "../auth/session.js";
+import { DEMO_TENANT_ID } from "../demo/seed.js";
+
+/**
+ * Public read-only demo (#229). Anonymous visitor hits `/demo`, gets a
+ * short-lived session bound to the pre-seeded `u_demo_visitor` /
+ * `t_demo` pair, and lands on the dashboard. All writes on the session
+ * are refused by `createReadOnlyMiddleware`; the nightly
+ * `demo-reseed` scheduler job keeps the data fresh.
+ *
+ * Errors: 503 if the demo tenant hasn't been seeded yet (first deploy
+ * before the job fires, or someone manually wiped it). The UI should
+ * surface this as "demo is temporarily unavailable, try again soon."
+ */
+
+export function createDemoRoutes(db: Db) {
+  const app = new Hono();
+
+  app.get("/", async (c) => {
+    const visitor = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, "u_demo_visitor"))
+      .get();
+    if (!visitor) {
+      return c.json(
+        {
+          error: {
+            message:
+              "Demo tenant has not been seeded yet. Try again in a moment or contact support.",
+            type: "demo_unavailable",
+          },
+        },
+        503,
+      );
+    }
+
+    const sessionId = await createSession(db, visitor.id, { readOnly: true });
+    setSessionCookie(c, sessionId, { readOnly: true });
+
+    const dashboardUrl = process.env.DASHBOARD_URL || "http://localhost:3000";
+    return c.redirect(`${dashboardUrl}/dashboard?demo=1`);
+  });
+
+  return app;
+}

--- a/packages/gateway/tests/demo.test.ts
+++ b/packages/gateway/tests/demo.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { auditLogs, costLogs, requests, sessions, subscriptions, users } from "@provara/db";
+import { eq } from "drizzle-orm";
+import { makeTestDb } from "./_setup/db.js";
+import { reseedDemoTenant, DEMO_TENANT_ID } from "../src/demo/seed.js";
+import { createReadOnlyMiddleware } from "../src/middleware/read-only.js";
+import { __testSetReadOnlySession, __testSetTenant } from "../src/auth/tenant.js";
+
+describe("#229 — demo tenant seed", () => {
+  let db: Db;
+  beforeEach(async () => {
+    db = await makeTestDb();
+  });
+
+  it("seeds the expected top-level objects idempotently", async () => {
+    await reseedDemoTenant(db);
+    await reseedDemoTenant(db);
+
+    const uRows = await db.select().from(users).where(eq(users.tenantId, DEMO_TENANT_ID)).all();
+    expect(uRows).toHaveLength(3);
+    expect(uRows.some((u) => u.id === "u_demo_visitor")).toBe(true);
+
+    const sub = await db
+      .select()
+      .from(subscriptions)
+      .where(eq(subscriptions.tenantId, DEMO_TENANT_ID))
+      .get();
+    expect(sub?.tier).toBe("enterprise");
+    expect(sub?.includesIntelligence).toBe(true);
+
+    const reqs = await db
+      .select()
+      .from(requests)
+      .where(eq(requests.tenantId, DEMO_TENANT_ID))
+      .all();
+    expect(reqs.length).toBe(200);
+
+    const costs = await db
+      .select()
+      .from(costLogs)
+      .where(eq(costLogs.tenantId, DEMO_TENANT_ID))
+      .all();
+    expect(costs.length).toBe(200);
+
+    const audit = await db
+      .select()
+      .from(auditLogs)
+      .where(eq(auditLogs.tenantId, DEMO_TENANT_ID))
+      .all();
+    expect(audit.length).toBeGreaterThan(0);
+  });
+
+  it("populates attribution fields on every seeded request", async () => {
+    await reseedDemoTenant(db);
+    const r = await db.select().from(requests).where(eq(requests.tenantId, DEMO_TENANT_ID)).all();
+    for (const row of r) {
+      expect(row.userId).toBeTruthy();
+      expect(row.apiTokenId).toBeTruthy();
+      expect(row.taskType).toBeTruthy();
+      expect(row.complexity).toBeTruthy();
+    }
+  });
+
+  it("clears prior demo rows before re-seeding (no duplicates)", async () => {
+    await reseedDemoTenant(db);
+    const first = await db.select().from(requests).where(eq(requests.tenantId, DEMO_TENANT_ID)).all();
+    await reseedDemoTenant(db);
+    const second = await db.select().from(requests).where(eq(requests.tenantId, DEMO_TENANT_ID)).all();
+    expect(second.length).toBe(first.length);
+  });
+});
+
+describe("#229 — read-only session middleware", () => {
+  it("passes GETs through regardless of read-only flag", async () => {
+    const app = new Hono();
+    app.use("/v1/x", async (c, next) => {
+      __testSetReadOnlySession(c.req.raw, true);
+      __testSetTenant(c.req.raw, "t_demo");
+      return next();
+    });
+    app.use("/v1/x", createReadOnlyMiddleware());
+    app.get("/v1/x", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/v1/x");
+    expect(res.status).toBe(200);
+  });
+
+  it("blocks write verbs with 403 demo_read_only", async () => {
+    const app = new Hono();
+    app.use("/v1/x", async (c, next) => {
+      __testSetReadOnlySession(c.req.raw, true);
+      __testSetTenant(c.req.raw, "t_demo");
+      return next();
+    });
+    app.use("/v1/x", createReadOnlyMiddleware());
+    app.post("/v1/x", (c) => c.json({ ok: true }));
+    app.put("/v1/x", (c) => c.json({ ok: true }));
+    app.patch("/v1/x", (c) => c.json({ ok: true }));
+    app.delete("/v1/x", (c) => c.json({ ok: true }));
+
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const res = await app.request("/v1/x", { method });
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error.type).toBe("demo_read_only");
+    }
+  });
+
+  it("does NOT block write verbs on non-demo sessions", async () => {
+    const app = new Hono();
+    app.use("/v1/x", async (c, next) => {
+      // No __testSetReadOnlySession — this is a normal session.
+      __testSetTenant(c.req.raw, "t_normal");
+      return next();
+    });
+    app.use("/v1/x", createReadOnlyMiddleware());
+    app.post("/v1/x", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/v1/x", { method: "POST" });
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Ships the public read-only demo tenant (#229). Anonymous visitors click `/demo` → get a short-lived read-only session on pre-seeded `t_demo` → land on `/dashboard` with a non-dismissible "demo mode" banner. Unblocks the landing-page "See it live →" CTA that shipped in PR #231 as a 404.

## How it works

1. `GET /demo` creates a 1-hour read-only session bound to `u_demo_visitor`, sets the cookie, redirects to `DASHBOARD_URL/dashboard?demo=1`.
2. Tenant middleware flags the session as read-only via a new WeakMap on the request.
3. `createReadOnlyMiddleware()` (mounted on `/v1/*` and `/v1/chat/completions`) refuses `POST/PUT/PATCH/DELETE` with `403 demo_read_only`. Reads / exports / chart renders all pass through untouched.
4. `DemoBanner` (client component wired into the dashboard layout) reads `isDemo` from `AuthContext` and renders a sticky strip.
5. Scheduler job `demo-reseed` wipes and reseeds `t_demo` nightly; gated by `PROVARA_DEMO_ENABLED=true`.

## Seed narrative

The seed data is crafted to showcase every feature on first visit:

- 200 requests + cost logs across 30 days, 5 cells, 3 providers, 3 users, 2 API tokens
- ~67 judge feedback rows — weighted toward 3–5, with one cell (`coding+complex`) systematically low to drive the regression narrative
- 1 unresolved regression event on that cell with a -1.4 delta
- 2 active cost migrations with real reported savings (`$28.50` and `$14.70`/mo)
- Budget at 75% of a $500 cap with `[50, 75]` thresholds already fired
- Weight snapshots with a `balanced → cost` profile change mid-window so `/v1/spend/drift` returns a real event

Enterprise subscription so every tier-gated view unlocks.

## Ops action alongside merge

On Railway → `provara-gateway` → Variables:
- Add `PROVARA_DEMO_ENABLED=true`

Redeploy. The `demo-reseed` job fires after 30s on first start and populates `t_demo`. After that, `/demo` works.

## Tests

- 6 new tests (3 for seed idempotency + shape, 3 for middleware behavior)
- Full suite 517/517

## Files

- `packages/db/src/schema.ts` + migration `0035_luxuriant_texas_twister.sql` — `sessions.read_only`
- `packages/gateway/src/auth/session.ts` — `createSession({ readOnly })`, short TTL
- `packages/gateway/src/auth/tenant.ts` — `sessionReadOnlyMap`, `isReadOnlySession()`, test helper
- `packages/gateway/src/middleware/read-only.ts` — the write-verb blocker
- `packages/gateway/src/routes/demo.ts` — `GET /demo` handler
- `packages/gateway/src/demo/seed.ts` — the full reseed
- `packages/gateway/src/index.ts` — `demo-reseed` scheduler job
- `packages/gateway/src/routes/auth.ts` — `/auth/me` returns `isDemo`
- `packages/gateway/src/router.ts` — route wiring + middleware mount
- `apps/web/src/lib/auth-context.tsx` — `isDemo` in context
- `apps/web/src/components/demo-banner.tsx` — new banner component
- `apps/web/src/app/dashboard/layout.tsx` — mount banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
