### PR TITLE
feat(#233): structured-output-aware routing

### DIFF
--- a/apps/docs/content/docs/api/chat-completions.mdx
+++ b/apps/docs/content/docs/api/chat-completions.mdx
@@ -42,8 +42,15 @@ Provara extends the standard request body with optional hints the router uses wh
 |---|---|---|
 | `routing_hint` | `coding`, `creative`, `summarization`, `qa`, `general` | Overrides the task-type classifier |
 | `complexity_hint` | `simple`, `medium`, `complex` | Overrides the complexity classifier |
+| `requires_structured_output` | `boolean` | Narrows the candidate pool to models known to reliably follow JSON schemas. Auto-detected from `response_format: { type: "json_schema" \| "json_object" }` or a non-empty `tools` array — only set explicitly to override an auto-detection. Pinned `model` bypasses. |
 
 Ignored when `model` is pinned.
+
+### Structured-output routing
+
+When a request carries a JSON schema (`response_format.type === "json_schema"` or `json_object`) or a `tools` array, the router narrows its candidate pool to models listed in `STRUCTURED_OUTPUT_RELIABLE`. If no registered provider has a capable model, the request returns `HTTP 502 no_capable_provider` rather than silently routing to a model that will emit a plausible-but-wrong-shape response.
+
+The current capable list: `gpt-4o`, `gpt-4.1`, `gpt-4.1-mini`, `o3`, `o4-mini`, `claude-opus-4-6`, `claude-sonnet-4-6`, `gemini-2.5-pro`. Unknown models default to "not capable" — the safe choice.
 
 ## Response envelope
 

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -6,7 +6,7 @@ import { requests } from "@provara/db";
 import { nanoid } from "nanoid";
 import { logCost } from "./cost/index.js";
 import { calculateCost } from "./cost/pricing.js";
-import { createRoutingEngine, type RoutingProfile } from "./routing/index.js";
+import { createRoutingEngine, NoCapableProviderError, type RoutingProfile } from "./routing/index.js";
 import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
@@ -265,9 +265,43 @@ export async function createRouter(ctx: RouterContext) {
 
   // OpenAI-compatible chat completions endpoint
   app.post("/v1/chat/completions", async (c) => {
-    const body = await c.req.json<CompletionRequest & { provider?: string; cache?: boolean; complexity_hint?: "simple" | "medium" | "complex" }>();
-    const { provider: providerName, routing_hint, complexity_hint, cache: cacheParam, ...rest } = body;
+    const body = await c.req.json<CompletionRequest & {
+      provider?: string;
+      cache?: boolean;
+      complexity_hint?: "simple" | "medium" | "complex";
+      /**
+       * Explicit opt-in to structured-output routing filter (#233).
+       * Auto-detected from `response_format: { type: "json_schema" }`
+       * or a non-empty `tools` array — callers don't need to set this
+       * unless they want to override a negative auto-detection.
+       */
+      requires_structured_output?: boolean;
+      response_format?: { type?: string };
+      tools?: unknown[];
+    }>();
+    const {
+      provider: providerName,
+      routing_hint,
+      complexity_hint,
+      cache: cacheParam,
+      requires_structured_output,
+      response_format,
+      tools,
+      ...rest
+    } = body;
     const request = rest as CompletionRequest;
+
+    // Auto-detect structured-output intent (#233). Explicit flag wins
+    // when set; otherwise any standard JSON-schema / tool-use marker
+    // flips it on.
+    const autoDetectStructured =
+      response_format?.type === "json_schema" ||
+      response_format?.type === "json_object" ||
+      (Array.isArray(tools) && tools.length > 0);
+    const requiresStructuredOutput =
+      typeof requires_structured_output === "boolean"
+        ? requires_structured_output
+        : autoDetectStructured;
     // Serialize once for all downstream DB writes (cache-hit row, streaming
     // row, non-streaming row). Messages is otherwise stringified 2–3× per
     // request on the hot path.
@@ -344,16 +378,33 @@ export async function createRouter(ctx: RouterContext) {
         );
       }
     }
-    const routingResult = await routingEngine.route({
-      messages: request.messages,
-      provider: providerName,
-      model: request.model !== "" ? request.model : undefined,
-      routingHint: routing_hint,
-      complexityHint: complexity_hint,
-      routingProfile: (tokenInfo?.routingProfile as RoutingProfile) || undefined,
-      routingWeights: tokenInfo?.routingWeights || undefined,
-      tenantId,
-    });
+    let routingResult;
+    try {
+      routingResult = await routingEngine.route({
+        messages: request.messages,
+        provider: providerName,
+        model: request.model !== "" ? request.model : undefined,
+        routingHint: routing_hint,
+        complexityHint: complexity_hint,
+        requiresStructuredOutput,
+        routingProfile: (tokenInfo?.routingProfile as RoutingProfile) || undefined,
+        routingWeights: tokenInfo?.routingWeights || undefined,
+        tenantId,
+      });
+    } catch (err) {
+      if (err instanceof NoCapableProviderError) {
+        return c.json(
+          {
+            error: {
+              message: err.message,
+              type: "no_capable_provider",
+            },
+          },
+          502,
+        );
+      }
+      throw err;
+    }
 
     // Check cache before calling any provider.
     // Cache lookup order: exact-match (in-memory) → semantic-match (embedding

--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -12,9 +12,25 @@ import { createBoostTable } from "./adaptive/migrations.js";
 import { createRegressionCellTable } from "./adaptive/regression.js";
 import { getPricing } from "../cost/index.js";
 import { getRoutingConfig } from "./config.js";
+import { isStructuredOutputReliable } from "./model-capabilities.js";
 
 export type { RoutingResult, RouteTarget } from "./types.js";
 export { type RoutingProfile } from "./adaptive/index.js";
+
+/**
+ * Raised when `requires_structured_output` is true but no registered
+ * provider / model is known to reliably follow JSON schemas. The chat-
+ * completions handler in router.ts surfaces this as HTTP 502
+ * `no_capable_provider` — the caller asked for a constraint we can't
+ * honor; better to fail loudly than silently route to an unreliable
+ * model.
+ */
+export class NoCapableProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoCapableProviderError";
+  }
+}
 
 export interface RoutingEngineConfig {
   registry: ProviderRegistry;
@@ -36,6 +52,17 @@ export interface RoutingRequest {
    * shared pool only. `null`/`undefined` = anonymous caller, pool-only.
    */
   tenantId?: string | null;
+  /**
+   * Caller needs a response matching a structured output schema (#233).
+   * When true, the adaptive router and fallback chain both filter to
+   * models listed in `STRUCTURED_OUTPUT_RELIABLE`. Detected automatically
+   * from OpenAI-shape `response_format: { type: "json_schema" }` or a
+   * `tools` array, or set explicitly via the `requires_structured_output`
+   * request flag. A request with this flag and no capable candidate
+   * surfaces as `no_capable_provider` rather than silently routing to
+   * an unreliable model.
+   */
+  requiresStructuredOutput?: boolean;
 }
 
 export async function createRoutingEngine(config: RoutingEngineConfig) {
@@ -112,7 +139,25 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
   }
 
   async function route(request: RoutingRequest): Promise<RoutingResult> {
-    const allFallbacks = buildDynamicFallbacks(config.registry);
+    let allFallbacks = buildDynamicFallbacks(config.registry);
+
+    // Structured-output filter (#233). When the caller has signaled (or
+    // we auto-detected) that the response must match a JSON schema, the
+    // router narrows every candidate pool to models we've marked as
+    // reliably schema-conformant. Fallback chain, adaptive scoring, and
+    // A/B test variants all run against the filtered set. A user-
+    // pinned provider/model bypasses this filter — pinning is an
+    // explicit declaration that the caller knows what they're doing.
+    if (request.requiresStructuredOutput && !(request.provider && request.model) && !request.model) {
+      allFallbacks = allFallbacks.filter((t) => isStructuredOutputReliable(t.model));
+      if (allFallbacks.length === 0) {
+        throw new NoCapableProviderError(
+          "No provider registered with a model known to reliably follow structured output schemas. " +
+            "Register a capable model (gpt-4.1, claude-sonnet-4-6, gemini-2.5-pro, etc.) or set " +
+            "`requires_structured_output: false` to opt back into the full candidate pool.",
+        );
+      }
+    }
 
     // User override: explicit provider + model bypasses routing entirely.
     // routingHint + complexityHint let callers place the sample in a meaningful
@@ -166,6 +211,15 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
     const profile = request.routingProfile || "balanced";
     const availableProviders = new Set(config.registry.list().map((p) => p.name));
 
+    // The `availableProviders` set gates which adaptive candidates can be
+    // picked. When structured output is required we also need to prevent
+    // individual unreliable models within an otherwise-capable provider
+    // from winning — `allFallbacks` was already filtered above, but the
+    // adaptive EMA sees the full matrix. Post-filter the result.
+    const schemaFilter = request.requiresStructuredOutput
+      ? (target: RouteTarget) => isStructuredOutputReliable(target.model)
+      : null;
+
     // A/B test candidate (may or may not run before adaptive based on config)
     const abResult = await findActiveAbTest(taskType, complexity);
     const adaptiveResult = await adaptive.getBestModel(
@@ -199,7 +253,7 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
       };
     }
 
-    if (adaptiveResult) {
+    if (adaptiveResult && (!schemaFilter || schemaFilter(adaptiveResult.target))) {
       const { target, via } = adaptiveResult;
       return {
         provider: target.provider,

--- a/packages/gateway/src/routing/model-capabilities.ts
+++ b/packages/gateway/src/routing/model-capabilities.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-model capability flags that influence routing but aren't pricing
+ * (#233). Kept as a separate registry from `MODEL_PRICING` so the
+ * pricing data stays focused and so ops can update a model's
+ * structured-output reliability without editing cost lookups.
+ *
+ * Sources for the starting list:
+ *   - OpenAI: gpt-4o and gpt-4.1 families support structured outputs
+ *     via the Responses/Chat Completions JSON-schema mode; nano is
+ *     excluded because it frequently emits malformed shapes even when
+ *     asked for a schema (UAT regression, April 2026).
+ *   - Anthropic: sonnet and opus follow JSON-schema prompts reliably.
+ *     Haiku is a coin flip — listed as unreliable.
+ *   - Google: gemini-2.5-pro is reliable; flash variants are not.
+ *   - Everything else (Mistral, xAI, Z.ai) is conservatively `false`
+ *     until we have tenant signal that proves otherwise.
+ *
+ * Unknown models default to `false` — the safe choice. If a caller
+ * needs structured output and the adaptive router's candidate pool
+ * filters empty, the request returns a clear error rather than silently
+ * routing to a probably-unreliable model.
+ */
+
+export const STRUCTURED_OUTPUT_RELIABLE = new Set<string>([
+  // OpenAI
+  "gpt-4o",
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "o3",
+  "o4-mini",
+  // Anthropic
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  // Google
+  "gemini-2.5-pro",
+]);
+
+/**
+ * Is this model known to reliably emit responses matching a
+ * caller-supplied JSON schema? Unknown / unlisted models return false
+ * — the adaptive router treats that as "don't pick for structured
+ * requests," not "pick anyway and hope."
+ */
+export function isStructuredOutputReliable(model: string): boolean {
+  return STRUCTURED_OUTPUT_RELIABLE.has(model);
+}

--- a/packages/gateway/tests/structured-output-routing.test.ts
+++ b/packages/gateway/tests/structured-output-routing.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { createRoutingEngine, NoCapableProviderError } from "../src/routing/index.js";
+import { isStructuredOutputReliable } from "../src/routing/model-capabilities.js";
+import { makeTestDb } from "./_setup/db.js";
+import { makeFakeProvider } from "./_setup/fake-provider.js";
+import { makeFakeRegistry } from "./_setup/fake-registry.js";
+
+describe("#233 — structured-output-aware routing", () => {
+  it("known-capable models return true; unlisted models default to false", () => {
+    expect(isStructuredOutputReliable("gpt-4.1")).toBe(true);
+    expect(isStructuredOutputReliable("claude-sonnet-4-6")).toBe(true);
+    expect(isStructuredOutputReliable("gemini-2.5-pro")).toBe(true);
+    // Unlisted — the model that motivated #233
+    expect(isStructuredOutputReliable("gpt-4.1-nano")).toBe(false);
+    // Haiku — listed as unreliable
+    expect(isStructuredOutputReliable("claude-haiku-4-5-20251001")).toBe(false);
+    // Model we've never heard of
+    expect(isStructuredOutputReliable("some-future-model-v1")).toBe(false);
+  });
+
+  it("user-pinned provider+model bypasses the structured-output filter", async () => {
+    // Caller explicitly pinning a non-capable model is an explicit
+    // decision — the filter should not override it.
+    const db = await makeTestDb();
+    const registry = makeFakeRegistry([
+      makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+    ]);
+    const engine = await createRoutingEngine({ registry, db });
+
+    const result = await engine.route({
+      messages: [{ role: "user", content: "return JSON" }],
+      provider: "openai",
+      model: "gpt-4.1-nano",
+      requiresStructuredOutput: true,
+    });
+
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("gpt-4.1-nano");
+    expect(result.routedBy).toBe("user-override");
+  });
+
+  it("throws NoCapableProviderError when no capable model is registered", async () => {
+    const db = await makeTestDb();
+    // Only unreliable models available.
+    const registry = makeFakeRegistry([
+      makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+      makeFakeProvider({ name: "anthropic", models: ["claude-haiku-4-5-20251001"] }),
+    ]);
+    const engine = await createRoutingEngine({ registry, db });
+
+    await expect(
+      engine.route({
+        messages: [{ role: "user", content: "return JSON" }],
+        requiresStructuredOutput: true,
+      }),
+    ).rejects.toThrow(NoCapableProviderError);
+  });
+
+  it("narrows the fallback chain to capable models when the flag is set", async () => {
+    const db = await makeTestDb();
+    const registry = makeFakeRegistry([
+      makeFakeProvider({ name: "openai", models: ["gpt-4.1", "gpt-4.1-nano"] }),
+      makeFakeProvider({ name: "anthropic", models: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001"] }),
+    ]);
+    const engine = await createRoutingEngine({ registry, db });
+
+    const result = await engine.route({
+      messages: [{ role: "user", content: "return JSON" }],
+      requiresStructuredOutput: true,
+    });
+
+    // Every fallback (plus the winner) must be in the capable set.
+    for (const fallback of result.fallbacks) {
+      expect(isStructuredOutputReliable(fallback.model)).toBe(true);
+    }
+    expect(isStructuredOutputReliable(result.model)).toBe(true);
+  });
+
+  it("passes unreliable models through when the flag is NOT set", async () => {
+    // Regression guard: the filter only activates on opt-in. Default
+    // behavior preserves cheapest-first fallback including nano/haiku.
+    const db = await makeTestDb();
+    const registry = makeFakeRegistry([
+      makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
+    ]);
+    const engine = await createRoutingEngine({ registry, db });
+
+    const result = await engine.route({
+      messages: [{ role: "user", content: "hi" }],
+      // requiresStructuredOutput omitted
+    });
+
+    expect(result.model).toBe("gpt-4.1-nano");
+  });
+});


### PR DESCRIPTION
Callers asking for JSON-schema responses get routed only to capable models (opt-in flag or auto-detect from `response_format` / `tools`). Unknown models default unreliable. No capable provider → HTTP 502 `no_capable_provider` instead of silent schema miss. 522/522.