### PR TITLE
feat(#256): vision polish — regression skip, UI surfaces, logs thumbnails

### DIFF
--- a/apps/docs/content/docs/features/vision.mdx
+++ b/apps/docs/content/docs/features/vision.mdx
@@ -75,6 +75,14 @@ Input guardrails run on the text portion of each message only. If a rule fires:
 
 If you need PII scanning inside image content, that's an OCR-first pipeline on the client side before the request reaches the gateway.
 
+## Regression detection
+
+Image-bearing requests are **excluded from the replay bank by default**. Running regression on vision is ~10–15× the token cost of text (image tokens across candidate replays plus the judge-model call) and the heuristic judge struggles to grade subjective visual outputs reliably.
+
+The filter operates at two levels: whole cells with `taskType = "vision"` are skipped in the bank-population cycle, and any individual stored prompt that contains an `image_url` part is also skipped (defense-in-depth against pre-existing rows that pre-date the cell-level filter).
+
+Set `PROVARA_REGRESSION_INCLUDE_VISION=true` to opt back in. Budget accordingly — a single vision replay event can cost more than a day of text regression on a busy cell.
+
 ## Known limitations
 
 - **Pricing**: the gateway's cost calculation uses the model's per-token text pricing; vision-specific image-token pricing (OpenAI's "detail" tiers, Anthropic's image-tile counts) isn't yet factored in. Cost figures for vision requests are lower bounds, not exact.

--- a/apps/web/src/app/dashboard/logs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/logs/[id]/page.tsx
@@ -136,12 +136,67 @@ function formatCost(cost: number | null): string {
   return `$${cost.toFixed(4)}`;
 }
 
-function formatMessages(promptJson: string): { role: string; content: string }[] {
+type MessageContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+type StoredMessage = { role: string; content: string | MessageContentPart[] };
+
+function formatMessages(promptJson: string): StoredMessage[] {
   try {
     const parsed = JSON.parse(promptJson);
     if (Array.isArray(parsed)) return parsed;
   } catch {}
   return [{ role: "user", content: promptJson }];
+}
+
+/** Render a message's content. Text stays as a wrapped <pre>; image_url parts
+ *  render as thumbnails that click-to-expand. Data URIs render inline (already
+ *  local to the browser); http(s) URLs render as a link with the domain shown
+ *  — the browser fetches, the dashboard server never sees the bytes. */
+function MessageContent({ content }: { content: string | MessageContentPart[] }) {
+  if (typeof content === "string") {
+    return (
+      <pre className="text-sm text-zinc-300 whitespace-pre-wrap font-sans leading-relaxed">
+        {content}
+      </pre>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {content.map((part, i) => {
+        if (part.type === "text") {
+          return (
+            <pre key={i} className="text-sm text-zinc-300 whitespace-pre-wrap font-sans leading-relaxed">
+              {part.text}
+            </pre>
+          );
+        }
+        if (part.type === "image_url") {
+          const url = part.image_url.url;
+          const isDataUri = url.startsWith("data:");
+          const label = isDataUri
+            ? url.slice(0, 30) + "…"
+            : (() => {
+                try { return new URL(url).hostname; } catch { return "external image"; }
+              })();
+          return (
+            <div key={i} className="space-y-1">
+              <p className="text-xs text-zinc-500 font-mono">image · {label}</p>
+              <a href={url} target="_blank" rel="noopener noreferrer">
+                <img
+                  src={url}
+                  alt="prompt attachment"
+                  loading="lazy"
+                  className="max-h-64 rounded border border-zinc-700 object-contain bg-zinc-800"
+                />
+              </a>
+            </div>
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
 }
 
 export default function RequestDetailPage() {
@@ -384,9 +439,7 @@ export default function RequestDetailPage() {
             }`}>
               {msg.role}
             </p>
-            <pre className="text-sm text-zinc-300 whitespace-pre-wrap font-sans leading-relaxed">
-              {msg.content}
-            </pre>
+            <MessageContent content={msg.content} />
           </div>
         ))}
       </div>

--- a/apps/web/src/app/dashboard/routing/page.tsx
+++ b/apps/web/src/app/dashboard/routing/page.tsx
@@ -25,7 +25,7 @@ interface Distribution {
   byComplexity: { complexity: string | null; count: number }[];
 }
 
-const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general"];
+const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general", "vision"];
 const COMPLEXITIES = ["simple", "medium", "complex"];
 
 function BarChart({ data, labelKey, valueKey }: { data: Record<string, unknown>[]; labelKey: string; valueKey: string }) {

--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -41,7 +41,7 @@ interface Props {
   getSparkline?: (key: string) => SparklinePoint[];
 }
 
-const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general"] as const;
+const TASK_TYPES = ["coding", "creative", "summarization", "qa", "general", "vision"] as const;
 const COMPLEXITIES = ["simple", "medium", "complex"] as const;
 
 export function cellKey(taskType: string, complexity: string, provider: string, model: string): string {

--- a/apps/web/src/components/badge.tsx
+++ b/apps/web/src/components/badge.tsx
@@ -5,6 +5,7 @@ const colors: Record<string, string> = {
   summarization: "bg-green-900/50 text-green-300",
   qa: "bg-amber-900/50 text-amber-300",
   general: "bg-zinc-800 text-zinc-300",
+  vision: "bg-pink-900/50 text-pink-300",
   simple: "bg-emerald-900/50 text-emerald-300",
   medium: "bg-yellow-900/50 text-yellow-300",
   complex: "bg-red-900/50 text-red-300",

--- a/packages/gateway/src/routing/adaptive/regression.ts
+++ b/packages/gateway/src/routing/adaptive/regression.ts
@@ -210,9 +210,18 @@ async function populateBankForCell(
   let skipped = 0;
   const slots = REPLAY_BANK_MAX_PER_CELL - existing.length;
 
+  const includeVision = shouldIncludeVision();
   for (const candidate of candidates) {
     if (added >= slots) break;
     if (seen.has(candidate.id)) {
+      skipped++;
+      continue;
+    }
+
+    // Vision requests are excluded by default — see shouldIncludeVision() for
+    // the cost/signal rationale. Set PROVARA_REGRESSION_INCLUDE_VISION=true
+    // to opt in once the cost budget is there for it.
+    if (!includeVision && promptHasImage(candidate.prompt)) {
       skipped++;
       continue;
     }
@@ -278,14 +287,46 @@ async function populateBankForCell(
   return { ...cell, added, skipped };
 }
 
+type StoredContentPart = { type: "text"; text: string } | { type: "image_url"; image_url: { url: string } } | { type: string; [k: string]: unknown };
+type StoredMessage = { role: string; content: string | StoredContentPart[] };
+
 function extractLastUserText(promptJson: string): string {
   try {
-    const messages = JSON.parse(promptJson) as Array<{ role: string; content: string }>;
+    const messages = JSON.parse(promptJson) as StoredMessage[];
     const lastUser = [...messages].reverse().find((m) => m.role === "user");
-    return lastUser?.content ?? "";
+    if (!lastUser) return "";
+    const content = lastUser.content;
+    if (typeof content === "string") return content;
+    return content
+      .map((p) => (p.type === "text" ? (p as { text: string }).text : ""))
+      .filter(Boolean)
+      .join(" ");
   } catch {
     return promptJson.slice(0, 2000);
   }
+}
+
+/** True if the stored prompt JSON contains any image_url content part. Used
+ *  to exclude vision requests from the replay bank (#256): image tokens are
+ *  expensive, base64 payloads balloon storage, and the judge heuristic
+ *  struggles to grade subjective vision outputs. */
+function promptHasImage(promptJson: string): boolean {
+  try {
+    const messages = JSON.parse(promptJson) as StoredMessage[];
+    return messages.some(
+      (m) => Array.isArray(m.content) && m.content.some((p) => p.type === "image_url"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Env flag that opts a deployment back into vision regression. Default off —
+ *  running regression on image-bearing prompts is ~10–15× the token cost of
+ *  text (image tokens + judge-model call across candidates) and produces
+ *  noisier signal because vision outputs resist heuristic grading. */
+function shouldIncludeVision(): boolean {
+  return process.env.PROVARA_REGRESSION_INCLUDE_VISION === "true";
 }
 
 /**
@@ -298,8 +339,13 @@ export async function runBankPopulationCycle(
   embeddings: EmbeddingProvider | null,
 ): Promise<BankPopulateResult[]> {
   const cells = await distinctEligibleCells(db);
+  const includeVision = shouldIncludeVision();
   const results: BankPopulateResult[] = [];
   for (const cell of cells) {
+    // Skip the whole vision cell by default (#256) — cheaper than filtering
+    // every candidate individually and avoids spending a fetch on requests
+    // that would all be rejected downstream.
+    if (!includeVision && cell.taskType === "vision") continue;
     // Tier gate (#168): even if the tenant has opted in, skip cells owned
     // by tenants without Intelligence access. Prevents cross-tier leakage
     // if a tenant downgrades from Pro → Free with opt-in still flagged.


### PR DESCRIPTION
Follow-up to #257.

## Summary
- **Regression skip** — image-bearing requests are excluded from the replay bank by default. Cell-level filter (`taskType = "vision"`) + defensive candidate-level filter (any stored prompt with an `image_url` part). `PROVARA_REGRESSION_INCLUDE_VISION=true` opts in. Rationale: vision replays are ~10–15× text token cost and the judge heuristic struggles to grade subjective visual outputs.
- **UI surfaces** — `vision` added to the hardcoded `TASK_TYPES` lists in the routing matrix and adaptive heatmap; Badge component gets a pink `vision` variant so request badges render in brand. A/B test scope dropdown is intentionally left unchanged — the router skips A/B for vision, so surfacing it there would let users create experiments that never fire.
- **Logs detail thumbnails** — image parts render inline (data URIs) or as hostname-labeled `<img>` links (http URLs). The dashboard server never fetches the bytes; the browser does.
- **Docs** — `features/vision.mdx` gets a "Regression detection" section covering the default-off behavior and the opt-in flag.

## Test plan
- [x] `npx tsc --noEmit` clean in gateway and web
- [ ] Visit `/dashboard/routing` with vision traffic — confirm "vision" row appears in the cell matrix
- [ ] Visit `/dashboard/logs/<id>` for an image-bearing request — confirm thumbnail renders (data URI inline, http URL as hostname+img)
- [ ] Confirm a vision request's Badge on the recent-requests table renders pink, not gray
- [ ] With `PROVARA_REGRESSION_INCLUDE_VISION` unset, manually trigger `runBankPopulationCycle` — confirm vision cells are skipped and log doesn't grow
- [ ] Set the flag, re-run — confirm vision cells populate (cost check: token counts in cost_logs reflect image tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)