### PR TITLE
feat(#263): live traffic tap — real-time SSE console

### DIFF
--- a/apps/docs/content/docs/features/analytics.mdx
+++ b/apps/docs/content/docs/features/analytics.mdx
@@ -191,6 +191,16 @@ Endpoint: `GET /v1/analytics/models/compare?range=7d`.
 - If two models have similar `avgScore` within noise (±0.05 with >50 feedback rows each) and one is 2–5× cheaper, run an A/B test to confirm and let cost migration ([cost-migration](/docs/features/cost-migration)) move the routing cell.
 - Low `feedbackCount` on a high-traffic model is a blind spot — you're flying routing decisions on latency and cost alone for that model.
 
+## Live traffic tap
+
+Endpoint: `GET /v1/analytics/live` (Server-Sent Events). UI: `/dashboard/live`.
+
+**Measures:** nothing — it's a live tail of completed requests, not an aggregate. Each event is a compact summary (provider, model, taskType, routedBy, tokens, cost, prompt preview) published as the gateway finishes writing the `requests` row.
+
+**Calculated as:** in-process pub/sub. The router publishes after every live, cached, and streaming completion. The SSE handler filters by tenant and forwards. Stream is ephemeral — no server-side persistence. For a time-bounded lookup use the Logs page.
+
+**How to improve:** not an optimization target; it's a debugging tool. Use it when a customer reports an issue and you need to see what's happening *now*.
+
 ## Related
 
 - [Semantic cache](/docs/features/semantic-cache) — exact + semantic caching internals

--- a/apps/web/src/app/dashboard/live/page.tsx
+++ b/apps/web/src/app/dashboard/live/page.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { gatewayUrl } from "../../../lib/gateway-client";
+import { formatCost, formatLatency, formatTokens } from "../../../lib/format";
+
+interface LiveEvent {
+  id: string;
+  provider: string;
+  model: string;
+  taskType: string | null;
+  complexity: string | null;
+  routedBy: string | null;
+  cached: boolean;
+  usedFallback: boolean;
+  latencyMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number | null;
+  tenantId: string | null;
+  userId: string | null;
+  apiTokenId: string | null;
+  promptPreview: string;
+  createdAt: string;
+}
+
+const MAX_EVENTS = 200;
+
+const PROVIDER_COLORS: Record<string, string> = {
+  openai: "bg-emerald-900/40 text-emerald-300 border-emerald-800/50",
+  anthropic: "bg-orange-900/40 text-orange-300 border-orange-800/50",
+  google: "bg-blue-900/40 text-blue-300 border-blue-800/50",
+  mistral: "bg-purple-900/40 text-purple-300 border-purple-800/50",
+  xai: "bg-cyan-900/40 text-cyan-300 border-cyan-800/50",
+  zai: "bg-pink-900/40 text-pink-300 border-pink-800/50",
+  ollama: "bg-zinc-800 text-zinc-300 border-zinc-700",
+};
+
+export default function LivePage() {
+  const [events, setEvents] = useState<LiveEvent[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [providerFilter, setProviderFilter] = useState("");
+  const [modelFilter, setModelFilter] = useState("");
+  const [routedByFilter, setRoutedByFilter] = useState("");
+  const [userFilter, setUserFilter] = useState("");
+
+  // Pause buffer — events arrive while paused go here so Resume can flush them.
+  const pausedBuffer = useRef<LiveEvent[]>([]);
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
+
+  useEffect(() => {
+    const url = gatewayUrl("/v1/analytics/live");
+    // EventSource doesn't support credentials:include by default on cross-origin;
+    // we rely on the gateway's CORS config already set up for the dashboard. If
+    // cookies don't reach it, the gateway will reject as anonymous — fine for
+    // self-host single-tenant, and CORS is configured correctly for cloud.
+    const es = new EventSource(url, { withCredentials: true });
+    es.onopen = () => setConnected(true);
+    es.onerror = () => setConnected(false);
+    es.onmessage = (msg) => {
+      try {
+        const ev = JSON.parse(msg.data) as LiveEvent;
+        if (pausedRef.current) {
+          pausedBuffer.current.push(ev);
+          return;
+        }
+        setEvents((prev) => [ev, ...prev].slice(0, MAX_EVENTS));
+      } catch {}
+    };
+    return () => es.close();
+  }, []);
+
+  function resume() {
+    const buffered = pausedBuffer.current;
+    pausedBuffer.current = [];
+    setPaused(false);
+    if (buffered.length > 0) {
+      setEvents((prev) => [...buffered.reverse(), ...prev].slice(0, MAX_EVENTS));
+    }
+  }
+
+  function clear() {
+    setEvents([]);
+    pausedBuffer.current = [];
+  }
+
+  const filtered = events.filter((e) => {
+    if (providerFilter && e.provider !== providerFilter) return false;
+    if (modelFilter && !e.model.includes(modelFilter)) return false;
+    if (routedByFilter && e.routedBy !== routedByFilter) return false;
+    if (userFilter && e.userId !== userFilter) return false;
+    return true;
+  });
+
+  const uniqueProviders = Array.from(new Set(events.map((e) => e.provider))).sort();
+  const uniqueRoutedBy = Array.from(new Set(events.map((e) => e.routedBy).filter(Boolean) as string[])).sort();
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">Live</h1>
+          <span className="flex items-center gap-1.5 text-xs">
+            <span className={`w-1.5 h-1.5 rounded-full ${connected ? "bg-emerald-500 animate-pulse" : "bg-zinc-600"}`} />
+            <span className="text-zinc-500">{connected ? "streaming" : "disconnected"}</span>
+          </span>
+          {paused && (
+            <span className="text-xs px-2 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-800/50">
+              paused · {pausedBuffer.current.length} buffered
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => (paused ? resume() : setPaused(true))}
+            className="px-3 py-1.5 text-sm rounded-md bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200"
+          >
+            {paused ? "Resume" : "Pause"}
+          </button>
+          <button
+            onClick={clear}
+            className="px-3 py-1.5 text-sm rounded-md bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <p className="text-sm text-zinc-500">
+        Ephemeral tail of completed chat-completion requests in this workspace. No server-side history — for time-bounded lookups use <Link href="/dashboard/logs" className="text-blue-400 hover:text-blue-300 underline">Logs</Link>.
+      </p>
+
+      {/* Filters */}
+      <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+        <div>
+          <label className="block text-xs text-zinc-500 mb-1">Provider</label>
+          <select
+            value={providerFilter}
+            onChange={(e) => setProviderFilter(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-sm text-zinc-200"
+          >
+            <option value="">All</option>
+            {uniqueProviders.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-zinc-500 mb-1">Model contains</label>
+          <input
+            value={modelFilter}
+            onChange={(e) => setModelFilter(e.target.value)}
+            placeholder="e.g. gpt-4"
+            className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-sm text-zinc-200"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-zinc-500 mb-1">Routed by</label>
+          <select
+            value={routedByFilter}
+            onChange={(e) => setRoutedByFilter(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-sm text-zinc-200"
+          >
+            <option value="">All</option>
+            {uniqueRoutedBy.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs text-zinc-500 mb-1">User ID</label>
+          <input
+            value={userFilter}
+            onChange={(e) => setUserFilter(e.target.value)}
+            placeholder="exact match"
+            className="w-full bg-zinc-900 border border-zinc-800 rounded px-2 py-1.5 text-sm text-zinc-200"
+          />
+        </div>
+      </div>
+
+      {/* Event stream */}
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg overflow-hidden">
+        {filtered.length === 0 ? (
+          <div className="py-16 text-center text-zinc-600 text-sm">
+            {events.length === 0
+              ? "Waiting for traffic… submit a request from the playground or your app."
+              : "No events match the current filters."}
+          </div>
+        ) : (
+          <ul className="divide-y divide-zinc-800/60 max-h-[75vh] overflow-y-auto">
+            {filtered.map((ev) => {
+              const time = new Date(ev.createdAt);
+              return (
+                <li key={ev.id} className="px-4 py-2.5 hover:bg-zinc-900/80 transition-colors">
+                  <Link href={`/dashboard/logs/${ev.id}`} className="block">
+                    <div className="flex items-center gap-3 text-xs">
+                      <span className="text-zinc-600 font-mono w-20 shrink-0">
+                        {time.toLocaleTimeString("en-US", { hour12: false })}
+                      </span>
+                      <span className={`px-1.5 py-0.5 rounded text-xs font-medium border ${PROVIDER_COLORS[ev.provider] || "bg-zinc-800 text-zinc-300 border-zinc-700"}`}>
+                        {ev.provider}
+                      </span>
+                      <span className="font-mono text-zinc-300 truncate w-48 shrink-0">
+                        {ev.model}
+                      </span>
+                      {ev.taskType && (
+                        <span className="text-zinc-400">{ev.taskType}/{ev.complexity ?? "?"}</span>
+                      )}
+                      {ev.routedBy && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-blue-900/30 text-blue-300">
+                          {ev.routedBy}
+                        </span>
+                      )}
+                      {ev.cached && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-cyan-900/40 text-cyan-300">cached</span>
+                      )}
+                      {ev.usedFallback && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-amber-900/40 text-amber-300">fallback</span>
+                      )}
+                      <span className="text-zinc-500 ml-auto shrink-0">
+                        {formatLatency(ev.latencyMs)} · {formatTokens(ev.inputTokens)}/{formatTokens(ev.outputTokens)} · {formatCost(ev.cost ?? 0)}
+                      </span>
+                    </div>
+                    {ev.promptPreview && (
+                      <div className="mt-1 text-xs text-zinc-500 pl-[92px] truncate">
+                        {ev.promptPreview}
+                      </div>
+                    )}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-nav.tsx
+++ b/apps/web/src/components/dashboard-nav.tsx
@@ -38,6 +38,16 @@ const navGroups: NavGroup[] = [
         ),
       },
       {
+        href: "/dashboard/live",
+        label: "Live",
+        icon: (
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <circle cx="12" cy="12" r="3" fill="currentColor" />
+            <circle cx="12" cy="12" r="8" strokeOpacity="0.4" />
+          </svg>
+        ),
+      },
+      {
         href: "/dashboard/analytics",
         label: "Analytics",
         icon: (

--- a/packages/gateway/src/live/emitter.ts
+++ b/packages/gateway/src/live/emitter.ts
@@ -1,0 +1,75 @@
+/**
+ * In-process pub/sub for the live traffic tap (#263). The gateway writes a
+ * `requests` row on every completed chat-completion (live, cached, streaming)
+ * and then publishes a compact event to this emitter; the SSE handler at
+ * `/v1/analytics/live` subscribes, filters by tenant, and forwards to the
+ * browser.
+ *
+ * Single-process by design — Railway runs one gateway replica in the common
+ * case, and the live view is ephemeral (missing a few events on restart is
+ * fine, full history is in `/dashboard/logs`). If we go multi-replica the
+ * right move is a Redis fan-out, not persisting this stream.
+ */
+
+export interface LiveEvent {
+  id: string;
+  provider: string;
+  model: string;
+  taskType: string | null;
+  complexity: string | null;
+  routedBy: string | null;
+  cached: boolean;
+  usedFallback: boolean;
+  latencyMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  cost: number | null;
+  tenantId: string | null;
+  userId: string | null;
+  apiTokenId: string | null;
+  promptPreview: string;
+  createdAt: string;
+}
+
+type Listener = (event: LiveEvent) => void;
+
+const listeners = new Set<Listener>();
+
+export function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function publish(event: LiveEvent): void {
+  for (const l of listeners) {
+    try {
+      l(event);
+    } catch (err) {
+      console.warn("[live-emitter] listener threw:", err instanceof Error ? err.message : err);
+    }
+  }
+}
+
+/** Truncate a JSON-encoded messages array to a short preview. Handles both
+ *  string content and ContentPart[] — images are rendered as `[image]` so the
+ *  preview stays text-only and bounded in size. */
+export function buildPromptPreview(promptJson: string, maxChars = 200): string {
+  try {
+    const messages = JSON.parse(promptJson) as Array<{
+      role: string;
+      content: string | Array<{ type: string; text?: string }>;
+    }>;
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    if (!lastUser) return "";
+    const text =
+      typeof lastUser.content === "string"
+        ? lastUser.content
+        : lastUser.content
+            .map((p) => (p.type === "text" && p.text ? p.text : p.type === "image_url" ? "[image]" : ""))
+            .filter(Boolean)
+            .join(" ");
+    return text.length > maxChars ? text.slice(0, maxChars) + "…" : text;
+  } catch {
+    return promptJson.slice(0, maxChars);
+  }
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -39,6 +39,7 @@ import { checkBudgetHardStop } from "./billing/budget-alerts.js";
 import { createJudge } from "./routing/judge.js";
 import { getCached, putCache, cacheStats } from "./cache/index.js";
 import { messagesHaveImage } from "./providers/types.js";
+import { publish as publishLive, subscribe as subscribeLive, buildPromptPreview, type LiveEvent } from "./live/emitter.js";
 import { createSemanticCache, type SemanticCache } from "./cache/semantic.js";
 import { createEmbeddingProvider } from "./embeddings/index.js";
 import { getMode } from "./config.js";
@@ -513,6 +514,25 @@ export async function createRouter(ctx: RouterContext) {
           abTestId: routingResult.abTestId || null,
         })
         .run();
+      publishLive({
+        id: hitId,
+        provider: providerForResp,
+        model: modelForResp,
+        taskType: routingResult.taskType,
+        complexity: routingResult.complexity,
+        routedBy: routingResult.routedBy,
+        cached: true,
+        usedFallback: false,
+        latencyMs: 0,
+        inputTokens,
+        outputTokens,
+        cost: 0,
+        tenantId,
+        userId: attribution.userId,
+        apiTokenId: attribution.apiTokenId,
+        promptPreview: buildPromptPreview(promptJson),
+        createdAt: new Date().toISOString(),
+      });
       c.header("X-Provara-Request-Id", hitId);
       c.header("X-Provara-Cache", cacheSource);
       return c.json({
@@ -728,6 +748,26 @@ export async function createRouter(ctx: RouterContext) {
                   tenantId,
                   userId: attribution.userId,
                   apiTokenId: attribution.apiTokenId,
+                }).then((streamCost) => {
+                  publishLive({
+                    id: requestId,
+                    provider: usedProvider,
+                    model: usedModel,
+                    taskType: routingResult.taskType,
+                    complexity: routingResult.complexity,
+                    routedBy: routingResult.routedBy,
+                    cached: false,
+                    usedFallback,
+                    latencyMs,
+                    inputTokens: usage.inputTokens,
+                    outputTokens: usage.outputTokens,
+                    cost: streamCost,
+                    tenantId,
+                    userId: attribution.userId,
+                    apiTokenId: attribution.apiTokenId,
+                    promptPreview: buildPromptPreview(promptJson),
+                    createdAt: new Date().toISOString(),
+                  });
                 }).catch(() => {});
 
                 if (!skipCache) {
@@ -876,7 +916,7 @@ export async function createRouter(ctx: RouterContext) {
       );
     }
 
-    await logCost(ctx.db, {
+    const costUsd = await logCost(ctx.db, {
       requestId,
       provider: usedProvider,
       model: usedModel,
@@ -885,6 +925,26 @@ export async function createRouter(ctx: RouterContext) {
       tenantId,
       userId: attribution.userId,
       apiTokenId: attribution.apiTokenId,
+    });
+
+    publishLive({
+      id: requestId,
+      provider: usedProvider,
+      model: usedModel,
+      taskType: routingResult.taskType,
+      complexity: routingResult.complexity,
+      routedBy: routingResult.routedBy,
+      cached: false,
+      usedFallback,
+      latencyMs,
+      inputTokens: response.usage.inputTokens,
+      outputTokens: response.usage.outputTokens,
+      cost: costUsd,
+      tenantId,
+      userId: attribution.userId,
+      apiTokenId: attribution.apiTokenId,
+      promptPreview: buildPromptPreview(promptJson),
+      createdAt: new Date().toISOString(),
     });
 
     // Cache the response for future identical requests
@@ -993,6 +1053,57 @@ export async function createRouter(ctx: RouterContext) {
       activeAutoAbTestId: autoMap.get(`${cell.taskType}::${cell.complexity}`) ?? null,
     }));
     return c.json({ cells });
+  });
+
+  // Live traffic tap (#263). SSE stream of completed requests, scoped to the
+  // caller's tenant. In-process pub/sub — the router publishes to an emitter
+  // after writing each `requests` row, this handler subscribes and forwards.
+  // Stream is ephemeral; historical logs stay in `/dashboard/logs`.
+  app.get("/v1/analytics/live", (c) => {
+    const tenantId = getTenantId(c.req.raw);
+
+    const stream = new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        controller.enqueue(encoder.encode(": shiplog-live-connected\n\n"));
+
+        const unsubscribe = subscribeLive((event) => {
+          // Tenant isolation — anonymous tenant (null) only receives its own null events.
+          if (tenantId !== null && event.tenantId !== tenantId) return;
+          if (tenantId === null && event.tenantId !== null) return;
+          try {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+          } catch {
+            unsubscribe();
+          }
+        });
+
+        // Keep-alive comment every 20s so proxies don't close the stream
+        const keepAlive = setInterval(() => {
+          try {
+            controller.enqueue(encoder.encode(": keep-alive\n\n"));
+          } catch {
+            clearInterval(keepAlive);
+          }
+        }, 20_000);
+
+        const abort = () => {
+          clearInterval(keepAlive);
+          unsubscribe();
+          try { controller.close(); } catch {}
+        };
+        c.req.raw.signal.addEventListener("abort", abort);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        "Connection": "keep-alive",
+        "X-Accel-Buffering": "no",
+      },
+    });
   });
 
   // Scheduler observability (admin-only). Exposes per-job last-run state


### PR DESCRIPTION
Closes #263.

## Summary
- `GET /v1/analytics/live` — Server-Sent Events stream of completed chat-completion events, tenant-scoped.
- In-process pub/sub (`packages/gateway/src/live/emitter.ts`) — router publishes from all three request-row write sites (cache hit, non-stream, stream).
- `/dashboard/live` — live tail UI with filters (provider, model, routedBy, userId), pause/resume with buffered flush, clear, click-through to Logs detail.
- Nav entry added; analytics.mdx gets a "Live traffic tap" section.

## Out of scope
Multi-replica correlation (fine for Railway single-replica), server-side persistence (use Logs for historical), and replay-from-live (click through to Logs detail + use existing replay there).

## Test plan
- [x] `tsc --noEmit` clean in gateway + web
- [ ] `npx turbo dev`, open `/dashboard/live` in one tab, submit a playground request in another — event appears within ~1s
- [ ] Apply `provider = openai` filter, submit an Anthropic request — does not appear; submit OpenAI — appears
- [ ] Pause, submit 3 more requests, Resume — all 3 flush in at top of list
- [ ] Clear — list empties, stream stays connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)