### PR TITLE
fix: serve own robots.txt + sitemap.xml

### DIFF
--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/dashboard/", "/login", "/signup", "/invite/"],
+      },
+    ],
+    sitemap: "https://www.provara.xyz/sitemap.xml",
+    host: "https://www.provara.xyz",
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const BASE = "https://www.provara.xyz";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  return [
+    { url: `${BASE}/`, lastModified: now, changeFrequency: "weekly", priority: 1.0 },
+    { url: `${BASE}/pricing`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${BASE}/models`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${BASE}/privacy`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
+    { url: `${BASE}/terms`, lastModified: now, changeFrequency: "monthly", priority: 0.3 },
+    {
+      url: `${BASE}/enterprise-data-handling`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Cloudflare was auto-injecting a content-signals-only robots.txt with no explicit Allow rules (all comments, no actual directives). Some social/search crawlers treat that as ambiguous.
- No sitemap existed at all (`/sitemap.xml` returned 404).
- Added `apps/web/src/app/robots.ts` — explicit `Allow: /`, disallows dashboard + auth routes, points at sitemap.
- Added `apps/web/src/app/sitemap.ts` — lists every public marketing page (/, /pricing, /models, /privacy, /terms, /enterprise-data-handling).

Next.js serves these at `/robots.txt` and `/sitemap.xml` and takes precedence over the Cloudflare injection.

## Test plan

- [x] Typecheck clean
- [ ] After deploy: `curl https://www.provara.xyz/robots.txt` shows our rules, not the content-signals block
- [ ] `curl https://www.provara.xyz/sitemap.xml` returns 200 with the 6 URLs
- [ ] Re-test social previews: LinkedIn Post Inspector, Twitter Card Validator, Facebook Sharing Debugger, Slack unfurl

Last-code-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)