### PR TITLE
fix(#247): admins can manage team; owner role pinned against demotion

### DIFF
--- a/apps/web/src/app/dashboard/team/page.tsx
+++ b/apps/web/src/app/dashboard/team/page.tsx
@@ -4,6 +4,9 @@ import { useCallback, useEffect, useState } from "react";
 import { gatewayClientFetch, gatewayFetchRaw } from "../../../lib/gateway-client";
 import { TierBadge } from "../../../components/tier-badge";
 import { useToast } from "../../../components/toast";
+import { useAuth } from "../../../lib/auth-context";
+
+type Role = "owner" | "admin" | "developer" | "viewer";
 
 interface Member {
   id: string;
@@ -38,6 +41,9 @@ function formatDate(iso: string): string {
 }
 
 export default function TeamPage() {
+  const { user } = useAuth();
+  const viewerRole = (user?.role ?? "viewer") as Role;
+  const viewerId = user?.id ?? "";
   const [members, setMembers] = useState<Member[]>([]);
   const [seats, setSeats] = useState<Seats | null>(null);
   const [invites, setInvites] = useState<Invite[]>([]);
@@ -138,7 +144,13 @@ export default function TeamPage() {
             </thead>
             <tbody>
               {members.map((m) => (
-                <MemberRow key={m.id} member={m} onChanged={load} />
+                <MemberRow
+                  key={m.id}
+                  member={m}
+                  viewerRole={viewerRole}
+                  viewerId={viewerId}
+                  onChanged={load}
+                />
               ))}
             </tbody>
           </table>
@@ -172,6 +184,7 @@ export default function TeamPage() {
 
       {inviteOpen && seats && (
         <InviteModal
+          viewerRole={viewerRole}
           onClose={() => setInviteOpen(false)}
           onCreated={(url) => {
             setInviteOpen(false);
@@ -186,10 +199,35 @@ export default function TeamPage() {
   );
 }
 
-function MemberRow({ member, onChanged }: { member: Member; onChanged: () => void }) {
+function MemberRow({
+  member,
+  viewerRole,
+  viewerId,
+  onChanged,
+}: {
+  member: Member;
+  viewerRole: Role;
+  viewerId: string;
+  onChanged: () => void;
+}) {
   const toast = useToast();
 
-  async function updateRole(newRole: "owner" | "admin" | "developer" | "viewer") {
+  // Permission gating — mirrors the backend policy so the UI never
+  // shows an action the server will refuse. See team.ts PATCH/DELETE.
+  const isSelf = member.id === viewerId;
+  const viewerIsOwner = viewerRole === "owner";
+  // Only owners can touch owner rows; nobody can touch themselves.
+  const canEditRole = !isSelf && (viewerIsOwner || member.role !== "owner");
+  const canRemove = !isSelf && (viewerIsOwner || member.role !== "owner");
+  // Owner tier is only assignable by another owner.
+  const roleOptions: Array<{ value: Role; label: string }> = [
+    ...(viewerIsOwner ? [{ value: "owner" as const, label: "Owner" }] : []),
+    { value: "admin", label: "Admin" },
+    { value: "developer", label: "Developer" },
+    { value: "viewer", label: "Viewer" },
+  ];
+
+  async function updateRole(newRole: Role) {
     const res = await gatewayFetchRaw(`/v1/admin/team/${member.id}`, {
       method: "PATCH",
       body: JSON.stringify({ role: newRole }),
@@ -224,31 +262,44 @@ function MemberRow({ member, onChanged }: { member: Member; onChanged: () => voi
             <div className="w-7 h-7 rounded-full bg-zinc-800" />
           )}
           <div>
-            <div className="text-zinc-200">{member.name || member.email}</div>
+            <div className="text-zinc-200">
+              {member.name || member.email}
+              {isSelf && <span className="ml-2 text-xs text-zinc-500">(you)</span>}
+            </div>
             {member.name && <div className="text-xs text-zinc-500">{member.email}</div>}
           </div>
         </div>
       </td>
       <td className="px-4 py-3">
-        <select
-          value={member.role}
-          onChange={(e) => updateRole(e.target.value as "owner" | "admin" | "developer" | "viewer")}
-          className="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs focus:outline-none focus:border-blue-500"
-        >
-          <option value="owner">Owner</option>
-          <option value="admin">Admin</option>
-          <option value="developer">Developer</option>
-          <option value="viewer">Viewer</option>
-        </select>
+        {canEditRole ? (
+          <select
+            value={member.role}
+            onChange={(e) => updateRole(e.target.value as Role)}
+            className="bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs focus:outline-none focus:border-blue-500"
+          >
+            {/* Include the current role even if it wouldn't normally be
+                in the assignable set (edge: viewer-era history). */}
+            {!roleOptions.some((o) => o.value === member.role) && (
+              <option value={member.role}>{member.role}</option>
+            )}
+            {roleOptions.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-xs text-zinc-400 capitalize">{member.role}</span>
+        )}
       </td>
       <td className="px-4 py-3 text-zinc-500 text-xs">{formatDate(member.createdAt)}</td>
       <td className="px-4 py-3 text-right">
-        <button
-          onClick={remove}
-          className="text-xs text-zinc-500 hover:text-red-400"
-        >
-          Remove
-        </button>
+        {canRemove ? (
+          <button
+            onClick={remove}
+            className="text-xs text-zinc-500 hover:text-red-400"
+          >
+            Remove
+          </button>
+        ) : null}
       </td>
     </tr>
   );
@@ -299,16 +350,19 @@ function InviteRow({ invite, onChanged }: { invite: Invite; onChanged: () => voi
 
 function InviteModal({
   onClose,
+  viewerRole,
   onCreated,
   onError,
 }: {
+  viewerRole: Role;
   onClose: () => void;
   onCreated: (url: string) => void;
   onError: (msg: string) => void;
 }) {
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<"owner" | "admin" | "developer" | "viewer">("developer");
+  const [role, setRole] = useState<Role>("developer");
   const [submitting, setSubmitting] = useState(false);
+  const canInviteOwner = viewerRole === "owner";
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -353,13 +407,15 @@ function InviteModal({
             <label className="block text-xs font-medium text-zinc-400 mb-1.5">Role</label>
             <select
               value={role}
-              onChange={(e) => setRole(e.target.value as "owner" | "admin" | "developer" | "viewer")}
+              onChange={(e) => setRole(e.target.value as Role)}
               className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-blue-500"
             >
               <option value="viewer">Viewer — read-only access to dashboards, logs, spend</option>
               <option value="developer">Developer — use the gateway, manage own tokens, edit prompts</option>
               <option value="admin">Admin — everything except billing and tenant deletion</option>
-              <option value="owner">Owner — full access including billing and team</option>
+              {canInviteOwner && (
+                <option value="owner">Owner — full access including billing and team</option>
+              )}
             </select>
           </div>
         </div>

--- a/packages/gateway/src/routes/team.ts
+++ b/packages/gateway/src/routes/team.ts
@@ -49,11 +49,24 @@ export function createTeamRoutes(db: Db) {
     return c.json({ members, seats });
   });
 
-  // Update a member's role (owner only)
+  // Update a member's role. Admin+ required at the router level;
+  // in-handler guards enforce the "owner is pinned" policy:
+  //   - nobody can change their own role (prevents self-demotion or
+  //     self-promotion, and removes the only foot-gun that could leave
+  //     a tenant ownerless)
+  //   - admins cannot touch owner rows (can't demote an owner, can't
+  //     promote anyone to owner — prevents tenant hijacking)
+  //   - the last remaining owner cannot be demoted (sharper,
+  //     explicit invariant; today it's already guaranteed by the
+  //     self-change block, but hard-coding it here means future path
+  //     additions can't accidentally strand a tenant ownerless)
   app.patch("/:id", async (c) => {
     const authUser = getAuthUser(c.req.raw);
-    if (!authUser || authUser.role !== "owner") {
-      return c.json({ error: { message: "Owner access required", type: "auth_error" } }, 403);
+    if (!authUser) {
+      return c.json({ error: { message: "Authentication required", type: "auth_error" } }, 401);
+    }
+    if (authUser.role !== "owner" && authUser.role !== "admin") {
+      return c.json({ error: { message: "Admin role or higher required.", type: "auth_error" } }, 403);
     }
 
     const targetId = c.req.param("id");
@@ -76,6 +89,34 @@ export function createTeamRoutes(db: Db) {
       return c.json({ error: { message: "Member not found", type: "not_found" } }, 404);
     }
 
+    // Admins cannot demote an owner or create a new owner — keeps
+    // ownership decisions (including the right to transfer or delete
+    // the tenant) in the hands of existing owners.
+    if (authUser.role !== "owner") {
+      if (target.role === "owner") {
+        return c.json({ error: { message: "Only an owner can change an owner's role.", type: "auth_error" } }, 403);
+      }
+      if (body.role === "owner") {
+        return c.json({ error: { message: "Only an owner can promote someone to owner.", type: "auth_error" } }, 403);
+      }
+    }
+
+    // Last-owner invariant: refuse to demote the only remaining owner,
+    // even if the caller is that owner. Keeps the tenant recoverable.
+    if (target.role === "owner" && body.role !== "owner") {
+      const ownerCount = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(users)
+        .where(and(eq(users.tenantId, authUser.tenantId), eq(users.role, "owner")))
+        .get();
+      if ((ownerCount?.count ?? 0) <= 1) {
+        return c.json(
+          { error: { message: "Cannot demote the last owner. Promote another member to owner first.", type: "validation_error" } },
+          400,
+        );
+      }
+    }
+
     await db.update(users).set({ role: body.role as ValidRole }).where(eq(users.id, targetId)).run();
 
     const updated = await db.select().from(users).where(eq(users.id, targetId)).get();
@@ -94,11 +135,16 @@ export function createTeamRoutes(db: Db) {
     return c.json({ member: updated });
   });
 
-  // Remove a member (owner only)
+  // Remove a member. Same policy as role-change: admin+ at router
+  // level, with in-handler guards for owner-pinning and last-owner
+  // invariant.
   app.delete("/:id", async (c) => {
     const authUser = getAuthUser(c.req.raw);
-    if (!authUser || authUser.role !== "owner") {
-      return c.json({ error: { message: "Owner access required", type: "auth_error" } }, 403);
+    if (!authUser) {
+      return c.json({ error: { message: "Authentication required", type: "auth_error" } }, 401);
+    }
+    if (authUser.role !== "owner" && authUser.role !== "admin") {
+      return c.json({ error: { message: "Admin role or higher required.", type: "auth_error" } }, 403);
     }
 
     const targetId = c.req.param("id");
@@ -112,6 +158,26 @@ export function createTeamRoutes(db: Db) {
 
     if (!target) {
       return c.json({ error: { message: "Member not found", type: "not_found" } }, 404);
+    }
+
+    // Admins can't remove owners.
+    if (authUser.role !== "owner" && target.role === "owner") {
+      return c.json({ error: { message: "Only an owner can remove an owner.", type: "auth_error" } }, 403);
+    }
+
+    // Last-owner invariant on removal.
+    if (target.role === "owner") {
+      const ownerCount = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(users)
+        .where(and(eq(users.tenantId, authUser.tenantId), eq(users.role, "owner")))
+        .get();
+      if ((ownerCount?.count ?? 0) <= 1) {
+        return c.json(
+          { error: { message: "Cannot remove the last owner. Promote another member to owner first.", type: "validation_error" } },
+          400,
+        );
+      }
     }
 
     // Clean up rows that hold a FK into users so the final user delete
@@ -186,8 +252,14 @@ export function createTeamRoutes(db: Db) {
   // fallback) and whether the transactional email was sent.
   app.post("/invites", async (c) => {
     const authUser = getAuthUser(c.req.raw);
-    if (!authUser || authUser.role !== "owner") {
-      return c.json({ error: { message: "Owner access required", type: "auth_error" } }, 403);
+    if (!authUser) {
+      return c.json({ error: { message: "Authentication required", type: "auth_error" } }, 401);
+    }
+    // Defense-in-depth: the router mounts this under `requireRole("admin")`
+    // so developers/viewers never reach here in prod, but the handler
+    // check keeps the invariant independent of router wiring.
+    if (authUser.role !== "owner" && authUser.role !== "admin") {
+      return c.json({ error: { message: "Admin role or higher required to invite members.", type: "auth_error" } }, 403);
     }
 
     const VALID_INVITE_ROLES = ["owner", "admin", "developer", "viewer"] as const;
@@ -199,6 +271,11 @@ export function createTeamRoutes(db: Db) {
     const role: InviteRole = VALID_INVITE_ROLES.includes(body.role as InviteRole)
       ? (body.role as InviteRole)
       : "developer";
+
+    // Admins can't invite as owner — matches the PATCH policy.
+    if (authUser.role !== "owner" && role === "owner") {
+      return c.json({ error: { message: "Only an owner can invite someone as owner.", type: "auth_error" } }, 403);
+    }
 
     if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       return c.json({ error: { message: "Valid email address required.", type: "validation_error" } }, 400);


### PR DESCRIPTION
## Summary

Closes two gaps from #247:

1. **Admin was in the matrix but not in the handler.** Router let admins through to \`/v1/admin/team\`, but the handler hard-required \`authUser.role === \"owner\"\` for role changes, removals, and invite creation — so admins got 403 on every action. Now admins can manage non-owner rows but can't touch owner rows.
2. **Owner role is now explicitly pinned.** Two invariants:
   - No user can change their own role (unchanged — prevents accidental self-lockout).
   - The last remaining owner can't be demoted or removed, even by another owner. Today that was emergent from the self-change block; making it explicit means future path additions can't accidentally strand a tenant ownerless.

## UI

Select boxes now reflect the permission model:

- Role dropdown drops the **Owner** option unless the viewer is an owner
- Rows for owner members are read-only when an admin is viewing them (no dropdown, no remove button)
- Invite modal hides the **Owner** option for admins
- Self rows lose their controls and get a "(you)" marker

## Test plan

- [x] 522/522 gateway tests pass
- [x] UAT:
  - nblanchard (admin) can change developer/viewer roles, can invite new members, but owner rows are read-only
  - Promote a developer to admin — works
  - Attempt to promote a developer to owner from an admin session — rejected
  - Attempt to demote the only owner — rejected with "last owner" message

Authored-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)