### PR TITLE
feat(#262): evals MVP — dataset upload, judge-scored runs, per-case results

### DIFF
--- a/apps/docs/content/docs/features/evals.mdx
+++ b/apps/docs/content/docs/features/evals.mdx
@@ -1,0 +1,77 @@
+---
+title: Evals
+description: Upload a JSONL dataset, run it against a model, get per-case judge scores. Prevent prompt/model regressions before they ship, not after.
+---
+
+Provara's replay bank, judge, and model registry already score quality on production traffic. Evals is the same loop applied to a curated dataset you control — a golden test set that regressions must pass to ship.
+
+**Positioning**: your prod quality monitor and your pre-deploy regression check run on the same judge, same models, same scoring. No drift between what "good" means in staging vs. production.
+
+## Quickstart
+
+1. Go to `/dashboard/evals`
+2. Click **Upload dataset**, paste JSONL (one case per line):
+   ```json
+   {"input": [{"role": "user", "content": "What's 2+2?"}]}
+   {"input": [{"role": "user", "content": "Summarize: the sky is blue because of Rayleigh scattering."}]}
+   {"input": [{"role": "user", "content": "Write a haiku about caching."}]}
+   ```
+3. Pick a dataset + a (provider, model) pair, click **Run**
+4. The run executes cases in batches of 4; judge scores each output on a 1–5 scale
+5. Open the run detail to watch progress, drill into individual cases, inspect scores + outputs
+
+## Case format
+
+Each JSONL line is a JSON object:
+
+| Field | Required | Description |
+|---|---|---|
+| `input` | yes | `ChatMessage[]` — the messages array you'd normally POST to `/v1/chat/completions` |
+| `expected` | no | String reference output. Not yet used for pass/fail; reserved for a follow-up that adds exact/fuzzy matching. |
+| `metadata` | no | Arbitrary object. Useful for tagging cases by category, source, ticket number, etc. |
+
+`ChatMessage.content` can be a string or the multimodal `ContentPart[]` shape — evals with image inputs work the same as production vision requests (see [vision](/docs/features/vision)).
+
+## Judge scoring
+
+Each output is graded by a small, cheap model (default: `gpt-4.1-mini` → `claude-haiku-4-5-*` → first available). The judge prompt asks for a 1–5 score considering accuracy, relevance, clarity, and completeness. Failed parses or unreachable judges leave `score: null` — these cases count toward the run's progress but not toward the average.
+
+**Aggregate score**: simple average across cases with a non-null score. Live-updating as each case completes, so long-running datasets show real-time convergence instead of a final reveal.
+
+## API
+
+Same endpoints the dashboard uses:
+
+```
+POST /v1/evals/datasets           { name, description?, jsonl }
+GET  /v1/evals/datasets           list
+GET  /v1/evals/datasets/:id       detail + first 5 cases preview
+DELETE /v1/evals/datasets/:id     cascades to dependent runs + results
+
+POST /v1/evals/runs               { datasetId, provider, model }
+GET  /v1/evals/runs               list (last 50)
+GET  /v1/evals/runs/:id           run + all results + completedCases
+```
+
+A run POST returns immediately (`202 Accepted` with `{ runId, status: "queued" }`); the executor works in the background and writes results as they complete. Poll `/runs/:id` to track progress.
+
+## Cost accounting
+
+Eval runs write rows to `cost_logs` with a `requestId` of `eval-<runId>-<caseIndex>`. They show up on your spend dashboard alongside production traffic, but don't contaminate the adaptive router's EMA — evals deliberately skip the `/v1/chat/completions` path so feedback from evals doesn't get mixed with feedback from real users.
+
+## Out of scope (MVP)
+
+Deferred to follow-ups:
+
+- **CLI + GitHub Action** — run a dataset against a candidate (provider, model) in CI, block the PR on regression. Primary distribution unlock.
+- **Prompt-version variants** — same dataset, two prompt versions, compare scores
+- **Pass/fail with expected outputs** — exact, fuzzy, or model-graded matching against `expected`
+- **Side-by-side run comparison** — two completed runs, delta per case + aggregate
+
+Track them under issues tagged with `feature` + related to #262.
+
+## Related
+
+- [Adaptive routing](/docs/features/adaptive-routing) — judge scoring for live traffic
+- [Regression detection](/docs/features/regression-detection) — replay bank for post-hoc regression catch; evals are the pre-deploy counterpart
+- [Analytics](/docs/features/analytics) — where eval cost shows up on the dashboard

--- a/apps/web/src/app/dashboard/evals/page.tsx
+++ b/apps/web/src/app/dashboard/evals/page.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { gatewayClientFetch, gatewayFetchRaw } from "../../../lib/gateway-client";
+import { formatCost } from "../../../lib/format";
+
+interface Dataset {
+  id: string;
+  name: string;
+  description: string | null;
+  caseCount: number;
+  createdAt: string;
+}
+
+interface Run {
+  id: string;
+  datasetId: string;
+  datasetName: string;
+  provider: string;
+  model: string;
+  status: "queued" | "running" | "completed" | "failed";
+  avgScore: number | null;
+  totalCost: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+}
+
+interface ProviderInfo {
+  name: string;
+  models: string[];
+}
+
+const EXAMPLE_JSONL = `{"input": [{"role": "user", "content": "What's 2+2?"}]}
+{"input": [{"role": "user", "content": "Summarize: the sky is blue because of Rayleigh scattering."}]}
+{"input": [{"role": "user", "content": "Write a haiku about caching."}]}`;
+
+function StatusBadge({ status }: { status: Run["status"] }) {
+  const colors: Record<Run["status"], string> = {
+    queued: "bg-zinc-800 text-zinc-300",
+    running: "bg-blue-900/40 text-blue-300",
+    completed: "bg-emerald-900/40 text-emerald-300",
+    failed: "bg-red-900/40 text-red-300",
+  };
+  return <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${colors[status]}`}>{status}</span>;
+}
+
+export default function EvalsPage() {
+  const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [runs, setRuns] = useState<Run[]>([]);
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Upload form
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadName, setUploadName] = useState("");
+  const [uploadDescription, setUploadDescription] = useState("");
+  const [uploadJsonl, setUploadJsonl] = useState("");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  // Run form
+  const [runDatasetId, setRunDatasetId] = useState("");
+  const [runProviderModel, setRunProviderModel] = useState("");
+  const [runError, setRunError] = useState<string | null>(null);
+  const [runSubmitting, setRunSubmitting] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [d, r, p] = await Promise.all([
+        gatewayClientFetch<{ datasets: Dataset[] }>("/v1/evals/datasets"),
+        gatewayClientFetch<{ runs: Run[] }>("/v1/evals/runs"),
+        gatewayClientFetch<{ providers: ProviderInfo[] }>("/v1/providers"),
+      ]);
+      setDatasets(d.datasets || []);
+      setRuns(r.runs || []);
+      setProviders(p.providers || []);
+    } catch (err) {
+      console.error("evals fetch failed", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    // Poll every 5s — runs update incrementally, keeps the UI honest.
+    const id = setInterval(fetchAll, 5000);
+    return () => clearInterval(id);
+  }, [fetchAll]);
+
+  async function handleUpload(e: React.FormEvent) {
+    e.preventDefault();
+    setUploadError(null);
+    setUploading(true);
+    try {
+      const res = await gatewayFetchRaw("/v1/evals/datasets", {
+        method: "POST",
+        body: JSON.stringify({
+          name: uploadName,
+          description: uploadDescription || undefined,
+          jsonl: uploadJsonl,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error?.message || `HTTP ${res.status}`);
+      }
+      setUploadOpen(false);
+      setUploadName("");
+      setUploadDescription("");
+      setUploadJsonl("");
+      fetchAll();
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleRun(e: React.FormEvent) {
+    e.preventDefault();
+    setRunError(null);
+    if (!runDatasetId || !runProviderModel) {
+      setRunError("Pick a dataset and a model");
+      return;
+    }
+    const [provider, ...modelParts] = runProviderModel.split("/");
+    const model = modelParts.join("/");
+    setRunSubmitting(true);
+    try {
+      const res = await gatewayFetchRaw("/v1/evals/runs", {
+        method: "POST",
+        body: JSON.stringify({ datasetId: runDatasetId, provider, model }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error?.message || `HTTP ${res.status}`);
+      }
+      setRunDatasetId("");
+      setRunProviderModel("");
+      fetchAll();
+    } catch (err) {
+      setRunError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-zinc-400">Loading evals…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Evals</h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            Upload a JSONL dataset, run it against a model, get per-case judge scores. Your golden test set and your prod quality monitor — same loop.
+          </p>
+        </div>
+        <button
+          onClick={() => setUploadOpen(!uploadOpen)}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-md text-sm font-medium"
+        >
+          {uploadOpen ? "Cancel" : "Upload dataset"}
+        </button>
+      </div>
+
+      {/* Upload form */}
+      {uploadOpen && (
+        <form onSubmit={handleUpload} className="bg-zinc-900/50 border border-zinc-800 rounded-lg p-5 space-y-4">
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Name</label>
+            <input
+              value={uploadName}
+              onChange={(e) => setUploadName(e.target.value)}
+              required
+              className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm"
+              placeholder="e.g. panel-photo-regression-v1"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Description (optional)</label>
+            <input
+              value={uploadDescription}
+              onChange={(e) => setUploadDescription(e.target.value)}
+              className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm"
+              placeholder="What this dataset covers"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Cases (JSONL — one JSON object per line)</label>
+            <textarea
+              value={uploadJsonl}
+              onChange={(e) => setUploadJsonl(e.target.value)}
+              rows={10}
+              required
+              className="w-full bg-zinc-950 border border-zinc-700 rounded px-3 py-2 text-xs font-mono"
+              placeholder={EXAMPLE_JSONL}
+            />
+            <p className="mt-1 text-xs text-zinc-600">
+              Each line: <code className="text-zinc-400">{`{"input": ChatMessage[], "expected"?: string, "metadata"?: object}`}</code>
+            </p>
+          </div>
+          {uploadError && (
+            <div className="text-xs text-red-400 bg-red-950/30 border border-red-900/40 rounded px-3 py-2">
+              {uploadError}
+            </div>
+          )}
+          <button
+            type="submit"
+            disabled={uploading}
+            className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 rounded-md text-sm font-medium"
+          >
+            {uploading ? "Uploading…" : "Create dataset"}
+          </button>
+        </form>
+      )}
+
+      {/* Datasets */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">Datasets</h2>
+        {datasets.length === 0 ? (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg py-10 text-center text-sm text-zinc-500">
+            No datasets yet. Upload JSONL above to get started.
+          </div>
+        ) : (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg divide-y divide-zinc-800/60">
+            {datasets.map((d) => (
+              <div key={d.id} className="px-4 py-3 flex items-center gap-4">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-zinc-200 truncate">{d.name}</p>
+                  {d.description && <p className="text-xs text-zinc-500 truncate">{d.description}</p>}
+                </div>
+                <span className="text-xs text-zinc-500 shrink-0">{d.caseCount} cases</span>
+                <span className="text-xs text-zinc-600 shrink-0">
+                  {new Date(d.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Run form */}
+      {datasets.length > 0 && (
+        <form onSubmit={handleRun} className="bg-zinc-900/50 border border-zinc-800 rounded-lg p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-zinc-200">Start a run</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <select
+              value={runDatasetId}
+              onChange={(e) => setRunDatasetId(e.target.value)}
+              className="bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm"
+            >
+              <option value="">Dataset…</option>
+              {datasets.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name} ({d.caseCount} cases)
+                </option>
+              ))}
+            </select>
+            <select
+              value={runProviderModel}
+              onChange={(e) => setRunProviderModel(e.target.value)}
+              className="bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm"
+            >
+              <option value="">Provider / Model…</option>
+              {providers.flatMap((p) =>
+                p.models.map((m) => (
+                  <option key={`${p.name}/${m}`} value={`${p.name}/${m}`}>
+                    {p.name} / {m}
+                  </option>
+                )),
+              )}
+            </select>
+            <button
+              type="submit"
+              disabled={runSubmitting}
+              className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-md text-sm font-medium"
+            >
+              {runSubmitting ? "Queuing…" : "Run"}
+            </button>
+          </div>
+          {runError && (
+            <div className="text-xs text-red-400 bg-red-950/30 border border-red-900/40 rounded px-3 py-2">
+              {runError}
+            </div>
+          )}
+        </form>
+      )}
+
+      {/* Runs */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">Recent runs</h2>
+        {runs.length === 0 ? (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg py-10 text-center text-sm text-zinc-500">
+            No runs yet.
+          </div>
+        ) : (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-zinc-900/60 text-xs text-zinc-500">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium">Dataset</th>
+                  <th className="px-4 py-2 text-left font-medium">Model</th>
+                  <th className="px-4 py-2 text-left font-medium">Status</th>
+                  <th className="px-4 py-2 text-right font-medium">Avg score</th>
+                  <th className="px-4 py-2 text-right font-medium">Cost</th>
+                  <th className="px-4 py-2 text-right font-medium">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-800/60">
+                {runs.map((r) => (
+                  <tr key={r.id} className="hover:bg-zinc-900/80 transition-colors">
+                    <td className="px-4 py-2">
+                      <Link href={`/dashboard/evals/runs/${r.id}`} className="text-blue-400 hover:text-blue-300">
+                        {r.datasetName}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-2 font-mono text-xs text-zinc-300">
+                      {r.provider} / {r.model}
+                    </td>
+                    <td className="px-4 py-2"><StatusBadge status={r.status} /></td>
+                    <td className="px-4 py-2 text-right text-zinc-300">
+                      {r.avgScore !== null ? r.avgScore.toFixed(2) : "—"}
+                    </td>
+                    <td className="px-4 py-2 text-right text-zinc-400">
+                      {r.totalCost !== null ? formatCost(r.totalCost) : "—"}
+                    </td>
+                    <td className="px-4 py-2 text-right text-xs text-zinc-500">
+                      {new Date(r.createdAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/evals/runs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/evals/runs/[id]/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { gatewayClientFetch } from "../../../../../lib/gateway-client";
+import { formatCost, formatLatency } from "../../../../../lib/format";
+
+interface Run {
+  id: string;
+  datasetId: string;
+  provider: string;
+  model: string;
+  status: "queued" | "running" | "completed" | "failed";
+  avgScore: number | null;
+  totalCost: number | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+}
+
+interface Result {
+  id: string;
+  caseIndex: number;
+  input: string;
+  output: string | null;
+  score: number | null;
+  judgeSource: string | null;
+  error: string | null;
+  latencyMs: number | null;
+  cost: number | null;
+  createdAt: string;
+}
+
+function scoreColor(score: number | null) {
+  if (score === null) return "text-zinc-500";
+  if (score >= 4) return "text-emerald-400";
+  if (score >= 3) return "text-yellow-400";
+  return "text-red-400";
+}
+
+function extractPromptPreview(inputJson: string, maxChars = 160): string {
+  try {
+    const messages = JSON.parse(inputJson) as Array<{ role: string; content: string | unknown[] }>;
+    const lastUser = [...messages].reverse().find((m) => m.role === "user");
+    if (!lastUser) return "";
+    const content = lastUser.content;
+    const text =
+      typeof content === "string"
+        ? content
+        : Array.isArray(content)
+          ? content
+              .map((p) => {
+                const part = p as { type?: string; text?: string };
+                return part.type === "text" && part.text ? part.text : part.type === "image_url" ? "[image]" : "";
+              })
+              .filter(Boolean)
+              .join(" ")
+          : "";
+    return text.length > maxChars ? text.slice(0, maxChars) + "…" : text;
+  } catch {
+    return inputJson.slice(0, maxChars);
+  }
+}
+
+export default function EvalRunPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = params.id as string;
+  const [run, setRun] = useState<Run | null>(null);
+  const [results, setResults] = useState<Result[]>([]);
+  const [completedCases, setCompletedCases] = useState(0);
+  const [totalCases, setTotalCases] = useState<number | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const fetchRun = useCallback(async () => {
+    try {
+      const data = await gatewayClientFetch<{
+        run: Run;
+        results: Result[];
+        completedCases: number;
+      }>(`/v1/evals/runs/${id}`);
+      setRun(data.run);
+      setResults(data.results);
+      setCompletedCases(data.completedCases);
+      if (totalCases === null) {
+        // Dataset total case count isn't in the run payload; fetch once.
+        try {
+          const ds = await gatewayClientFetch<{ caseCount: number }>(
+            `/v1/evals/datasets/${data.run.datasetId}`,
+          );
+          setTotalCases(ds.caseCount);
+        } catch {
+          setTotalCases(data.completedCases);
+        }
+      }
+    } catch {
+      router.push("/dashboard/evals");
+    }
+  }, [id, router, totalCases]);
+
+  useEffect(() => {
+    fetchRun();
+    // Poll while the run is in flight. Stop once it's terminal.
+    const poll = setInterval(() => {
+      if (run && (run.status === "completed" || run.status === "failed")) return;
+      fetchRun();
+    }, 3000);
+    return () => clearInterval(poll);
+  }, [fetchRun, run]);
+
+  if (!run) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <p className="text-zinc-400">Loading run…</p>
+      </div>
+    );
+  }
+
+  const progress = totalCases ? (completedCases / totalCases) * 100 : 0;
+
+  function toggle(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link href="/dashboard/evals" className="text-zinc-500 hover:text-zinc-300">
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+        </Link>
+        <h1 className="text-xl font-bold">Eval Run</h1>
+        <code className="text-xs text-zinc-600 font-mono">{run.id}</code>
+      </div>
+
+      {/* Summary */}
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg p-5 grid grid-cols-2 sm:grid-cols-4 gap-6">
+        <div>
+          <p className="text-xs text-zinc-500 mb-1">Model</p>
+          <p className="text-sm font-mono text-zinc-200">{run.provider} / {run.model}</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500 mb-1">Status</p>
+          <p className="text-sm text-zinc-200 capitalize">{run.status}</p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500 mb-1">Avg score</p>
+          <p className={`text-lg font-semibold ${scoreColor(run.avgScore)}`}>
+            {run.avgScore !== null ? run.avgScore.toFixed(2) : "—"}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-zinc-500 mb-1">Total cost</p>
+          <p className="text-sm text-zinc-300">{run.totalCost !== null ? formatCost(run.totalCost) : "—"}</p>
+        </div>
+      </div>
+
+      {/* Progress */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-xs text-zinc-400">
+          <span>
+            {completedCases} / {totalCases ?? "?"} cases
+          </span>
+          <span>{progress.toFixed(0)}%</span>
+        </div>
+        <div className="h-2 bg-zinc-900 rounded-full overflow-hidden">
+          <div
+            className={`h-full transition-all duration-500 ${run.status === "failed" ? "bg-red-600" : "bg-emerald-600"}`}
+            style={{ width: `${Math.min(progress, 100)}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Results */}
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold text-zinc-400 uppercase tracking-widest">Cases</h2>
+        {results.length === 0 ? (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg py-10 text-center text-sm text-zinc-500">
+            Waiting for first case to complete…
+          </div>
+        ) : (
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-lg divide-y divide-zinc-800/60">
+            {results.map((r) => {
+              const isOpen = expanded.has(r.id);
+              return (
+                <div key={r.id}>
+                  <button
+                    onClick={() => toggle(r.id)}
+                    className="w-full px-4 py-3 flex items-center gap-4 hover:bg-zinc-900/80 text-left"
+                  >
+                    <span className="text-xs text-zinc-600 font-mono w-8">#{r.caseIndex}</span>
+                    <span className={`text-sm font-semibold w-10 ${scoreColor(r.score)}`}>
+                      {r.score !== null ? `${r.score}/5` : "—"}
+                    </span>
+                    <span className="flex-1 text-xs text-zinc-400 truncate">
+                      {extractPromptPreview(r.input)}
+                    </span>
+                    <span className="text-xs text-zinc-500 shrink-0">
+                      {r.latencyMs !== null ? formatLatency(r.latencyMs) : ""} ·{" "}
+                      {r.cost !== null ? formatCost(r.cost) : ""}
+                    </span>
+                  </button>
+                  {isOpen && (
+                    <div className="px-4 py-3 bg-zinc-950/40 border-t border-zinc-800/60 space-y-3 text-xs">
+                      <div>
+                        <p className="text-zinc-500 mb-1">Input</p>
+                        <pre className="text-zinc-300 whitespace-pre-wrap font-mono bg-zinc-900/60 p-2 rounded max-h-48 overflow-y-auto">
+                          {r.input}
+                        </pre>
+                      </div>
+                      <div>
+                        <p className="text-zinc-500 mb-1">Output</p>
+                        <pre className="text-zinc-300 whitespace-pre-wrap font-sans bg-zinc-900/60 p-2 rounded max-h-64 overflow-y-auto">
+                          {r.output ?? "(no output)"}
+                        </pre>
+                      </div>
+                      {r.error && (
+                        <div>
+                          <p className="text-red-400 mb-1">Error</p>
+                          <pre className="text-red-300 whitespace-pre-wrap font-mono bg-red-950/30 p-2 rounded">
+                            {r.error}
+                          </pre>
+                        </div>
+                      )}
+                      {r.judgeSource && (
+                        <p className="text-zinc-500">Graded by {r.judgeSource}</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard-nav.tsx
+++ b/apps/web/src/components/dashboard-nav.tsx
@@ -97,6 +97,15 @@ const navGroups: NavGroup[] = [
           </svg>
         ),
       },
+      {
+        href: "/dashboard/evals",
+        label: "Evals",
+        icon: (
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        ),
+      },
     ],
   },
   {

--- a/packages/db/drizzle/0039_aromatic_photon.sql
+++ b/packages/db/drizzle/0039_aromatic_photon.sql
@@ -1,0 +1,41 @@
+CREATE TABLE `eval_datasets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`name` text NOT NULL,
+	`description` text,
+	`cases_jsonl` text NOT NULL,
+	`case_count` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `eval_runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`dataset_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`model` text NOT NULL,
+	`status` text DEFAULT 'queued' NOT NULL,
+	`avg_score` real,
+	`total_cost` real,
+	`started_at` integer,
+	`completed_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`dataset_id`) REFERENCES `eval_datasets`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `eval_results` (
+	`id` text PRIMARY KEY NOT NULL,
+	`run_id` text NOT NULL,
+	`case_index` integer NOT NULL,
+	`input` text NOT NULL,
+	`output` text,
+	`score` integer,
+	`judge_source` text,
+	`error` text,
+	`latency_ms` integer,
+	`cost` real,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`run_id`) REFERENCES `eval_runs`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `eval_results_run_idx` ON `eval_results` (`run_id`);

--- a/packages/db/drizzle/meta/0039_snapshot.json
+++ b/packages/db/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,3539 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "13894be1-77b6-4143-8665-648e06bc52e3",
+  "prevId": "a4c18002-1256-42cd-bfe0-256a8c5f6c22",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "adaptive_isolation_preferences_log": {
+      "name": "adaptive_isolation_preferences_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_created_by_user_id_users_id_fk": {
+          "name": "api_tokens_created_by_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_logs_tenant_created_idx": {
+          "name": "audit_logs_tenant_created_idx",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_tenant_action_created_idx": {
+          "name": "audit_logs_tenant_action_created_idx",
+          "columns": [
+            "tenant_id",
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cost_logs_tenant_user_created_idx": {
+          "name": "cost_logs_tenant_user_created_idx",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "cost_logs_tenant_token_created_idx": {
+          "name": "cost_logs_tenant_token_created_idx",
+          "columns": [
+            "tenant_id",
+            "api_token_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_datasets": {
+      "name": "eval_datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cases_jsonl": {
+          "name": "cases_jsonl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "case_count": {
+          "name": "case_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "case_index": {
+          "name": "case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_source": {
+          "name": "judge_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_results_run_idx": {
+          "name": "eval_results_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_run_id_eval_runs_id_fk": {
+          "name": "eval_results_run_id_eval_runs_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "eval_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_runs": {
+      "name": "eval_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "avg_score": {
+          "name": "avg_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "eval_runs_dataset_id_eval_datasets_id_fk": {
+          "name": "eval_runs_dataset_id_eval_datasets_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "eval_datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_first_name": {
+          "name": "pending_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_last_name": {
+          "name": "pending_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_email_idx": {
+          "name": "magic_link_tokens_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "magic_link_tokens_hash_idx": {
+          "name": "magic_link_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "modalities": {
+          "name": "modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routing_weight_snapshots": {
+      "name": "routing_weight_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "weights": {
+          "name": "weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rws_tenant_captured_idx": {
+          "name": "rws_tenant_captured_idx",
+          "columns": [
+            "tenant_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spend_budgets": {
+      "name": "spend_budgets",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "cap_usd": {
+          "name": "cap_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_thresholds": {
+          "name": "alert_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_emails": {
+          "name": "alert_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hard_stop": {
+          "name": "hard_stop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "alerted_thresholds": {
+          "name": "alerted_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_started_at": {
+          "name": "period_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sso_configs": {
+      "name": "sso_configs",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_entity_id": {
+          "name": "sp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_domains": {
+          "name": "email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_encryption": {
+          "name": "require_encryption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_adaptive_isolation": {
+      "name": "tenant_adaptive_isolation",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumes_pool": {
+          "name": "consumes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contributes_pool": {
+          "name": "contributes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1776632000000,
       "tag": "0038_normalize_moderate_complexity",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1776632431789,
+      "tag": "0039_aromatic_photon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -856,3 +856,70 @@ export const ssoConfigs = sqliteTable("sso_configs", {
     .notNull()
     .$defaultFn(() => new Date()),
 });
+
+/**
+ * Eval datasets and runs (#262). A dataset is a JSONL-encoded collection
+ * of input cases; a run executes every case against a (provider, model)
+ * pair and grades each output with the existing judge pipeline.
+ *
+ * MVP skips per-case expected outputs and pass/fail logic — the judge's
+ * 1–5 quality score is the primary signal. A follow-up will add
+ * expected-output matching and CI integration.
+ */
+export const evalDatasets = sqliteTable("eval_datasets", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  name: text("name").notNull(),
+  description: text("description"),
+  /** JSONL string — one case per line, shape `{input: ChatMessage[], expected?: string, metadata?: object}`. */
+  casesJsonl: text("cases_jsonl").notNull(),
+  caseCount: integer("case_count").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const evalRuns = sqliteTable("eval_runs", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  datasetId: text("dataset_id")
+    .notNull()
+    .references(() => evalDatasets.id),
+  provider: text("provider").notNull(),
+  model: text("model").notNull(),
+  /** Status lifecycle: queued → running → (completed | failed). Set to `failed`
+   *  if the executor crashes before finishing; partial results still persist. */
+  status: text("status", { enum: ["queued", "running", "completed", "failed"] })
+    .notNull()
+    .default("queued"),
+  /** Aggregate average score across all cases with a non-null score. Recomputed
+   *  each time results land so the UI can render a live-updating number. */
+  avgScore: real("avg_score"),
+  totalCost: real("total_cost"),
+  startedAt: integer("started_at", { mode: "timestamp" }),
+  completedAt: integer("completed_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+});
+
+export const evalResults = sqliteTable("eval_results", {
+  id: text("id").primaryKey(),
+  runId: text("run_id")
+    .notNull()
+    .references(() => evalRuns.id),
+  caseIndex: integer("case_index").notNull(),
+  /** Stored for the run view so we don't re-read the dataset JSONL for display. */
+  input: text("input").notNull(),
+  output: text("output"),
+  score: integer("score"),
+  judgeSource: text("judge_source"),
+  error: text("error"),
+  latencyMs: integer("latency_ms"),
+  cost: real("cost"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("eval_results_run_idx").on(table.runId),
+]);

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -9,6 +9,7 @@ import { calculateCost } from "./cost/pricing.js";
 import { createRoutingEngine, NoCapableProviderError, type RoutingProfile } from "./routing/index.js";
 import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
+import { createEvalRoutes } from "./routes/evals.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
 import { createAdminMiddleware, requireRole } from "./auth/admin.js";
@@ -244,6 +245,9 @@ export async function createRouter(ctx: RouterContext) {
 
   // Mount analytics routes
   app.route("/v1/analytics", createAnalyticsRoutes(ctx.db, ctx.registry));
+
+  // Mount evals routes (#262)
+  app.route("/v1/evals", createEvalRoutes(ctx.db, ctx.registry));
 
   // Mount API key management routes
   app.route("/v1/api-keys", createApiKeyRoutes(ctx.db));

--- a/packages/gateway/src/routes/evals.ts
+++ b/packages/gateway/src/routes/evals.ts
@@ -1,0 +1,481 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { evalDatasets, evalRuns, evalResults } from "@provara/db";
+import { eq, desc, and, sql, isNull } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
+import type { ProviderRegistry } from "../providers/index.js";
+import type { ChatMessage } from "../providers/types.js";
+import { logCost } from "../cost/index.js";
+
+/**
+ * Evals (#262). Upload a JSONL dataset, run it against a (provider, model)
+ * pair, grade outputs with the existing judge prompt, persist results.
+ *
+ * MVP scope:
+ *   - Dataset CRUD (JSONL upload, list, detail, delete)
+ *   - Run executor (bounded concurrency, judge-graded)
+ *   - Run list + detail
+ *
+ * Out of scope for MVP (follow-ups):
+ *   - Prompt-version variants
+ *   - Expected-output matching / pass-fail
+ *   - CLI + GitHub Action
+ *   - Side-by-side run comparisons
+ */
+
+interface DatasetCase {
+  input: ChatMessage[];
+  expected?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function parseJsonl(text: string): DatasetCase[] {
+  const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  const cases: DatasetCase[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(lines[i]);
+    } catch {
+      throw new Error(`Line ${i + 1}: invalid JSON`);
+    }
+    if (!parsed || typeof parsed !== "object") {
+      throw new Error(`Line ${i + 1}: must be a JSON object`);
+    }
+    const row = parsed as Record<string, unknown>;
+    const input = row.input;
+    if (!Array.isArray(input) || input.length === 0) {
+      throw new Error(`Line ${i + 1}: "input" must be a non-empty array of chat messages`);
+    }
+    cases.push({
+      input: input as ChatMessage[],
+      expected: typeof row.expected === "string" ? row.expected : undefined,
+      metadata:
+        row.metadata && typeof row.metadata === "object"
+          ? (row.metadata as Record<string, unknown>)
+          : undefined,
+    });
+  }
+  return cases;
+}
+
+const JUDGE_PROMPT = `You are a strict, impartial evaluator. Rate the response's quality on a 1–5 scale (1=terrible, 5=excellent). Consider accuracy, relevance, clarity, and completeness. Return ONLY JSON like {"score": N}, no other text.`;
+
+function parseJudgeResponse(raw: string): number | null {
+  const match = raw.match(/\{[\s\S]*?\}/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[0]) as { score?: unknown };
+    if (typeof parsed.score === "number" && parsed.score >= 1 && parsed.score <= 5) {
+      return Math.round(parsed.score);
+    }
+  } catch {}
+  return null;
+}
+
+function pickJudgeTarget(registry: ProviderRegistry): { provider: string; model: string } | null {
+  // Prefer a known reliable grader; fall back to any available provider.
+  const preferred: { provider: string; models: string[] }[] = [
+    { provider: "openai", models: ["gpt-4.1-mini", "gpt-4o-mini"] },
+    { provider: "anthropic", models: ["claude-haiku-4-5-20251001"] },
+  ];
+  for (const pref of preferred) {
+    const provider = registry.get(pref.provider);
+    if (!provider) continue;
+    for (const model of pref.models) {
+      if (provider.models.includes(model)) return { provider: pref.provider, model };
+    }
+  }
+  const first = registry.list()[0];
+  if (first && first.models.length > 0) {
+    return { provider: first.name, model: first.models[0] };
+  }
+  return null;
+}
+
+async function executeRun(
+  db: Db,
+  registry: ProviderRegistry,
+  runId: string,
+  datasetCases: DatasetCase[],
+  target: { provider: string; model: string },
+  tenantId: string | null,
+): Promise<void> {
+  await db
+    .update(evalRuns)
+    .set({ status: "running", startedAt: new Date() })
+    .where(eq(evalRuns.id, runId))
+    .run();
+
+  const provider = registry.get(target.provider);
+  if (!provider) {
+    await db
+      .update(evalRuns)
+      .set({ status: "failed", completedAt: new Date() })
+      .where(eq(evalRuns.id, runId))
+      .run();
+    return;
+  }
+
+  const judgeTarget = pickJudgeTarget(registry);
+  const CONCURRENCY = 4;
+  let totalScoreSum = 0;
+  let totalScoreCount = 0;
+  let totalCost = 0;
+
+  async function runCase(caseIndex: number, c: DatasetCase) {
+    const start = performance.now();
+    let output: string | null = null;
+    let score: number | null = null;
+    let judgeSource: string | null = null;
+    let errorStr: string | null = null;
+    let caseCost = 0;
+    try {
+      const resp = await provider!.complete({
+        model: target.model,
+        messages: c.input,
+        temperature: 0,
+      });
+      output = resp.content;
+      caseCost = await logCost(db, {
+        requestId: `eval-${runId}-${caseIndex}`,
+        provider: target.provider,
+        model: target.model,
+        inputTokens: resp.usage.inputTokens,
+        outputTokens: resp.usage.outputTokens,
+        tenantId,
+      });
+      if (judgeTarget) {
+        try {
+          const judgeProvider = registry.get(judgeTarget.provider);
+          if (judgeProvider) {
+            const lastUser = [...c.input].reverse().find((m) => m.role === "user");
+            const userText =
+              typeof lastUser?.content === "string"
+                ? lastUser.content
+                : Array.isArray(lastUser?.content)
+                  ? lastUser.content
+                      .map((p) => (p.type === "text" ? p.text : "[image]"))
+                      .join(" ")
+                  : "";
+            const judgeResp = await judgeProvider.complete({
+              model: judgeTarget.model,
+              messages: [
+                { role: "system", content: JUDGE_PROMPT },
+                {
+                  role: "user",
+                  content: `**User prompt:**\n${userText}\n\n**Response:**\n${output}`,
+                },
+              ],
+              temperature: 0,
+              max_tokens: 40,
+            });
+            score = parseJudgeResponse(judgeResp.content);
+            judgeSource = `${judgeTarget.provider}/${judgeTarget.model}`;
+          }
+        } catch (err) {
+          console.warn(
+            `[evals] judge failed for run ${runId} case ${caseIndex}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    } catch (err) {
+      errorStr = err instanceof Error ? err.message : String(err);
+    }
+
+    const latencyMs = Math.round(performance.now() - start);
+    await db
+      .insert(evalResults)
+      .values({
+        id: nanoid(),
+        runId,
+        caseIndex,
+        input: JSON.stringify(c.input),
+        output,
+        score,
+        judgeSource,
+        error: errorStr,
+        latencyMs,
+        cost: caseCost,
+      })
+      .run();
+
+    if (score !== null) {
+      totalScoreSum += score;
+      totalScoreCount++;
+    }
+    totalCost += caseCost;
+
+    // Incremental aggregate update so the UI's poll shows live progress.
+    await db
+      .update(evalRuns)
+      .set({
+        avgScore: totalScoreCount > 0 ? totalScoreSum / totalScoreCount : null,
+        totalCost,
+      })
+      .where(eq(evalRuns.id, runId))
+      .run();
+  }
+
+  // Execute cases in bounded concurrency batches.
+  for (let i = 0; i < datasetCases.length; i += CONCURRENCY) {
+    const batch = datasetCases.slice(i, i + CONCURRENCY).map((c, j) => runCase(i + j, c));
+    await Promise.all(batch);
+  }
+
+  await db
+    .update(evalRuns)
+    .set({ status: "completed", completedAt: new Date() })
+    .where(eq(evalRuns.id, runId))
+    .run();
+}
+
+export function createEvalRoutes(db: Db, registry: ProviderRegistry) {
+  const app = new Hono();
+
+  // --- Datasets ---
+
+  app.post("/datasets", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{ name?: string; description?: string; jsonl?: string }>();
+    if (!body.name || typeof body.name !== "string") {
+      return c.json({ error: { message: "`name` is required", type: "validation_error" } }, 400);
+    }
+    if (!body.jsonl || typeof body.jsonl !== "string") {
+      return c.json(
+        { error: { message: "`jsonl` is required (line-delimited JSON of cases)", type: "validation_error" } },
+        400,
+      );
+    }
+    let cases: DatasetCase[];
+    try {
+      cases = parseJsonl(body.jsonl);
+    } catch (err) {
+      return c.json(
+        {
+          error: {
+            message: `Dataset parse error: ${err instanceof Error ? err.message : String(err)}`,
+            type: "validation_error",
+          },
+        },
+        400,
+      );
+    }
+    if (cases.length === 0) {
+      return c.json({ error: { message: "Dataset has no cases", type: "validation_error" } }, 400);
+    }
+
+    const id = nanoid();
+    await db
+      .insert(evalDatasets)
+      .values({
+        id,
+        tenantId,
+        name: body.name,
+        description: body.description || null,
+        casesJsonl: body.jsonl,
+        caseCount: cases.length,
+      })
+      .run();
+    return c.json({ id, name: body.name, caseCount: cases.length }, 201);
+  });
+
+  app.get("/datasets", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const rows = await db
+      .select({
+        id: evalDatasets.id,
+        name: evalDatasets.name,
+        description: evalDatasets.description,
+        caseCount: evalDatasets.caseCount,
+        createdAt: evalDatasets.createdAt,
+      })
+      .from(evalDatasets)
+      .where(tenantFilter(evalDatasets.tenantId, tenantId))
+      .orderBy(desc(evalDatasets.createdAt))
+      .all();
+    return c.json({ datasets: rows });
+  });
+
+  app.get("/datasets/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+    const tc = tenantFilter(evalDatasets.tenantId, tenantId);
+    const row = await db
+      .select()
+      .from(evalDatasets)
+      .where(tc ? and(eq(evalDatasets.id, id), tc) : eq(evalDatasets.id, id))
+      .get();
+    if (!row) {
+      return c.json({ error: { message: "Dataset not found", type: "not_found" } }, 404);
+    }
+    // Return a preview of the first 5 cases so the UI can show what's inside
+    // without downloading the full JSONL (datasets can be large).
+    let preview: DatasetCase[] = [];
+    try {
+      preview = parseJsonl(row.casesJsonl).slice(0, 5);
+    } catch {}
+    return c.json({
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      caseCount: row.caseCount,
+      createdAt: row.createdAt,
+      preview,
+    });
+  });
+
+  app.delete("/datasets/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+    const tc = tenantFilter(evalDatasets.tenantId, tenantId);
+    const where = tc ? and(eq(evalDatasets.id, id), tc) : eq(evalDatasets.id, id);
+    const existing = await db.select().from(evalDatasets).where(where).get();
+    if (!existing) {
+      return c.json({ error: { message: "Dataset not found", type: "not_found" } }, 404);
+    }
+    // Cascade: delete dependent runs + their results. SQLite FK is non-cascading
+    // in our config, so explicit cleanup keeps the tables consistent.
+    const runs = await db.select({ id: evalRuns.id }).from(evalRuns).where(eq(evalRuns.datasetId, id)).all();
+    for (const r of runs) {
+      await db.delete(evalResults).where(eq(evalResults.runId, r.id)).run();
+    }
+    await db.delete(evalRuns).where(eq(evalRuns.datasetId, id)).run();
+    await db.delete(evalDatasets).where(where).run();
+    return c.json({ ok: true });
+  });
+
+  // --- Runs ---
+
+  app.post("/runs", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{ datasetId?: string; provider?: string; model?: string }>();
+    if (!body.datasetId || !body.provider || !body.model) {
+      return c.json(
+        { error: { message: "`datasetId`, `provider`, `model` are required", type: "validation_error" } },
+        400,
+      );
+    }
+    const tc = tenantFilter(evalDatasets.tenantId, tenantId);
+    const dataset = await db
+      .select()
+      .from(evalDatasets)
+      .where(tc ? and(eq(evalDatasets.id, body.datasetId), tc) : eq(evalDatasets.id, body.datasetId))
+      .get();
+    if (!dataset) {
+      return c.json({ error: { message: "Dataset not found", type: "not_found" } }, 404);
+    }
+    if (!registry.get(body.provider)) {
+      return c.json(
+        {
+          error: {
+            message: `Provider \`${body.provider}\` is not registered. Configure its API key first.`,
+            type: "validation_error",
+          },
+        },
+        400,
+      );
+    }
+
+    const runId = nanoid();
+    await db
+      .insert(evalRuns)
+      .values({
+        id: runId,
+        tenantId,
+        datasetId: body.datasetId,
+        provider: body.provider,
+        model: body.model,
+      })
+      .run();
+
+    // Fire-and-forget — the executor writes results + status as it goes. The UI
+    // polls `/runs/:id` to track progress.
+    let cases: DatasetCase[];
+    try {
+      cases = parseJsonl(dataset.casesJsonl);
+    } catch (err) {
+      await db
+        .update(evalRuns)
+        .set({ status: "failed", completedAt: new Date() })
+        .where(eq(evalRuns.id, runId))
+        .run();
+      return c.json(
+        {
+          error: {
+            message: `Failed to parse dataset cases: ${err instanceof Error ? err.message : String(err)}`,
+            type: "internal_error",
+          },
+        },
+        500,
+      );
+    }
+    void executeRun(db, registry, runId, cases, { provider: body.provider, model: body.model }, tenantId).catch(
+      async (err) => {
+        console.error(`[evals] run ${runId} crashed:`, err instanceof Error ? err.message : err);
+        await db
+          .update(evalRuns)
+          .set({ status: "failed", completedAt: new Date() })
+          .where(eq(evalRuns.id, runId))
+          .run();
+      },
+    );
+
+    return c.json({ runId, status: "queued" }, 202);
+  });
+
+  app.get("/runs", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const rows = await db
+      .select({
+        id: evalRuns.id,
+        datasetId: evalRuns.datasetId,
+        datasetName: evalDatasets.name,
+        provider: evalRuns.provider,
+        model: evalRuns.model,
+        status: evalRuns.status,
+        avgScore: evalRuns.avgScore,
+        totalCost: evalRuns.totalCost,
+        startedAt: evalRuns.startedAt,
+        completedAt: evalRuns.completedAt,
+        createdAt: evalRuns.createdAt,
+      })
+      .from(evalRuns)
+      .innerJoin(evalDatasets, eq(evalRuns.datasetId, evalDatasets.id))
+      .where(tenantFilter(evalRuns.tenantId, tenantId))
+      .orderBy(desc(evalRuns.createdAt))
+      .limit(50)
+      .all();
+    return c.json({ runs: rows });
+  });
+
+  app.get("/runs/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+    const tc = tenantFilter(evalRuns.tenantId, tenantId);
+    const run = await db
+      .select()
+      .from(evalRuns)
+      .where(tc ? and(eq(evalRuns.id, id), tc) : eq(evalRuns.id, id))
+      .get();
+    if (!run) {
+      return c.json({ error: { message: "Run not found", type: "not_found" } }, 404);
+    }
+    const results = await db
+      .select()
+      .from(evalResults)
+      .where(eq(evalResults.runId, id))
+      .orderBy(evalResults.caseIndex)
+      .all();
+    const totals = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(evalResults)
+      .where(eq(evalResults.runId, id))
+      .get();
+    return c.json({ run, results, completedCases: totals?.count || 0 });
+  });
+
+  return app;
+}


### PR DESCRIPTION
Closes #262.

## Summary
- **DB** (migration 0039): `eval_datasets`, `eval_runs`, `eval_results`. All tenant-scoped. FK from results → runs → datasets.
- **Gateway** (`packages/gateway/src/routes/evals.ts`): dataset CRUD with JSONL validation, run executor with bounded concurrency (4) and judge-graded 1–5 scoring, live-updating aggregate `avg_score` + `total_cost`. Eval cost rows land in `cost_logs` with `requestId: eval-<runId>-<caseIndex>` — shows up on spend dashboard but routed outside `/v1/chat/completions` so evals don't contaminate the adaptive EMA.
- **Dashboard**: `/dashboard/evals` (upload + list + run form + recent runs) and `/dashboard/evals/runs/[id]` (progress bar, live aggregate, expandable per-case rows).
- **Docs**: `features/evals.mdx` — quickstart, case format, judge scoring, API surface, MVP scope + follow-up list.

## Judge target
Picked dynamically at run time: prefers `openai/gpt-4.1-mini` → `openai/gpt-4o-mini` → `anthropic/claude-haiku-4-5-*` → first available. Failed parses or unreachable judges leave `score: null`; non-null scores drive the aggregate.

## Out of scope (follow-ups)
- CLI + GitHub Action (the distribution unlock — biggest next piece)
- Prompt-version variants (same dataset, two prompt versions, compare)
- Pass/fail with `expected` outputs (exact, fuzzy, or model-graded matching)
- Side-by-side run comparison view

## Test plan
- [x] `tsc --noEmit` clean in gateway + web
- [ ] Upload 5-case JSONL, run against `gpt-4.1-mini`, watch progress bar fill in real time
- [ ] Verify `avg_score` updates as cases land (not only at completion)
- [ ] Verify `cost_logs` gets rows with `request_id LIKE 'eval-%'`
- [ ] Verify adaptive EMA (`/dashboard/routing` heatmap) is unchanged after running evals — scores should not leak into prod cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)