### PR TITLE
fix(#251): route Enterprise sole-owner delete to support

### DIFF
--- a/apps/web/src/app/dashboard/profile/page.tsx
+++ b/apps/web/src/app/dashboard/profile/page.tsx
@@ -19,6 +19,7 @@ interface Me {
   isSoleOwner: boolean;
   ownerCount: number;
   authMethods: string[];
+  tier: string;
 }
 
 interface SessionRow {
@@ -118,6 +119,15 @@ export default function ProfilePage() {
       });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
+        // Enterprise tenants intentionally can't self-delete —
+        // surface the support email prominently instead of a generic
+        // error toast.
+        if (body?.error?.type === "enterprise_offboarding_required") {
+          alert(
+            `${body.error.message}\n\nSupport: ${body.supportEmail ?? "legal@corelumen.io"}`,
+          );
+          return;
+        }
         toast.error(`Could not delete: ${body?.error?.message ?? "Unknown error"}`);
         return;
       }
@@ -275,24 +285,45 @@ export default function ProfilePage() {
       {/* Danger zone */}
       <section className="bg-red-950/20 border border-red-900/40 rounded-lg p-6">
         <h2 className="text-sm font-semibold text-red-200 uppercase tracking-widest mb-2">Danger zone</h2>
-        <p className="text-sm text-zinc-400 mb-4">
-          {me.isSoleOwner ? (
-            <>
-              You are the <strong>sole owner</strong> of this tenant. Deleting your account will
-              cancel the Stripe subscription and permanently delete all tenant data. To preserve
-              the tenant, promote another member to Owner first in{" "}
-              <a href="/dashboard/team" className="text-blue-400 hover:underline">Team settings</a>.
-            </>
-          ) : (
-            <>Deleting your account removes you from this tenant. Tenant data and other members are unaffected.</>
-          )}
-        </p>
-        <button
-          onClick={deleteAccount}
-          className="px-4 py-2 bg-red-900/40 hover:bg-red-900/60 border border-red-800 rounded-lg text-sm font-medium text-red-200 transition-colors"
-        >
-          {me.isSoleOwner ? "Delete tenant and my account" : "Delete my account"}
-        </button>
+        {me.isSoleOwner && (me.tier === "enterprise" || me.tier === "selfhost_enterprise") ? (
+          <>
+            <p className="text-sm text-zinc-400 mb-4">
+              Enterprise tenants are offboarded through support so contract termination,
+              data export, and final invoicing are handled by a human. Email{" "}
+              <a href="mailto:legal@corelumen.io" className="text-blue-400 hover:underline">
+                legal@corelumen.io
+              </a>{" "}
+              to start the process.
+            </p>
+            <a
+              href="mailto:legal@corelumen.io?subject=Enterprise%20tenant%20offboarding"
+              className="inline-block px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-sm font-medium text-zinc-200"
+            >
+              Contact support
+            </a>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-zinc-400 mb-4">
+              {me.isSoleOwner ? (
+                <>
+                  You are the <strong>sole owner</strong> of this tenant. Deleting your account will
+                  cancel the Stripe subscription and permanently delete all tenant data. To preserve
+                  the tenant, promote another member to Owner first in{" "}
+                  <a href="/dashboard/team" className="text-blue-400 hover:underline">Team settings</a>.
+                </>
+              ) : (
+                <>Deleting your account removes you from this tenant. Tenant data and other members are unaffected.</>
+              )}
+            </p>
+            <button
+              onClick={deleteAccount}
+              className="px-4 py-2 bg-red-900/40 hover:bg-red-900/60 border border-red-800 rounded-lg text-sm font-medium text-red-200 transition-colors"
+            >
+              {me.isSoleOwner ? "Delete tenant and my account" : "Delete my account"}
+            </button>
+          </>
+        )}
       </section>
     </div>
   );

--- a/packages/gateway/src/routes/me.ts
+++ b/packages/gateway/src/routes/me.ts
@@ -83,6 +83,9 @@ export function createMeRoutes(db: Db) {
       .where(eq(oauthAccounts.userId, authUser.id))
       .all();
 
+    const sub = await getSubscriptionForTenant(db, authUser.tenantId);
+    const tier = sub?.tier ?? "free";
+
     return c.json({
       user: {
         id: me.id,
@@ -97,6 +100,7 @@ export function createMeRoutes(db: Db) {
         isSoleOwner,
         ownerCount,
         authMethods: methods.map((m) => m.provider),
+        tier,
       },
     });
   });
@@ -245,6 +249,30 @@ export function createMeRoutes(db: Db) {
     const isSoleOwner = authUser.role === "owner" && ownerCount <= 1;
 
     if (isSoleOwner) {
+      // Enterprise tenants have signed contracts with termination
+      // clauses, data-export timelines, and manual invoicing. Bypassing
+      // those with a self-serve `stripe.subscriptions.cancel()` would
+      // create contract disputes and skip the customer-success
+      // offboarding. Route Enterprise sole-owners to a human path
+      // instead; they can still leave the tenant (not the sole-owner
+      // branch) or ask support to execute the wipe.
+      const existingSub = await getSubscriptionForTenant(db, authUser.tenantId);
+      const tier = existingSub?.tier ?? null;
+      if (tier === "enterprise" || tier === "selfhost_enterprise") {
+        return c.json(
+          {
+            error: {
+              message:
+                "Enterprise tenants must be offboarded through support. Email legal@corelumen.io to start the process — we'll coordinate contract termination, data export, and final invoicing.",
+              type: "enterprise_offboarding_required",
+            },
+            tenantId: authUser.tenantId,
+            supportEmail: "legal@corelumen.io",
+          },
+          409,
+        );
+      }
+
       if (!body.confirmTenantName || body.confirmTenantName !== authUser.tenantId) {
         return c.json(
           {


### PR DESCRIPTION
## Summary

Enterprise contracts have termination clauses, data-export timelines, and manual invoicing. Self-serving through \`stripe.subscriptions.cancel()\` would bypass all of that.

- **Backend:** sole-owner delete on Enterprise tier now returns \`409 enterprise_offboarding_required\` with \`supportEmail: legal@corelumen.io\`. Non-sole-owner Enterprise users can still leave the tenant — only the tenant-wipe branch is gated.
- **UI:** Danger zone on the profile page shows a "Contact support" mailto for Enterprise sole-owners instead of the red delete button.

## Test plan

- [x] 522/522 gateway tests pass
- [ ] UAT on Enterprise tenant: sole-owner sees the support-email card instead of delete button; non-sole-owner can leave normally
- [ ] UAT on Pro/Team tenant: self-serve delete still works end-to-end

Last-code-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)