### PR TITLE
feat(#265): jailbreak detection — four built-in guardrail rules

### DIFF
--- a/apps/docs/content/docs/features/jailbreak-detection.mdx
+++ b/apps/docs/content/docs/features/jailbreak-detection.mdx
@@ -1,0 +1,61 @@
+---
+title: Jailbreak detection
+description: Detect and block prompt-injection attempts that try to extract system prompts, override instructions, or pivot the assistant off-policy.
+---
+
+Every enterprise security questionnaire asks about prompt injection. Provara ships four built-in detection rules that catch the most common attack surfaces, layered on top of the existing guardrails engine — no new infrastructure, no extra latency.
+
+**Tier**: free. Ships as part of the core gateway.
+
+## What's detected
+
+| Rule | Catches | Default action |
+|---|---|---|
+| Instruction override | "ignore previous instructions", "disregard your rules", "forget everything above" | Block |
+| System prompt extraction | "reveal your system prompt", "show me the initial prompt", "repeat your instructions" | Block |
+| Role reversal / mode switch | "you are now DAN", "pretend to be unrestricted", "enable developer mode" | Block |
+| Delimiter injection | `### new instructions`, `</system>`, `[SYSTEM]`, embedded `SYSTEM:` headers | Block |
+
+All rules are **disabled by default**. Tenants opt in from `/dashboard/guardrails` once they've reviewed the false-positive tradeoff for their workload.
+
+## Enabling
+
+1. Open `/dashboard/guardrails`
+2. Find the rules under the "Jailbreak Detection" group
+3. Toggle on the ones you want
+4. Optionally switch action from `block` to `flag` if you want observation-mode first (flagged requests still reach the model; violations log to the guardrails table for audit)
+
+## Tuning for false positives
+
+The patterns are deliberately literal — no context analysis, just regex matches on input text. This means:
+
+- A legitimate request like *"Can you show me the instructions for setting up a dev environment?"* will match "show me... the instructions" and block. For this kind of workload, either use `flag` mode or disable the system-prompt-extraction rule specifically.
+- The role-reversal rule targets the well-known DAN/DUDE/jailbreak lexicon. Less likely to false-positive against normal traffic, but a tutorial writing about jailbreaks *will* trip it. Guardrails are per-tenant, so content-writing workspaces can stay permissive while production API traffic stays locked down.
+
+Custom rules (`type: "regex"`) can complement the built-ins — add a pattern specific to your domain (e.g. block any message containing your internal ticketing system's API key prefix).
+
+## Limitations
+
+The MVP is heuristic-only. **Deferred to a follow-up**:
+
+- **Classifier-based detection** — route a copy of each input to a small model trained on jailbreak datasets. Catches semantic attacks that don't match known phrases. Will ship behind a flag since it adds a per-request API call.
+- **Multi-language patterns** — current rules are English-only. Non-English jailbreaks pass through silently.
+- **Response-side detection** — detecting when a jailbreak *succeeded* from the output, not just the input. A separate, harder problem.
+
+## API
+
+Same guardrails endpoints you already use:
+
+```
+GET    /v1/guardrails            list rules (auto-seeds jailbreak rules on first call)
+PUT    /v1/guardrails/:id        toggle enabled, change action, edit pattern
+POST   /v1/guardrails            create a custom rule
+GET    /v1/guardrails/logs       recent violations
+```
+
+Blocked requests return `400 guardrail_error` with the matched rule name in the message. The audit log row records the matched snippet so you can review false positives.
+
+## Related
+
+- [Guardrails](/docs/features/guardrails) — the engine that backs this feature; covers PII detection, custom regex, and rule lifecycle
+- [Audit logs](/docs/features/audit-logs) — every guardrail action is logged for compliance review

--- a/apps/web/src/app/dashboard/guardrails/page.tsx
+++ b/apps/web/src/app/dashboard/guardrails/page.tsx
@@ -34,6 +34,7 @@ const TYPE_LABELS: Record<string, string> = {
   content: "Content Policy",
   regex: "Custom Regex",
   token_limit: "Token Limit",
+  jailbreak: "Jailbreak Detection",
 };
 
 function AddRuleForm({ onCreated }: { onCreated: () => void }) {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -246,7 +246,7 @@ export const guardrailRules = sqliteTable("guardrail_rules", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),
   name: text("name").notNull(),
-  type: text("type", { enum: ["pii", "content", "regex", "token_limit"] }).notNull(),
+  type: text("type", { enum: ["pii", "content", "regex", "token_limit", "jailbreak"] }).notNull(),
   target: text("target", { enum: ["input", "output", "both"] }).notNull().default("both"),
   action: text("action", { enum: ["block", "redact", "flag"] }).notNull().default("block"),
   pattern: text("pattern"), // regex pattern or JSON config

--- a/packages/gateway/src/guardrails/patterns.ts
+++ b/packages/gateway/src/guardrails/patterns.ts
@@ -1,4 +1,6 @@
-// Built-in PII detection patterns
+// Built-in PII detection patterns + jailbreak/prompt-injection signatures.
+// All patterns compile with `gi` flags in engine.ts, so case-insensitivity is
+// free — patterns stay readable.
 export const BUILTIN_RULES = [
   {
     name: "SSN (US Social Security Number)",
@@ -46,6 +48,42 @@ export const BUILTIN_RULES = [
     name: "Generic API Key/Secret",
     type: "content" as const,
     pattern: "(?i)(?:api[_-]?key|api[_-]?secret|access[_-]?token|secret[_-]?key)\\s*[:=]\\s*['\"]?[A-Za-z0-9_\\-]{20,}",
+    target: "input" as const,
+    action: "block" as const,
+  },
+
+  // Jailbreak / prompt-injection detection (#265). Disabled by default;
+  // tenants opt in from the dashboard once they understand the false-positive
+  // tradeoff. Input-side only — output-side detection is a separate problem.
+  {
+    name: "Jailbreak — instruction override",
+    type: "jailbreak" as const,
+    pattern:
+      "\\b(?:ignore\\s+(?:all\\s+|your\\s+|previous\\s+|prior\\s+|earlier\\s+|the\\s+)*(?:instructions?|prompts?|rules?|system\\s+prompts?)|forget\\s+(?:everything|all)\\s+(?:above|before)|disregard\\s+(?:the\\s+|your\\s+|previous\\s+)?(?:instructions?|rules?))\\b",
+    target: "input" as const,
+    action: "block" as const,
+  },
+  {
+    name: "Jailbreak — system prompt extraction",
+    type: "jailbreak" as const,
+    pattern:
+      "\\b(?:reveal|show|print|output|repeat|display)\\s+(?:me\\s+)?(?:your|the)\\s+(?:system\\s+prompt|initial\\s+prompt|instructions?|rules?|guidelines?|original\\s+prompt)\\b",
+    target: "input" as const,
+    action: "block" as const,
+  },
+  {
+    name: "Jailbreak — role reversal / mode switch",
+    type: "jailbreak" as const,
+    pattern:
+      "\\b(?:you\\s+are\\s+now\\s+(?:DAN|DUDE|STAN|Do\\s+Anything\\s+Now|Developer\\s+Mode|Admin\\s+Mode|Jailbroken)|pretend\\s+(?:you\\s+are|to\\s+be)\\s+(?:an?\\s+|the\\s+)?(?:unrestricted|uncensored|unfiltered|jailbroken|unlocked)|enable\\s+(?:developer|debug|admin|god|sudo)\\s+mode)\\b",
+    target: "input" as const,
+    action: "block" as const,
+  },
+  {
+    name: "Jailbreak — delimiter injection",
+    type: "jailbreak" as const,
+    pattern:
+      "(?:#{2,}\\s*(?:new\\s+instructions?|end\\s+of\\s+system|override|system\\s+prompt)|</(?:system|instructions?)>|\\[\\s*SYSTEM\\s*\\]|\\n\\s*SYSTEM\\s*:)",
     target: "input" as const,
     action: "block" as const,
   },


### PR DESCRIPTION
Closes #265.

## Summary
- Four new built-in guardrail rules under a new `jailbreak` type: instruction override, system prompt extraction, role reversal / mode switch, delimiter injection.
- Disabled by default — tenants opt in from `/dashboard/guardrails` after reviewing the false-positive tradeoff.
- No migration: SQLite text columns don't enforce enum at DB level, and `ensureBuiltInRules` auto-seeds missing rules on any GET to /v1/guardrails so existing tenants pick up the new rules on next dashboard open.
- UI: `TYPE_LABELS` gets a "Jailbreak Detection" entry so rules render in their own group.
- Docs: `features/jailbreak-detection.mdx` covers what's caught, tuning, limitations.

## Deferred to follow-up
- Classifier-based detection (small-model API call per request)
- Multi-language patterns
- Response-side success detection

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Open `/dashboard/guardrails` — confirm 4 new rules appear under "Jailbreak Detection", all disabled
- [ ] Toggle "instruction override" on; POST a request containing "ignore previous instructions" — confirm 400 `guardrail_error`
- [ ] Confirm a legitimate request that doesn't match passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)