### PR TITLE
fix(#256): image presence beats caller routing_hint for taskType

### DIFF
--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -219,16 +219,26 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
     }
 
     // Classify the request. Caller-supplied `routingHint` / `complexityHint`
-    // always win over the classifier — the hints are an explicit claim that
+    // normally win over the classifier — the hints are an explicit claim that
     // the caller knows better than the heuristic (e.g. a schema-heavy
     // request where a short user message still demands a capable model).
     // Images short-circuit: the classifier's keyword heuristics are text-only
     // and running them over image placeholders produces noise. Vision goes
     // in its own cell for adaptive learning.
+    //
+    // Image presence beats the caller's taskType hint (#256): the hint is a
+    // text-content heuristic, but having an image_url part is a structural
+    // fact about the request. Without this override a caller like Ampline
+    // that sends `routing_hint: "qa"` on every estimate pollutes the qa cell
+    // with vision samples and leaves the vision cell permanently empty on
+    // the routing matrix. Complexity hint still wins — "complex" vs "medium"
+    // vision is a meaningful distinction the caller may want to preserve.
     const classification = hasImage
       ? { taskType: "vision" as TaskType, complexity: "complex" as Complexity, taskConfidence: 1, complexityConfidence: 1, usedLlmFallback: false }
       : await classifyRequest(request.messages, config.registry);
-    const taskType: TaskType = request.routingHint || classification.taskType;
+    const taskType: TaskType = hasImage
+      ? "vision"
+      : request.routingHint || classification.taskType;
     const complexity: Complexity = request.complexityHint || classification.complexity;
 
     const { abTestPreempts } = getRoutingConfig();


### PR DESCRIPTION
Follow-up to #257 / #258.

## Summary
- Vision requests from callers that pin a `routing_hint` (e.g. Ampline uses `"qa"` on every estimate) were being logged under the hint's cell instead of `vision`. Candidate pool was filtering correctly via `hasImage`, but the adaptive EMA and the routing matrix on the dashboard saw them under the wrong cell.
- Image presence is a structural fact about the request, not a text-content heuristic — it should win over the caller's hint for the taskType label.
- Complexity hint is intentionally unchanged: "complex" vs "medium" vision is a meaningful distinction callers may want to preserve.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] POST to `/v1/chat/completions` with both `routing_hint: "qa"` AND an `image_url` content part — confirm the logged `requests.task_type` is `"vision"`, not `"qa"`
- [ ] POST without an image but with `routing_hint: "qa"` — confirm the hint still wins, taskType is `"qa"` (no regression on the text path)
- [ ] Confirm `/dashboard/routing` matrix now shows a populated `vision` row for the tenant

## Note on existing data
Previously logged Ampline vision requests stayed in `qa/complex`. Not backfilling — contractor feedback scores on vision responses vs text QA should be similar enough that adaptive EMA contamination is mild. Going forward, cells will separate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)