### PR TITLE
fix: gate /v1/evals/* behind Intelligence tier; keep live tap free

### DIFF
--- a/apps/docs/content/docs/features/evals.mdx
+++ b/apps/docs/content/docs/features/evals.mdx
@@ -3,6 +3,8 @@ title: Evals
 description: Upload a JSONL dataset, run it against a model, get per-case judge scores. Prevent prompt/model regressions before they ship, not after.
 ---
 
+**Tier**: Intelligence (paid). Self-host and cloud tenants without a Pro+ subscription get a `402` with an upgrade payload.
+
 Provara's replay bank, judge, and model registry already score quality on production traffic. Evals is the same loop applied to a curated dataset you control — a golden test set that regressions must pass to ship.
 
 **Positioning**: your prod quality monitor and your pre-deploy regression check run on the same judge, same models, same scoring. No drift between what "good" means in staging vs. production.

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -240,6 +240,7 @@ export async function createRouter(ctx: RouterContext) {
   const tierGate = requireIntelligenceTier(ctx.db);
   app.use("/v1/regression/*", tierGate);
   app.use("/v1/cost-migrations/*", tierGate);
+  app.use("/v1/evals/*", tierGate);
   app.route("/v1/regression", createRegressionRoutes(ctx.db, routingEngine.regressionCellTable));
   app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
 


### PR DESCRIPTION
## Summary
- `/v1/evals/*` now sits behind `requireIntelligenceTier`, joining `/v1/regression/*` and `/v1/cost-migrations/*`. Self-host without `PROVARA_CLOUD` and cloud tenants without Pro+ get the standard `402` + upgrade-card payload.
- `/v1/analytics/live` stays free by design — gateway-level observability, same bucket as `/dashboard/logs`. Its job is to be a shareable wedge that pulls users toward the paid tier.
- `features/evals.mdx` now opens with a "Tier: Intelligence (paid)" banner so prospects aren't surprised.

## Rationale
Per the monetization decision captured earlier: Intelligence features (adaptive, regression, cost migration, spend intelligence) are paid; core gateway stays free. Evals are the pre-deploy counterpart to regression detection and belong in the Intelligence bucket. Live tap is core-gateway observability — free is the right pitch + funnel play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)