### PR TITLE
feat(#266): fork-from-log + save-as-eval-case

### DIFF
--- a/apps/docs/content/docs/features/evals.mdx
+++ b/apps/docs/content/docs/features/evals.mdx
@@ -72,6 +72,17 @@ Deferred to follow-ups:
 
 Track them under issues tagged with `feature` + related to #262.
 
+## Building datasets from production traffic
+
+The fastest way to seed a dataset is from real requests that went through Provara:
+
+1. Open `/dashboard/logs`, find the request you want to use as a test case
+2. Click **Fork to Playground** (top-right of the detail page)
+3. Edit the prompt / settings / model if you want, rerun
+4. Click **Save as eval case** in the top bar — pick an existing dataset or create a new one inline
+
+Each saved case stores the user→assistant exchange as a single JSONL line with `expected` set to the observed response. Run the dataset later against any candidate model to catch regressions before they ship.
+
 ## Related
 
 - [Adaptive routing](/docs/features/adaptive-routing) — judge scoring for live traffic

--- a/apps/web/src/app/dashboard/logs/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/logs/[id]/page.tsx
@@ -305,6 +305,16 @@ export default function RequestDetailPage() {
         </Link>
         <h1 className="text-xl font-bold">Request Detail</h1>
         <code className="text-xs text-zinc-600 font-mono">{request.id}</code>
+        <Link
+          href={`/dashboard/playground?forkFrom=${request.id}`}
+          className="ml-auto px-3 py-1.5 text-xs rounded-md bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-200 inline-flex items-center gap-1.5"
+          title="Open this request in the Playground with messages + model pre-filled"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8h9M7.5 12h9m-9 4h6M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          Fork to Playground
+        </Link>
       </div>
 
       {/* Metadata grid */}

--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { gatewayClientFetch } from "../../../lib/gateway-client";
+import { useSearchParams, useRouter } from "next/navigation";
+import { gatewayClientFetch, gatewayFetchRaw } from "../../../lib/gateway-client";
 import { ChatInput, type ChatInputHandle } from "../../../components/chat/ChatInput";
 import { MessageList } from "../../../components/chat/MessageList";
 import { SettingsPanel } from "../../../components/chat/SettingsPanel";
@@ -46,6 +47,66 @@ export default function PlaygroundPage() {
       .then((data) => setProviders(data.providers || []))
       .catch(console.error);
   }, []);
+
+  // Fork from a logged request (#266). When the URL carries `?forkFrom=<id>`,
+  // load that request's messages + model + system prompt into the playground
+  // so the user can edit and rerun without manual copy-paste. Runs once on
+  // mount; strips the param after loading so a page refresh doesn't re-fork.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const forkFromId = searchParams.get("forkFrom");
+  useEffect(() => {
+    if (!forkFromId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await gatewayClientFetch<{
+          request: { provider: string; model: string; prompt: string };
+        }>(`/v1/analytics/requests/${forkFromId}`);
+        if (cancelled) return;
+        const messages = JSON.parse(data.request.prompt) as Array<{
+          role: "system" | "user" | "assistant";
+          content: string | Array<{ type: string; text?: string }>;
+        }>;
+        const systemMsg = messages.find((m) => m.role === "system");
+        if (systemMsg) {
+          setSystemPrompt(
+            typeof systemMsg.content === "string"
+              ? systemMsg.content
+              : systemMsg.content
+                  .map((p) => (p.type === "text" && p.text ? p.text : ""))
+                  .filter(Boolean)
+                  .join("\n"),
+          );
+        }
+        const nonSystem = messages
+          .filter((m) => m.role !== "system")
+          .map((m) => ({
+            role: m.role,
+            content:
+              typeof m.content === "string"
+                ? m.content
+                : m.content
+                    .map((p) =>
+                      p.type === "text" && p.text ? p.text : p.type === "image_url" ? "[image]" : "",
+                    )
+                    .filter(Boolean)
+                    .join(" "),
+          }));
+        session.loadMessages(nonSystem);
+        setSelectedProvider(data.request.provider);
+        setSelectedModel(data.request.model);
+        toast.success("Loaded request — edit and rerun below");
+      } catch {
+        toast.error("Failed to load request");
+      } finally {
+        // Clear the query param so a refresh doesn't re-fork.
+        router.replace("/dashboard/playground");
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [forkFromId]);
 
   // Auto-save when messages change and streaming has completed. Creates on the
   // first assistant turn of an unsaved session; otherwise PATCHes the active
@@ -102,6 +163,97 @@ export default function PlaygroundPage() {
     if (!id) return;
     session.loadMessages(slice);
     setActiveConversationId(id);
+  }
+
+  // Save-as-eval-case state (#266)
+  const [saveEvalOpen, setSaveEvalOpen] = useState(false);
+  const [evalDatasets, setEvalDatasets] = useState<{ id: string; name: string }[]>([]);
+  const [evalDatasetId, setEvalDatasetId] = useState("");
+  const [newDatasetName, setNewDatasetName] = useState("");
+  const [savingEval, setSavingEval] = useState(false);
+
+  async function openSaveEval() {
+    setSaveEvalOpen(true);
+    try {
+      const res = await gatewayClientFetch<{ datasets: { id: string; name: string }[] }>(
+        "/v1/evals/datasets",
+      );
+      setEvalDatasets(res.datasets || []);
+    } catch {
+      // If evals is tier-gated and the tenant doesn't have access, this 402s —
+      // surface a helpful toast instead of a silent empty list.
+      toast.error("Evals requires the Intelligence tier. Upgrade to save cases.");
+      setSaveEvalOpen(false);
+    }
+  }
+
+  async function handleSaveEvalCase() {
+    // Take everything up through the last assistant message — that's the case
+    // the user wants to lock in as a regression test. Trailing unanswered user
+    // prompts are dropped because they don't represent a completed exchange.
+    const lastAssistant = session.messages.map((m) => m.role).lastIndexOf("assistant");
+    if (lastAssistant < 0) {
+      toast.error("No assistant response to save yet");
+      return;
+    }
+    const inputMessages = session.messages
+      .slice(0, lastAssistant)
+      .map((m) => ({ role: m.role, content: m.content }));
+    const expectedMessage = session.messages[lastAssistant];
+
+    if (inputMessages.length === 0) {
+      toast.error("Need at least one user prompt before the assistant response");
+      return;
+    }
+
+    setSavingEval(true);
+    try {
+      let datasetId = evalDatasetId;
+      if (!datasetId) {
+        if (!newDatasetName.trim()) {
+          toast.error("Pick a dataset or enter a name for a new one");
+          setSavingEval(false);
+          return;
+        }
+        // Create a new dataset with this single case inline.
+        const jsonl = JSON.stringify({
+          input: inputMessages,
+          expected: expectedMessage.content,
+          metadata: { source: "playground-save" },
+        });
+        const res = await gatewayFetchRaw("/v1/evals/datasets", {
+          method: "POST",
+          body: JSON.stringify({ name: newDatasetName.trim(), jsonl }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.error?.message || `HTTP ${res.status}`);
+        }
+        const created = (await res.json()) as { id: string };
+        datasetId = created.id;
+      } else {
+        const res = await gatewayFetchRaw(`/v1/evals/datasets/${datasetId}/cases`, {
+          method: "POST",
+          body: JSON.stringify({
+            input: inputMessages,
+            expected: expectedMessage.content,
+            metadata: { source: "playground-save" },
+          }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => null);
+          throw new Error(body?.error?.message || `HTTP ${res.status}`);
+        }
+      }
+      toast.success("Saved to eval dataset");
+      setSaveEvalOpen(false);
+      setEvalDatasetId("");
+      setNewDatasetName("");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save case");
+    } finally {
+      setSavingEval(false);
+    }
   }
 
   async function handleShare() {
@@ -275,6 +427,15 @@ export default function PlaygroundPage() {
                 Share
               </button>
             )}
+            {session.messages.some((m) => m.role === "assistant") && (
+              <button
+                onClick={openSaveEval}
+                className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 bg-zinc-800 border border-zinc-700 rounded-lg transition-colors"
+                title="Save this exchange as a regression test case in an eval dataset"
+              >
+                Save as eval case
+              </button>
+            )}
             <button
               onClick={handleNewConversation}
               title="Start a fresh conversation. The current chat stays saved in the sidebar."
@@ -394,6 +555,63 @@ export default function PlaygroundPage() {
           </p>
         </div>
       </SettingsPanel>
+
+      {/* Save-as-eval-case modal (#266) */}
+      {saveEvalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className="bg-zinc-900 border border-zinc-800 rounded-lg w-full max-w-md p-5 space-y-4">
+            <div>
+              <h2 className="text-lg font-semibold">Save as eval case</h2>
+              <p className="text-xs text-zinc-500 mt-1">
+                Stores the current user+assistant exchange as a regression test in an eval dataset.
+              </p>
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs text-zinc-400">Existing dataset</label>
+              <select
+                value={evalDatasetId}
+                onChange={(e) => {
+                  setEvalDatasetId(e.target.value);
+                  if (e.target.value) setNewDatasetName("");
+                }}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-sm"
+              >
+                <option value="">— none —</option>
+                {evalDatasets.map((d) => (
+                  <option key={d.id} value={d.id}>{d.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="block text-xs text-zinc-400">…or create new dataset</label>
+              <input
+                value={newDatasetName}
+                onChange={(e) => {
+                  setNewDatasetName(e.target.value);
+                  if (e.target.value) setEvalDatasetId("");
+                }}
+                placeholder="e.g. panel-photo-regression-v1"
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-sm"
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                onClick={() => setSaveEvalOpen(false)}
+                className="px-3 py-1.5 text-xs rounded-md bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveEvalCase}
+                disabled={savingEval}
+                className="px-3 py-1.5 text-xs rounded-md bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium"
+              >
+                {savingEval ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/gateway/src/routes/evals.ts
+++ b/packages/gateway/src/routes/evals.ts
@@ -327,6 +327,51 @@ export function createEvalRoutes(db: Db, registry: ProviderRegistry) {
     });
   });
 
+  // Append a single case to an existing dataset. Used by the playground's
+  // "Save as eval case" button (#266) — lets users turn a forked-and-edited
+  // prod request into a regression test with one click.
+  app.post("/datasets/:id/cases", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { id } = c.req.param();
+    const body = await c.req.json<{
+      input?: ChatMessage[];
+      expected?: string;
+      metadata?: Record<string, unknown>;
+    }>();
+    if (!Array.isArray(body.input) || body.input.length === 0) {
+      return c.json(
+        { error: { message: "`input` must be a non-empty ChatMessage[]", type: "validation_error" } },
+        400,
+      );
+    }
+    const tc = tenantFilter(evalDatasets.tenantId, tenantId);
+    const existing = await db
+      .select()
+      .from(evalDatasets)
+      .where(tc ? and(eq(evalDatasets.id, id), tc) : eq(evalDatasets.id, id))
+      .get();
+    if (!existing) {
+      return c.json({ error: { message: "Dataset not found", type: "not_found" } }, 404);
+    }
+    const newCase: DatasetCase = {
+      input: body.input,
+      ...(body.expected ? { expected: body.expected } : {}),
+      ...(body.metadata ? { metadata: body.metadata } : {}),
+    };
+    const updatedJsonl =
+      (existing.casesJsonl.endsWith("\n") ? existing.casesJsonl : existing.casesJsonl + "\n") +
+      JSON.stringify(newCase);
+    await db
+      .update(evalDatasets)
+      .set({
+        casesJsonl: updatedJsonl,
+        caseCount: existing.caseCount + 1,
+      })
+      .where(eq(evalDatasets.id, id))
+      .run();
+    return c.json({ ok: true, caseCount: existing.caseCount + 1 }, 201);
+  });
+
   app.delete("/datasets/:id", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const { id } = c.req.param();


### PR DESCRIPTION
Closes #266.

## Summary
- **Fork to Playground** — button on logs detail page; playground loads messages + model + system prompt from `?forkFrom=<id>`.
- **Save as eval case** — button in playground top bar opens a modal to pick/create a dataset; saves user→assistant exchange as a JSONL case with `expected` set to the observed response.
- **Gateway** — new `POST /v1/evals/datasets/:id/cases` appends a single case to an existing dataset. Tier-gated under Intelligence (inherits the `/v1/evals/*` middleware).
- **Docs** — evals.mdx adds a "Building datasets from production traffic" section describing the Fork → Edit → Save loop.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Open any log detail page, click Fork — playground loads with messages + provider/model pre-filled
- [ ] Edit the prompt, rerun, verify a real response
- [ ] Click Save as eval case, create new dataset — case lands, dataset appears on `/dashboard/evals`
- [ ] Run that dataset against a model — case executes; output differs from the `expected` (optional for MVP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)