### PR TITLE
fix: api-keys page — accurate banner for role-gated members

### DIFF
--- a/apps/web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/web/src/app/dashboard/api-keys/page.tsx
@@ -186,6 +186,7 @@ export default function ApiKeysPage() {
   const [keys, setKeys] = useState<ApiKey[]>([]);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [masterKeyConfigured, setMasterKeyConfigured] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
   const [loading, setLoading] = useState(true);
 
   async function fetchData() {
@@ -196,8 +197,12 @@ export default function ApiKeysPage() {
         gatewayFetchRaw("/v1/providers"),
       ]);
 
-      const statusData = await statusRes.json();
-      setMasterKeyConfigured(statusData.configured);
+      if (statusRes.status === 401 || statusRes.status === 403) {
+        setForbidden(true);
+      } else if (statusRes.ok) {
+        const statusData = await statusRes.json();
+        setMasterKeyConfigured(statusData.configured);
+      }
 
       if (keysRes?.ok) {
         const keysData = await keysRes.json();
@@ -239,10 +244,19 @@ export default function ApiKeysPage() {
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">API Keys</h1>
-        {masterKeyConfigured && <AddKeyForm onSaved={fetchData} />}
+        {!forbidden && masterKeyConfigured && <AddKeyForm onSaved={fetchData} />}
       </div>
 
-      {!masterKeyConfigured && (
+      {forbidden && (
+        <div className="bg-amber-900/30 border border-amber-800 rounded-lg p-4">
+          <h3 className="font-medium text-amber-200 mb-1">Owner access required</h3>
+          <p className="text-sm text-amber-300/80">
+            Provider API keys are managed by tenant owners. Ask an owner on your team to add or rotate keys.
+          </p>
+        </div>
+      )}
+
+      {!forbidden && !masterKeyConfigured && (
         <div className="bg-amber-900/30 border border-amber-800 rounded-lg p-4">
           <h3 className="font-medium text-amber-200 mb-1">Master Key Required</h3>
           <p className="text-sm text-amber-300/80">


### PR DESCRIPTION
## Summary

- Members hitting \`/dashboard/api-keys\` saw "Master Key Required" even though the env var was set. Root cause: \`/v1/api-keys/status\` is owner-gated and returns 403 for members. Frontend parsed the 403 body as JSON without checking \`.ok\`, landing on \`configured=undefined\` → misleading install-help banner.
- Now: 401/403 shows "Owner access required" instead. Missing-master-key path still shows the install help.

This is the UX-visible part of a bigger product question — whether members should be able to manage their own tokens/keys at all — which is being brainstormed separately.

## Test plan

- [x] Typecheck
- [ ] After deploy: nblanchard@opencore.io (member) sees the "Owner access required" banner, not the master-key help.

Last-code-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)