### PR TITLE
fix(#247): role middleware uses rank-based minimum-tier semantics

### DIFF
--- a/packages/gateway/src/auth/admin.ts
+++ b/packages/gateway/src/auth/admin.ts
@@ -164,16 +164,31 @@ export function getAuthRole(req: Request): Role | null {
 }
 
 /**
- * Role middleware — restricts access to users with the required role.
- * Must run after createAdminMiddleware (which attaches the user).
- * In self_hosted mode, this is a no-op.
+ * Role rank — higher rank subsumes lower. Callers pass the *minimum*
+ * required role to `requireRole`; anyone at or above that rank
+ * passes through. Owner is always allowed because it has the top
+ * rank. Viewer is the floor.
+ */
+const ROLE_RANK: Record<Role, number> = {
+  viewer: 1,
+  developer: 2,
+  admin: 3,
+  owner: 4,
+};
+
+/**
+ * Role middleware — restricts access to users at or above the
+ * required role. Must run after createAdminMiddleware (which
+ * attaches the user). In self_hosted mode, this is a no-op.
  *
- * Accepts either a single role or an array. Owner is always allowed.
- * Legacy single-role callers like `requireRole("owner")` remain valid.
+ * Accepts either a single role or an array. For an array, the
+ * minimum rank wins (so `requireRole(["developer"])` allows every
+ * role at or above developer: developer, admin, owner).
  */
 export function requireRole(role: Role | Role[]) {
-  const allowed = new Set<Role>(Array.isArray(role) ? role : [role]);
-  allowed.add("owner"); // owner is always allowed
+  const required = Array.isArray(role) ? role : [role];
+  const minRank = Math.min(...required.map((r) => ROLE_RANK[r]));
+  const minRoleName = (Object.entries(ROLE_RANK).find(([, r]) => r === minRank)?.[0]) ?? "admin";
 
   return async (c: Context, next: Next) => {
     if (getMode() !== "multi_tenant") {
@@ -189,15 +204,14 @@ export function requireRole(role: Role | Role[]) {
     }
 
     const normalized = normalizeRole(user.role);
-    if (allowed.has(normalized)) {
+    if (ROLE_RANK[normalized] >= minRank) {
       return next();
     }
 
-    const requiredList = Array.from(allowed).join(", ");
     return c.json(
       {
         error: {
-          message: `Insufficient permissions. Required role: ${requiredList}.`,
+          message: `Insufficient permissions. ${minRoleName} role or higher required.`,
           type: "auth_error",
         },
       },


### PR DESCRIPTION
## Summary

Admin users got 403 on developer-tier routes (tokens, prompts) because the initial \`requireRole\` in #248 used exact-set membership instead of role hierarchy. \`requireRole([\"developer\"])\` at the router level was silently rejecting admins even though admin is strictly more privileged.

Fix: role rank (viewer=1, developer=2, admin=3, owner=4) and \`requireRole\` means "rank ≥ rank of role". Router callsites needed no changes since they were already written assuming minimum-tier semantics.

## Test plan

- [x] 522/522 gateway tests pass
- [ ] After deploy: nblanchard (admin) sees tokens page, can create tokens, can also see/manage provider API keys

Last-code-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)