### PR TITLE
fix: split migration 0038 statements for libSQL

### DIFF
--- a/packages/db/drizzle/0038_normalize_moderate_complexity.sql
+++ b/packages/db/drizzle/0038_normalize_moderate_complexity.sql
@@ -7,4 +7,5 @@
 -- never rendered. Normalizing to the closest valid value ("medium")
 -- makes the historical data visible again without discarding it.
 UPDATE requests SET complexity = 'medium' WHERE complexity = 'moderate';
+--> statement-breakpoint
 UPDATE model_scores SET complexity = 'medium' WHERE complexity = 'moderate';


### PR DESCRIPTION
## Summary
Gateway is crash-looping on startup — migration 0038 issued two `UPDATE` statements in one `client.execute()` call, which libSQL/Turso rejects with `SQL_MANY_STATEMENTS`. Drizzle's convention is `--> statement-breakpoint` between statements.

## Fix
Insert the breakpoint comment between the two `UPDATE`s.

```sql
UPDATE requests SET complexity = 'medium' WHERE complexity = 'moderate';
--> statement-breakpoint
UPDATE model_scores SET complexity = 'medium' WHERE complexity = 'moderate';
```

## Test plan
- [ ] Deploy — confirm migrate completes and gateway boots
- [ ] `SELECT COUNT(*) FROM requests WHERE complexity = 'moderate'` → 0
- [ ] `SELECT COUNT(*) FROM model_scores WHERE complexity = 'moderate'` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)