### PR TITLE
fix(#251): protect operator tenants from self-serve delete

### DIFF
--- a/apps/web/src/app/dashboard/profile/page.tsx
+++ b/apps/web/src/app/dashboard/profile/page.tsx
@@ -20,6 +20,7 @@ interface Me {
   ownerCount: number;
   authMethods: string[];
   tier: string;
+  isOperator: boolean;
 }
 
 interface SessionRow {
@@ -285,7 +286,12 @@ export default function ProfilePage() {
       {/* Danger zone */}
       <section className="bg-red-950/20 border border-red-900/40 rounded-lg p-6">
         <h2 className="text-sm font-semibold text-red-200 uppercase tracking-widest mb-2">Danger zone</h2>
-        {me.isSoleOwner && (me.tier === "enterprise" || me.tier === "selfhost_enterprise") ? (
+        {me.isOperator ? (
+          <p className="text-sm text-zinc-400">
+            This is a Provara operator account. Account and tenant lifecycle for operators is
+            managed by the platform team directly — there&apos;s no self-serve delete here by design.
+          </p>
+        ) : me.isSoleOwner && (me.tier === "enterprise" || me.tier === "selfhost_enterprise") ? (
           <>
             <p className="text-sm text-zinc-400 mb-4">
               Enterprise tenants are offboarded through support so contract termination,

--- a/packages/gateway/src/routes/me.ts
+++ b/packages/gateway/src/routes/me.ts
@@ -41,6 +41,7 @@ import {
 } from "../audit/actions.js";
 import { getStripe } from "../stripe/index.js";
 import { getSubscriptionForTenant } from "../stripe/subscriptions.js";
+import { isOperatorTenant } from "../auth/tier.js";
 
 /**
  * Self-service profile routes (#251). These are all gated by the
@@ -85,6 +86,7 @@ export function createMeRoutes(db: Db) {
 
     const sub = await getSubscriptionForTenant(db, authUser.tenantId);
     const tier = sub?.tier ?? "free";
+    const isOperator = await isOperatorTenant(db, authUser.tenantId);
 
     return c.json({
       user: {
@@ -101,6 +103,7 @@ export function createMeRoutes(db: Db) {
         ownerCount,
         authMethods: methods.map((m) => m.provider),
         tier,
+        isOperator,
       },
     });
   });
@@ -239,6 +242,25 @@ export function createMeRoutes(db: Db) {
     const body: { confirmTenantName?: string } = await c.req
       .json<{ confirmTenantName?: string }>()
       .catch(() => ({}));
+
+    // Operator tenants are the super-admin accounts (PROVARA_OPERATOR_EMAILS)
+    // we use to run the platform. Self-serve delete is intentionally off
+    // here — if we ever need to tear one down it's done by hand with a
+    // DB script so we don't accidentally nuke the account we're using for
+    // production support.
+    const operator = await isOperatorTenant(db, authUser.tenantId);
+    if (operator) {
+      return c.json(
+        {
+          error: {
+            message:
+              "Operator accounts cannot be deleted through the dashboard. These are managed by the Provara team directly.",
+            type: "operator_tenant_protected",
+          },
+        },
+        409,
+      );
+    }
 
     const ownerCountRow = await db
       .select({ count: sql<number>`count(*)` })


### PR DESCRIPTION
## Summary

Operator accounts (emails on \`PROVARA_OPERATOR_EMAILS\`) are the platform-team accounts used to run Provara. A self-serve delete there would wipe the account we use for production support and billing — catastrophic.

- **Backend:** \`DELETE /v1/me\` returns \`409 operator_tenant_protected\` for any operator tenant.
- **GET /v1/me** now returns \`isOperator\`.
- **Profile UI:** Danger zone renders a non-destructive "managed by the platform team" note instead of the delete button when \`isOperator\` is true.

## Test plan

- [x] 522/522 gateway tests pass
- [ ] UAT: syndicalt@gmail.com (operator) sees the operator note in the Danger zone; no delete button visible
- [ ] UAT: non-operator tenants still see normal delete flow

Last-code-by: Claude/Opus 4.7 (Claude Code, 1M context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)