### PR TITLE
feat(#264): prompt canary deploys — weighted rollout + auto-promote/revert

### DIFF
--- a/apps/docs/content/docs/features/prompt-canary-deploys.mdx
+++ b/apps/docs/content/docs/features/prompt-canary-deploys.mdx
@@ -1,0 +1,97 @@
+---
+title: Prompt canary deploys
+description: Ship a new prompt version to a percentage of traffic; auto-promote or auto-revert based on feedback scores.
+---
+
+Prompt changes are production deploys dressed up as content edits. Provara treats them that way: start a canary, monitor scores, and let the scheduler promote or revert based on criteria you set.
+
+**Tier**: free. Ships as part of the core gateway.
+
+## How it works
+
+1. A prompt template has a **published** version (the stable one serving production)
+2. You add a new version (v2) and start a **canary rollout** at, say, 25% traffic
+3. Clients resolve the template via `POST /v1/rollouts/resolve/:templateId` — the gateway weighted-picks canary vs stable per request
+4. Clients pass the returned `versionId` as `prompt_version_id` on the next `/v1/chat/completions` call
+5. User or judge feedback attached to those requests flows back per-version into the rollout's stats
+6. Every hour, the `prompt-rollout-eval` scheduler checks criteria. When canary + stable both meet `min_samples`:
+   - If `canary_avg_score - stable_avg_score >= -max_avg_score_delta` → **promote** (swap publishedVersionId to canary)
+   - Else → **revert** (canary status flipped, stable stays published)
+
+One active rollout per template at a time. Historical rollouts stay in the database with their completion reason for audit.
+
+## Starting a rollout (UI)
+
+1. Open `/dashboard/prompts`, click the template
+2. Scroll to the **Canary rollout** panel
+3. Click **Start canary**, pick the canary version, set rollout %, criteria:
+   - `min_samples` — required samples per arm before any auto-decision (default 20)
+   - `max_avg_score_delta` — tolerated drop in canary avg score vs stable. `0.3` means "canary can be up to 0.3 points worse on a 1–5 scale and still promote"
+   - `window_hours` — rolling window for sample counting (default 24)
+4. The panel shows live canary vs stable stats + a prediction of the next scheduler decision
+
+## Starting a rollout (API)
+
+```bash
+curl -X POST https://gateway.provara.xyz/v1/rollouts \
+  -H "Content-Type: application/json" \
+  -d '{
+    "templateId": "<template-id>",
+    "canaryVersionId": "<version-id>",
+    "rolloutPct": 25,
+    "criteria": {
+      "min_samples": 20,
+      "max_avg_score_delta": 0.3,
+      "window_hours": 24
+    }
+  }'
+```
+
+## Client integration
+
+```ts
+// 1. Resolve to get a versionId and messages
+const resolved = await fetch(`/v1/rollouts/resolve/${templateId}`, { method: "POST" }).then(r => r.json());
+// { versionId, messages, rolloutId?, variant? }
+
+// 2. Use messages for your completion, pass versionId for tracking
+const completion = await fetch("/v1/chat/completions", {
+  method: "POST",
+  body: JSON.stringify({
+    model: "", // let adaptive routing decide
+    messages: resolved.messages,
+    prompt_version_id: resolved.versionId,
+  }),
+});
+```
+
+The `prompt_version_id` field on `/v1/chat/completions` is what ties the request back to the rollout for stats — without it the scheduler has nothing to evaluate.
+
+## Manual overrides
+
+The UI and API both support **Promote now** and **Revert now** buttons that bypass criteria evaluation. Use them when you've seen enough qualitative signal (user feedback, bug reports) and don't want to wait for the scheduler.
+
+```
+POST /v1/rollouts/:id/promote
+POST /v1/rollouts/:id/revert
+```
+
+## Auto-promotion criteria — more detail
+
+The promotion rule is **not** "canary beats stable." It's "canary didn't drop more than `max_avg_score_delta` below stable." The asymmetric tolerance is intentional: prompt changes are usually iterative refinements, not radical improvements. Requiring a net-positive delta would stall most useful rollouts.
+
+If you want a strictly-better gate, set `max_avg_score_delta: 0` — that requires canary ≥ stable to promote.
+
+## Limitations
+
+Deferred to follow-ups:
+
+- **Cost delta evaluation** — promote only if canary cost is ≤ stable cost + threshold
+- **p95 latency evaluation** — same idea for latency (currently the criteria only watches quality scores)
+- **Sticky user assignment** — a given userId always gets the same arm for the rollout's duration
+- **Gradual ramp-up** — start at 5%, step to 25%, step to 50% automatically on passing intermediate checks
+
+## Related
+
+- [Prompts](/docs/features/prompts) — prompt template management (where canary rollouts attach)
+- [Analytics](/docs/features/analytics) — feedback scoring pipeline that drives the criteria

--- a/apps/web/src/app/dashboard/prompts/page.tsx
+++ b/apps/web/src/app/dashboard/prompts/page.tsx
@@ -168,10 +168,55 @@ function CreateTemplateForm({ onCreated }: { onCreated: () => void }) {
 
 // ---- Template Detail Modal ----
 
+interface Rollout {
+  id: string;
+  templateId: string;
+  canaryVersionId: string;
+  stableVersionId: string;
+  rolloutPct: number;
+  criteria: { min_samples: number; max_avg_score_delta: number; window_hours: number };
+  status: "active" | "promoted" | "reverted";
+  startedAt: string;
+  completedAt: string | null;
+  completionReason: string | null;
+}
+
+interface RolloutEvaluation {
+  outcome: "promote" | "revert" | "continue";
+  reason: string;
+  stats: {
+    canarySamples: number;
+    stableSamples: number;
+    canaryAvgScore: number | null;
+    stableAvgScore: number | null;
+  };
+}
+
 function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemplate; onClose: () => void; onRefresh: () => void }) {
   const [versions, setVersions] = useState<PromptVersion[]>([]);
   const [publishedId, setPublishedId] = useState(template.publishedVersionId);
   const [loading, setLoading] = useState(true);
+  const [rollouts, setRollouts] = useState<Rollout[]>([]);
+  const [activeEval, setActiveEval] = useState<RolloutEvaluation | null>(null);
+  const [showCanaryForm, setShowCanaryForm] = useState(false);
+  const [canaryVersionId, setCanaryVersionId] = useState("");
+  const [canaryPct, setCanaryPct] = useState(25);
+  const [canaryMinSamples, setCanaryMinSamples] = useState(20);
+  const [canaryMaxDelta, setCanaryMaxDelta] = useState(0.3);
+  const [canaryWindowH, setCanaryWindowH] = useState(24);
+
+  const activeRollout = rollouts.find((r) => r.status === "active") || null;
+
+  async function loadRollouts() {
+    try {
+      const res = await gatewayClientFetch<{ rollouts: Rollout[] }>(
+        `/v1/rollouts?templateId=${template.id}`,
+      );
+      setRollouts(res.rollouts || []);
+    } catch {
+      setRollouts([]);
+    }
+  }
 
   useEffect(() => {
     gatewayClientFetch<{ template: PromptTemplate; versions: PromptVersion[] }>(`/v1/admin/prompts/${template.id}`)
@@ -180,12 +225,75 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
         setPublishedId(data.template.publishedVersionId);
       })
       .finally(() => setLoading(false));
+    loadRollouts();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template.id]);
+
+  // Poll evaluation for the active rollout so the signal panel stays current.
+  useEffect(() => {
+    if (!activeRollout) {
+      setActiveEval(null);
+      return;
+    }
+    let cancelled = false;
+    async function fetchEval() {
+      try {
+        const res = await gatewayClientFetch<RolloutEvaluation>(
+          `/v1/rollouts/${activeRollout!.id}/evaluation`,
+        );
+        if (!cancelled) setActiveEval(res);
+      } catch {}
+    }
+    fetchEval();
+    const id = setInterval(fetchEval, 10_000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [activeRollout?.id]);
 
   async function handlePublish(versionId: string) {
     await gatewayFetchRaw(`/v1/admin/prompts/${template.id}/publish/${versionId}`, { method: "POST" });
     setPublishedId(versionId);
     onRefresh();
+  }
+
+  async function handleStartCanary() {
+    if (!canaryVersionId) return;
+    const res = await gatewayFetchRaw("/v1/rollouts", {
+      method: "POST",
+      body: JSON.stringify({
+        templateId: template.id,
+        canaryVersionId,
+        rolloutPct: canaryPct,
+        criteria: {
+          min_samples: canaryMinSamples,
+          max_avg_score_delta: canaryMaxDelta,
+          window_hours: canaryWindowH,
+        },
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      alert(body?.error?.message || `HTTP ${res.status}`);
+      return;
+    }
+    setShowCanaryForm(false);
+    setCanaryVersionId("");
+    await loadRollouts();
+  }
+
+  async function handlePromote(rolloutId: string) {
+    if (!confirm("Promote canary now? The published version will swap to the canary.")) return;
+    await gatewayFetchRaw(`/v1/rollouts/${rolloutId}/promote`, { method: "POST" });
+    await loadRollouts();
+    // Refresh published pointer
+    const detail = await gatewayClientFetch<{ template: PromptTemplate }>(`/v1/admin/prompts/${template.id}`);
+    setPublishedId(detail.template.publishedVersionId);
+    onRefresh();
+  }
+
+  async function handleRevert(rolloutId: string) {
+    if (!confirm("Revert canary now? Traffic will go back to the stable version.")) return;
+    await gatewayFetchRaw(`/v1/rollouts/${rolloutId}/revert`, { method: "POST" });
+    await loadRollouts();
   }
 
   async function handleDelete() {
@@ -213,6 +321,156 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
         </div>
 
         <div className="px-6 py-4 space-y-4">
+          {/* Canary rollout controls */}
+          <div className="border border-zinc-800 rounded-lg p-4 space-y-3 bg-zinc-950/40">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold">Canary rollout</p>
+                <p className="text-xs text-zinc-500">Ship a new version to a % of traffic; auto-promote or auto-revert based on feedback scores.</p>
+              </div>
+              {!activeRollout && publishedId && versions.length >= 2 && (
+                <button
+                  onClick={() => setShowCanaryForm(!showCanaryForm)}
+                  className="px-3 py-1.5 text-xs rounded-md bg-blue-600 hover:bg-blue-500 text-white font-medium"
+                >
+                  {showCanaryForm ? "Cancel" : "Start canary"}
+                </button>
+              )}
+            </div>
+
+            {activeRollout && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 flex-wrap text-xs">
+                  <span className="px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-800/50">active</span>
+                  <span className="text-zinc-400">canary at {activeRollout.rolloutPct}%</span>
+                  <span className="text-zinc-600">·</span>
+                  <span className="text-zinc-400">
+                    v{versions.find((v) => v.id === activeRollout.canaryVersionId)?.version ?? "?"} (canary) vs v{versions.find((v) => v.id === activeRollout.stableVersionId)?.version ?? "?"} (stable)
+                  </span>
+                  <span className="text-zinc-600">·</span>
+                  <span className="text-zinc-500">
+                    criteria: {activeRollout.criteria.min_samples} samples, Δ ≤ {activeRollout.criteria.max_avg_score_delta}, window {activeRollout.criteria.window_hours}h
+                  </span>
+                </div>
+                {activeEval && (
+                  <div className="bg-zinc-900 rounded p-3 text-xs space-y-1">
+                    <div className="flex items-center gap-3">
+                      <span className="text-zinc-500">Canary:</span>
+                      <span className="font-semibold text-zinc-200">
+                        {activeEval.stats.canaryAvgScore !== null ? activeEval.stats.canaryAvgScore.toFixed(2) : "—"}
+                      </span>
+                      <span className="text-zinc-600">({activeEval.stats.canarySamples} samples)</span>
+                      <span className="text-zinc-600 ml-4">Stable:</span>
+                      <span className="font-semibold text-zinc-200">
+                        {activeEval.stats.stableAvgScore !== null ? activeEval.stats.stableAvgScore.toFixed(2) : "—"}
+                      </span>
+                      <span className="text-zinc-600">({activeEval.stats.stableSamples} samples)</span>
+                    </div>
+                    <p className={
+                      activeEval.outcome === "promote" ? "text-emerald-400" :
+                      activeEval.outcome === "revert" ? "text-red-400" :
+                      "text-zinc-500"
+                    }>
+                      Next scheduler pass: <span className="font-mono">{activeEval.outcome}</span> — {activeEval.reason}
+                    </p>
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handlePromote(activeRollout.id)}
+                    className="px-2.5 py-1 text-xs rounded bg-emerald-900/50 hover:bg-emerald-800/50 text-emerald-300 border border-emerald-800/50"
+                  >
+                    Promote now
+                  </button>
+                  <button
+                    onClick={() => handleRevert(activeRollout.id)}
+                    className="px-2.5 py-1 text-xs rounded bg-red-900/50 hover:bg-red-800/50 text-red-300 border border-red-800/50"
+                  >
+                    Revert now
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {showCanaryForm && !activeRollout && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-xs text-zinc-500 mb-1">Canary version</label>
+                  <select
+                    value={canaryVersionId}
+                    onChange={(e) => setCanaryVersionId(e.target.value)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs"
+                  >
+                    <option value="">Select…</option>
+                    {versions.filter((v) => v.id !== publishedId).map((v) => (
+                      <option key={v.id} value={v.id}>v{v.version}{v.note ? ` — ${v.note}` : ""}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-zinc-500 mb-1">Rollout %</label>
+                  <input
+                    type="number" min={1} max={99} value={canaryPct}
+                    onChange={(e) => setCanaryPct(parseInt(e.target.value) || 1)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-zinc-500 mb-1">Min samples per arm</label>
+                  <input
+                    type="number" min={1} value={canaryMinSamples}
+                    onChange={(e) => setCanaryMinSamples(parseInt(e.target.value) || 1)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-zinc-500 mb-1">Max avg-score delta tolerated</label>
+                  <input
+                    type="number" step="0.01" min={0} value={canaryMaxDelta}
+                    onChange={(e) => setCanaryMaxDelta(parseFloat(e.target.value) || 0)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-zinc-500 mb-1">Evaluation window (hours)</label>
+                  <input
+                    type="number" min={1} value={canaryWindowH}
+                    onChange={(e) => setCanaryWindowH(parseInt(e.target.value) || 1)}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-xs"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <button
+                    onClick={handleStartCanary}
+                    disabled={!canaryVersionId}
+                    className="px-3 py-1.5 text-xs rounded-md bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium"
+                  >
+                    Start canary
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {rollouts.filter((r) => r.status !== "active").length > 0 && (
+              <details className="text-xs">
+                <summary className="text-zinc-500 cursor-pointer hover:text-zinc-300">
+                  Historical rollouts ({rollouts.filter((r) => r.status !== "active").length})
+                </summary>
+                <ul className="mt-2 space-y-1">
+                  {rollouts.filter((r) => r.status !== "active").map((r) => (
+                    <li key={r.id} className="text-zinc-400">
+                      <span className={r.status === "promoted" ? "text-emerald-400" : "text-red-400"}>
+                        {r.status}
+                      </span>{" "}
+                      — v{versions.find((v) => v.id === r.canaryVersionId)?.version ?? "?"} @ {r.rolloutPct}% ·{" "}
+                      <span className="text-zinc-500">{r.completionReason}</span>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+
           {loading ? (
             <p className="text-zinc-400 text-sm">Loading versions...</p>
           ) : versions.length === 0 ? (
@@ -222,14 +480,28 @@ function TemplateDetail({ template, onClose, onRefresh }: { template: PromptTemp
               const messages: Message[] = JSON.parse(v.messages);
               const variables: string[] = JSON.parse(v.variables);
               const isPublished = v.id === publishedId;
+              const isCanary = activeRollout?.canaryVersionId === v.id;
+              const isStable = activeRollout?.stableVersionId === v.id;
 
               return (
-                <div key={v.id} className={`border rounded-lg p-4 space-y-3 ${isPublished ? "border-emerald-800/50 bg-emerald-950/10" : "border-zinc-800"}`}>
+                <div key={v.id} className={`border rounded-lg p-4 space-y-3 ${
+                  isCanary ? "border-amber-800/50 bg-amber-950/10" :
+                  isPublished ? "border-emerald-800/50 bg-emerald-950/10" :
+                  "border-zinc-800"
+                }`}>
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-semibold">v{v.version}</span>
                       {isPublished && (
                         <span className="text-xs px-2 py-0.5 rounded bg-emerald-900/50 text-emerald-300 border border-emerald-800/50">Published</span>
+                      )}
+                      {isCanary && (
+                        <span className="text-xs px-2 py-0.5 rounded bg-amber-900/50 text-amber-300 border border-amber-800/50">
+                          Canary ({activeRollout?.rolloutPct}%)
+                        </span>
+                      )}
+                      {isStable && !isPublished && (
+                        <span className="text-xs px-2 py-0.5 rounded bg-zinc-800 text-zinc-400 border border-zinc-700">Stable baseline</span>
                       )}
                       {v.note && <span className="text-xs text-zinc-500">— {v.note}</span>}
                     </div>

--- a/packages/db/drizzle/0040_friendly_revanche.sql
+++ b/packages/db/drizzle/0040_friendly_revanche.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `prompt_rollouts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`template_id` text NOT NULL,
+	`canary_version_id` text NOT NULL,
+	`stable_version_id` text NOT NULL,
+	`rollout_pct` integer NOT NULL,
+	`criteria` text NOT NULL,
+	`status` text DEFAULT 'active' NOT NULL,
+	`started_at` integer NOT NULL,
+	`completed_at` integer,
+	`completion_reason` text,
+	FOREIGN KEY (`template_id`) REFERENCES `prompt_templates`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`canary_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`stable_version_id`) REFERENCES `prompt_versions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+ALTER TABLE `requests` ADD `prompt_version_id` text;

--- a/packages/db/drizzle/meta/0040_snapshot.json
+++ b/packages/db/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,3674 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "770cec7d-eac9-482b-932d-5ad39bb34529",
+  "prevId": "13894be1-77b6-4143-8665-648e06bc52e3",
+  "tables": {
+    "ab_test_variants": {
+      "name": "ab_test_variants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ab_test_variants_ab_test_id_ab_tests_id_fk": {
+          "name": "ab_test_variants_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "ab_test_variants",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ab_tests": {
+      "name": "ab_tests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_generated": {
+          "name": "auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source_task_type": {
+          "name": "source_task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_complexity": {
+          "name": "source_complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_reason": {
+          "name": "source_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_winner": {
+          "name": "resolved_winner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "adaptive_isolation_preferences_log": {
+      "name": "adaptive_isolation_preferences_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_at": {
+          "name": "changed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_logs": {
+      "name": "alert_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alert_logs_rule_id_alert_rules_id_fk": {
+          "name": "alert_logs_rule_id_alert_rules_id_fk",
+          "tableFrom": "alert_logs",
+          "tableTo": "alert_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "condition": {
+          "name": "condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gt'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window": {
+          "name": "window",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'1h'"
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iv": {
+          "name": "iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_tokens": {
+      "name": "api_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_limit": {
+          "name": "spend_limit",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spend_period": {
+          "name": "spend_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "routing_profile": {
+          "name": "routing_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'balanced'"
+        },
+        "routing_weights": {
+          "name": "routing_weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_tokens_hashed_token_unique": {
+          "name": "api_tokens_hashed_token_unique",
+          "columns": [
+            "hashed_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_created_by_user_id_users_id_fk": {
+          "name": "api_tokens_created_by_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_config": {
+      "name": "app_config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_email": {
+          "name": "actor_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "audit_logs_tenant_created_idx": {
+          "name": "audit_logs_tenant_created_idx",
+          "columns": [
+            "tenant_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_tenant_action_created_idx": {
+          "name": "audit_logs_tenant_action_created_idx",
+          "columns": [
+            "tenant_id",
+            "action",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_logs": {
+      "name": "cost_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cost_logs_tenant_user_created_idx": {
+          "name": "cost_logs_tenant_user_created_idx",
+          "columns": [
+            "tenant_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "cost_logs_tenant_token_created_idx": {
+          "name": "cost_logs_tenant_token_created_idx",
+          "columns": [
+            "tenant_id",
+            "api_token_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cost_logs_request_id_requests_id_fk": {
+          "name": "cost_logs_request_id_requests_id_fk",
+          "tableFrom": "cost_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_migrations": {
+      "name": "cost_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_provider": {
+          "name": "from_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_model": {
+          "name": "from_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_cost_per_1m": {
+          "name": "from_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_quality_score": {
+          "name": "from_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_provider": {
+          "name": "to_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_model": {
+          "name": "to_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_cost_per_1m": {
+          "name": "to_cost_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_quality_score": {
+          "name": "to_quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "projected_monthly_savings_usd": {
+          "name": "projected_monthly_savings_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grace_ends_at": {
+          "name": "grace_ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rolled_back_at": {
+          "name": "rolled_back_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_reason": {
+          "name": "rollback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_ref": {
+          "name": "api_key_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "models": {
+          "name": "models",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "custom_providers_name_unique": {
+          "name": "custom_providers_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_datasets": {
+      "name": "eval_datasets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cases_jsonl": {
+          "name": "cases_jsonl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "case_count": {
+          "name": "case_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_results": {
+      "name": "eval_results",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "case_index": {
+          "name": "case_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_source": {
+          "name": "judge_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "eval_results_run_idx": {
+          "name": "eval_results_run_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "eval_results_run_id_eval_runs_id_fk": {
+          "name": "eval_results_run_id_eval_runs_id_fk",
+          "tableFrom": "eval_results",
+          "tableTo": "eval_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_runs": {
+      "name": "eval_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dataset_id": {
+          "name": "dataset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "avg_score": {
+          "name": "avg_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "eval_runs_dataset_id_eval_datasets_id_fk": {
+          "name": "eval_runs_dataset_id_eval_datasets_id_fk",
+          "tableFrom": "eval_runs",
+          "tableTo": "eval_datasets",
+          "columnsFrom": [
+            "dataset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedback": {
+      "name": "feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_request_id_requests_id_fk": {
+          "name": "feedback_request_id_requests_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_logs": {
+      "name": "guardrail_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_name": {
+          "name": "rule_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_content": {
+          "name": "matched_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "guardrail_logs_rule_id_guardrail_rules_id_fk": {
+          "name": "guardrail_logs_rule_id_guardrail_rules_id_fk",
+          "tableFrom": "guardrail_logs",
+          "tableTo": "guardrail_rules",
+          "columnsFrom": [
+            "rule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guardrail_rules": {
+      "name": "guardrail_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'both'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'block'"
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "built_in": {
+          "name": "built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_link_tokens": {
+      "name": "magic_link_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_first_name": {
+          "name": "pending_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_last_name": {
+          "name": "pending_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_link_tokens_email_idx": {
+          "name": "magic_link_tokens_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "magic_link_tokens_hash_idx": {
+          "name": "magic_link_tokens_hash_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_registry": {
+      "name": "model_registry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_price_per_1m": {
+          "name": "input_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_price_per_1m": {
+          "name": "output_price_per_1m",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'builtin'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "modalities": {
+          "name": "modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_scores": {
+      "name": "model_scores",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_scores_tenant_id_task_type_complexity_provider_model_pk": {
+          "columns": [
+            "tenant_id",
+            "task_type",
+            "complexity",
+            "provider",
+            "model"
+          ],
+          "name": "model_scores_tenant_id_task_type_complexity_provider_model_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_accounts": {
+      "name": "oauth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_provider_account_idx": {
+          "name": "oauth_provider_account_idx",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_rollouts": {
+      "name": "prompt_rollouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canary_version_id": {
+          "name": "canary_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stable_version_id": {
+          "name": "stable_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rollout_pct": {
+          "name": "rollout_pct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "criteria": {
+          "name": "criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completion_reason": {
+          "name": "completion_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_rollouts_template_id_prompt_templates_id_fk": {
+          "name": "prompt_rollouts_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_rollouts",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_rollouts_canary_version_id_prompt_versions_id_fk": {
+          "name": "prompt_rollouts_canary_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_rollouts",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "canary_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prompt_rollouts_stable_version_id_prompt_versions_id_fk": {
+          "name": "prompt_rollouts_stable_version_id_prompt_versions_id_fk",
+          "tableFrom": "prompt_rollouts",
+          "tableTo": "prompt_versions",
+          "columnsFrom": [
+            "stable_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_templates": {
+      "name": "prompt_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_versions": {
+      "name": "prompt_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variables": {
+          "name": "variables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prompt_versions_template_id_prompt_templates_id_fk": {
+          "name": "prompt_versions_template_id_prompt_templates_id_fk",
+          "tableFrom": "prompt_versions",
+          "tableTo": "prompt_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "regression_events": {
+      "name": "regression_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_count": {
+          "name": "replay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_mean": {
+          "name": "original_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "replay_mean": {
+          "name": "replay_mean",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delta": {
+          "name": "delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "detected_at": {
+          "name": "detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolution_note": {
+          "name": "resolution_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "replay_bank": {
+      "name": "replay_bank",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score": {
+          "name": "original_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_source": {
+          "name": "original_score_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_request_id": {
+          "name": "source_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_replayed_at": {
+          "name": "last_replayed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "routed_by": {
+          "name": "routed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_fallback": {
+          "name": "used_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cached": {
+          "name": "cached",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cache_source": {
+          "name": "cache_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_input": {
+          "name": "tokens_saved_input",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens_saved_output": {
+          "name": "tokens_saved_output",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_errors": {
+          "name": "fallback_errors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_token_id": {
+          "name": "api_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ab_test_id": {
+          "name": "ab_test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_version_id": {
+          "name": "prompt_version_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_ab_test_id_ab_tests_id_fk": {
+          "name": "requests_ab_test_id_ab_tests_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "ab_tests",
+          "columnsFrom": [
+            "ab_test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routing_weight_snapshots": {
+      "name": "routing_weight_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "complexity": {
+          "name": "complexity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_all_'"
+        },
+        "weights": {
+          "name": "weights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile": {
+          "name": "profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rws_tenant_captured_idx": {
+          "name": "rws_tenant_captured_idx",
+          "columns": [
+            "tenant_id",
+            "captured_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "semantic_cache": {
+      "name": "semantic_cache",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt_hash": {
+          "name": "system_prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text": {
+          "name": "prompt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_dim": {
+          "name": "embedding_dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_hit_at": {
+          "name": "last_hit_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "shares": {
+      "name": "shares",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "spend_budgets": {
+      "name": "spend_budgets",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'monthly'"
+        },
+        "cap_usd": {
+          "name": "cap_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_thresholds": {
+          "name": "alert_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alert_emails": {
+          "name": "alert_emails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hard_stop": {
+          "name": "hard_stop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "alerted_thresholds": {
+          "name": "alerted_thresholds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_started_at": {
+          "name": "period_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sso_configs": {
+      "name": "sso_configs",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_entity_id": {
+          "name": "idp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_sso_url": {
+          "name": "idp_sso_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sp_entity_id": {
+          "name": "sp_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_domains": {
+          "name": "email_domains",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_encryption": {
+          "name": "require_encryption",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_webhook_events": {
+      "name": "stripe_webhook_events",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "includes_intelligence": {
+          "name": "includes_intelligence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscriptions_tenant_idx": {
+          "name": "subscriptions_tenant_idx",
+          "columns": [
+            "tenant_id"
+          ],
+          "isUnique": true
+        },
+        "subscriptions_customer_idx": {
+          "name": "subscriptions_customer_idx",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invites": {
+      "name": "team_invites",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_role": {
+          "name": "invited_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consumed_by_user_id": {
+          "name": "consumed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invites_tenant_email_idx": {
+          "name": "team_invites_tenant_email_idx",
+          "columns": [
+            "tenant_id",
+            "invited_email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "team_invites_invited_by_user_id_users_id_fk": {
+          "name": "team_invites_invited_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_invites_consumed_by_user_id_users_id_fk": {
+          "name": "team_invites_consumed_by_user_id_users_id_fk",
+          "tableFrom": "team_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "consumed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tenant_adaptive_isolation": {
+      "name": "tenant_adaptive_isolation",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumes_pool": {
+          "name": "consumes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "contributes_pool": {
+          "name": "contributes_pool",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_reports": {
+      "name": "usage_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reported_overage_count": {
+          "name": "reported_overage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_pushed_usd": {
+          "name": "total_pushed_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_identifier": {
+          "name": "last_event_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "usage_reports_sub_period_idx": {
+          "name": "usage_reports_sub_period_idx",
+          "columns": [
+            "stripe_subscription_id",
+            "period_start"
+          ],
+          "isUnique": true
+        },
+        "usage_reports_tenant_period_idx": {
+          "name": "usage_reports_tenant_period_idx",
+          "columns": [
+            "tenant_id",
+            "period_start"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1776632431789,
       "tag": "0039_aromatic_photon",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1776638039277,
+      "tag": "0040_friendly_revanche",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -149,6 +149,10 @@ export const requests = sqliteTable("requests", {
   userId: text("user_id"),
   apiTokenId: text("api_token_id"),
   abTestId: text("ab_test_id").references(() => abTests.id),
+  /** Prompt version id when the request was resolved from a prompt template
+   *  via `/v1/prompts/:id/resolve` (#264). Enables canary vs stable EMA
+   *  tracking for prompt rollouts. Null for ad-hoc chat completions. */
+  promptVersionId: text("prompt_version_id"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
@@ -327,6 +331,48 @@ export const promptVersions = sqliteTable("prompt_versions", {
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
     .$defaultFn(() => new Date()),
+});
+
+/**
+ * Prompt canary rollouts (#264). A rollout serves a canary version to a
+ * percentage of `/v1/prompts/:id/resolve` calls, with the remainder served
+ * by the current stable version. Quality feedback on canary traffic is
+ * tracked via `requests.prompt_version_id`, and the scheduler evaluates
+ * promotion criteria hourly.
+ *
+ * Lifecycle: active → (promoted | reverted). Exactly one active rollout
+ * per prompt template at a time; the API rejects a second start while
+ * another is active.
+ *
+ * `criteria` JSON shape: `{ min_samples: number, max_avg_score_delta: number,
+ * window_hours: number }`. A rollout is auto-promoted when both canary
+ * samples >= min_samples AND (avg_canary_score - avg_stable_score) >=
+ * max_avg_score_delta (i.e. the canary didn't drop more than the threshold).
+ */
+export const promptRollouts = sqliteTable("prompt_rollouts", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  templateId: text("template_id")
+    .notNull()
+    .references(() => promptTemplates.id),
+  canaryVersionId: text("canary_version_id")
+    .notNull()
+    .references(() => promptVersions.id),
+  stableVersionId: text("stable_version_id")
+    .notNull()
+    .references(() => promptVersions.id),
+  rolloutPct: integer("rollout_pct").notNull(),
+  criteria: text("criteria", { mode: "json" })
+    .$type<{ min_samples: number; max_avg_score_delta: number; window_hours: number }>()
+    .notNull(),
+  status: text("status", { enum: ["active", "promoted", "reverted"] })
+    .notNull()
+    .default("active"),
+  startedAt: integer("started_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  completedAt: integer("completed_at", { mode: "timestamp" }),
+  completionReason: text("completion_reason"),
 });
 
 export const modelScores = sqliteTable("model_scores", {

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -17,6 +17,7 @@ import { createScheduler } from "./scheduler/index.js";
 import { runAutoAbCycle } from "./routing/adaptive/auto-ab.js";
 import { runBankPopulationCycle, runReplayCycle } from "./routing/adaptive/regression.js";
 import { runCostMigrationCycle } from "./routing/adaptive/migrations.js";
+import { runRolloutEvaluationCycle } from "./prompts/rollouts.js";
 import { createEmbeddingProvider } from "./embeddings/index.js";
 import { getJudgeConfig } from "./routing/judge.js";
 import { isCloudDeployment } from "./config.js";
@@ -116,6 +117,29 @@ const COST_MIGRATION_INTERVAL_MS = parseInt(
   process.env.PROVARA_COST_MIGRATION_INTERVAL_MS || `${24 * 60 * 60 * 1000}`,
   10,
 );
+// Prompt rollout evaluation (#264). Hourly scan of active rollouts — if
+// canary vs stable stats meet the rollout's criteria, auto-promote; if the
+// score drop exceeds the tolerance, auto-revert. Otherwise continue.
+const ROLLOUT_EVAL_INTERVAL_MS = parseInt(
+  process.env.PROVARA_ROLLOUT_EVAL_INTERVAL_MS || `${60 * 60 * 1000}`,
+  10,
+);
+if (cloudDeployment) {
+  await scheduler.schedule({
+    name: "prompt-rollout-eval",
+    intervalMs: ROLLOUT_EVAL_INTERVAL_MS,
+    initialDelayMs: 180_000,
+    handler: async () => {
+      const stats = await runRolloutEvaluationCycle(db);
+      if (stats.promoted > 0 || stats.reverted > 0) {
+        console.log(
+          `[rollout-eval] evaluated=${stats.evaluated} promoted=${stats.promoted} reverted=${stats.reverted}`,
+        );
+      }
+    },
+  });
+}
+
 if (cloudDeployment) {
   await scheduler.schedule({
     name: "cost-migration",

--- a/packages/gateway/src/prompts/rollouts.ts
+++ b/packages/gateway/src/prompts/rollouts.ts
@@ -1,0 +1,249 @@
+import type { Db } from "@provara/db";
+import {
+  promptRollouts,
+  promptTemplates,
+  promptVersions,
+  requests,
+  feedback,
+} from "@provara/db";
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+/**
+ * Prompt canary rollouts (#264). Weighted routing + hourly criteria-based
+ * auto-promotion. The gateway's `/v1/prompts/:id/resolve` endpoint picks
+ * canary or stable; the scheduler's `prompt-rollout-eval` job promotes
+ * or reverts based on observed feedback.
+ */
+
+export interface RolloutCriteria {
+  min_samples: number;
+  max_avg_score_delta: number;
+  window_hours: number;
+}
+
+export interface ResolvedPrompt {
+  versionId: string;
+  messages: unknown;
+  rolloutId?: string;
+  variant?: "canary" | "stable";
+}
+
+/** Resolve the version to serve for a template, respecting an active rollout.
+ *  When no rollout is active, returns the template's published version.
+ *  Weighted random — not sticky per user, so a single caller's traffic is
+ *  distributed across canary/stable within the rollout_pct split. */
+export async function resolveVersion(
+  db: Db,
+  templateId: string,
+  tenantId: string | null,
+): Promise<ResolvedPrompt | null> {
+  const templateRow = await db
+    .select()
+    .from(promptTemplates)
+    .where(
+      tenantId
+        ? and(eq(promptTemplates.id, templateId), eq(promptTemplates.tenantId, tenantId))
+        : eq(promptTemplates.id, templateId),
+    )
+    .get();
+  if (!templateRow) return null;
+
+  const activeRollout = await db
+    .select()
+    .from(promptRollouts)
+    .where(
+      and(
+        eq(promptRollouts.templateId, templateId),
+        eq(promptRollouts.status, "active"),
+      ),
+    )
+    .get();
+
+  const pickVersion = async (versionId: string) => {
+    const vRow = await db.select().from(promptVersions).where(eq(promptVersions.id, versionId)).get();
+    if (!vRow) return null;
+    try {
+      return JSON.parse(vRow.messages);
+    } catch {
+      return null;
+    }
+  };
+
+  if (activeRollout) {
+    const roll = Math.random() * 100;
+    const pickCanary = roll < activeRollout.rolloutPct;
+    const chosenId = pickCanary ? activeRollout.canaryVersionId : activeRollout.stableVersionId;
+    const messages = await pickVersion(chosenId);
+    if (!messages) return null;
+    return {
+      versionId: chosenId,
+      messages,
+      rolloutId: activeRollout.id,
+      variant: pickCanary ? "canary" : "stable",
+    };
+  }
+
+  if (!templateRow.publishedVersionId) return null;
+  const messages = await pickVersion(templateRow.publishedVersionId);
+  if (!messages) return null;
+  return { versionId: templateRow.publishedVersionId, messages };
+}
+
+interface RolloutStats {
+  canarySamples: number;
+  stableSamples: number;
+  canaryAvgScore: number | null;
+  stableAvgScore: number | null;
+}
+
+/** Compute canary vs stable avg score within the rollout's evaluation window.
+ *  Samples are user-feedback rows joined to requests carrying the respective
+ *  prompt_version_id. Judge-source feedback is included — same grading loop
+ *  as live quality tracking. */
+async function computeRolloutStats(
+  db: Db,
+  canaryVersionId: string,
+  stableVersionId: string,
+  windowHours: number,
+): Promise<RolloutStats> {
+  const since = new Date(Date.now() - windowHours * 60 * 60 * 1000);
+  const row = await db
+    .select({
+      versionId: requests.promptVersionId,
+      avgScore: sql<number>`avg(${feedback.score})`,
+      n: sql<number>`count(${feedback.id})`,
+    })
+    .from(requests)
+    .innerJoin(feedback, eq(feedback.requestId, requests.id))
+    .where(
+      and(
+        sql`${requests.createdAt} >= ${since}`,
+        sql`${requests.promptVersionId} IN (${canaryVersionId}, ${stableVersionId})`,
+      ),
+    )
+    .groupBy(requests.promptVersionId)
+    .all();
+
+  let canaryStats = { n: 0, avg: null as number | null };
+  let stableStats = { n: 0, avg: null as number | null };
+  for (const r of row) {
+    if (r.versionId === canaryVersionId) canaryStats = { n: r.n, avg: r.avgScore };
+    if (r.versionId === stableVersionId) stableStats = { n: r.n, avg: r.avgScore };
+  }
+  return {
+    canarySamples: canaryStats.n,
+    stableSamples: stableStats.n,
+    canaryAvgScore: canaryStats.avg,
+    stableAvgScore: stableStats.avg,
+  };
+}
+
+export interface RolloutDecision {
+  outcome: "promote" | "revert" | "continue";
+  reason: string;
+  stats: RolloutStats;
+}
+
+/** Evaluate a single rollout against its criteria.
+ *  Promotion: canary samples meet min, and score delta >= -max_avg_score_delta.
+ *  Revert: canary samples meet min, but score delta < -max_avg_score_delta.
+ *  Continue: not enough samples yet. */
+export async function evaluateRollout(
+  db: Db,
+  rolloutId: string,
+): Promise<RolloutDecision | null> {
+  const rollout = await db.select().from(promptRollouts).where(eq(promptRollouts.id, rolloutId)).get();
+  if (!rollout || rollout.status !== "active") return null;
+
+  const criteria = rollout.criteria;
+  const stats = await computeRolloutStats(
+    db,
+    rollout.canaryVersionId,
+    rollout.stableVersionId,
+    criteria.window_hours,
+  );
+
+  if (stats.canarySamples < criteria.min_samples) {
+    return {
+      outcome: "continue",
+      reason: `canary samples ${stats.canarySamples} < min ${criteria.min_samples}`,
+      stats,
+    };
+  }
+  if (stats.stableSamples < criteria.min_samples) {
+    return {
+      outcome: "continue",
+      reason: `stable samples ${stats.stableSamples} < min ${criteria.min_samples}`,
+      stats,
+    };
+  }
+  const canaryAvg = stats.canaryAvgScore ?? 0;
+  const stableAvg = stats.stableAvgScore ?? 0;
+  const delta = canaryAvg - stableAvg;
+  if (delta < -Math.abs(criteria.max_avg_score_delta)) {
+    return {
+      outcome: "revert",
+      reason: `canary avg ${canaryAvg.toFixed(2)} vs stable ${stableAvg.toFixed(2)} (delta ${delta.toFixed(2)}) outside threshold ${criteria.max_avg_score_delta}`,
+      stats,
+    };
+  }
+  return {
+    outcome: "promote",
+    reason: `canary avg ${canaryAvg.toFixed(2)} vs stable ${stableAvg.toFixed(2)} (delta ${delta.toFixed(2)}) within threshold`,
+    stats,
+  };
+}
+
+/** Apply a promote/revert decision: update the rollout row and, on promote,
+ *  swap the template's publishedVersionId to the canary version. */
+export async function applyDecision(
+  db: Db,
+  rolloutId: string,
+  decision: RolloutDecision,
+): Promise<void> {
+  if (decision.outcome === "continue") return;
+  const rollout = await db.select().from(promptRollouts).where(eq(promptRollouts.id, rolloutId)).get();
+  if (!rollout) return;
+
+  await db
+    .update(promptRollouts)
+    .set({
+      status: decision.outcome === "promote" ? "promoted" : "reverted",
+      completedAt: new Date(),
+      completionReason: decision.reason,
+    })
+    .where(eq(promptRollouts.id, rolloutId))
+    .run();
+
+  if (decision.outcome === "promote") {
+    await db
+      .update(promptTemplates)
+      .set({ publishedVersionId: rollout.canaryVersionId, updatedAt: new Date() })
+      .where(eq(promptTemplates.id, rollout.templateId))
+      .run();
+  }
+}
+
+/** Scheduler entry — evaluate every active rollout and apply decisions. */
+export async function runRolloutEvaluationCycle(db: Db): Promise<{
+  evaluated: number;
+  promoted: number;
+  reverted: number;
+}> {
+  const active = await db
+    .select({ id: promptRollouts.id })
+    .from(promptRollouts)
+    .where(eq(promptRollouts.status, "active"))
+    .all();
+
+  let promoted = 0;
+  let reverted = 0;
+  for (const row of active) {
+    const decision = await evaluateRollout(db, row.id);
+    if (!decision || decision.outcome === "continue") continue;
+    await applyDecision(db, row.id, decision);
+    if (decision.outcome === "promote") promoted++;
+    if (decision.outcome === "revert") reverted++;
+  }
+  return { evaluated: active.length, promoted, reverted };
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -10,6 +10,7 @@ import { createRoutingEngine, NoCapableProviderError, type RoutingProfile } from
 import { createAbTestRoutes } from "./routes/ab-tests.js";
 import { createAnalyticsRoutes } from "./routes/analytics.js";
 import { createEvalRoutes } from "./routes/evals.js";
+import { createRolloutRoutes } from "./routes/rollouts.js";
 import { createApiKeyRoutes } from "./routes/api-keys.js";
 import { createAuthMiddleware, getTokenInfo } from "./auth/middleware.js";
 import { createAdminMiddleware, requireRole } from "./auth/admin.js";
@@ -250,6 +251,11 @@ export async function createRouter(ctx: RouterContext) {
   // Mount evals routes (#262)
   app.route("/v1/evals", createEvalRoutes(ctx.db, ctx.registry));
 
+  // Mount prompt rollout routes (#264). Weighted-pick resolve lives under
+  // /v1/rollouts/resolve/:templateId to avoid a route-shadow collision with
+  // the existing /v1/prompts/* sub-app.
+  app.route("/v1/rollouts", createRolloutRoutes(ctx.db));
+
   // Mount API key management routes
   app.route("/v1/api-keys", createApiKeyRoutes(ctx.db));
 
@@ -305,6 +311,9 @@ export async function createRouter(ctx: RouterContext) {
       provider?: string;
       cache?: boolean;
       complexity_hint?: "simple" | "medium" | "complex";
+      /** Prompt-template version id threaded through from `/v1/rollouts/resolve/:templateId`
+       *  so canary vs stable feedback can be tracked per version (#264). */
+      prompt_version_id?: string;
       /**
        * Explicit opt-in to structured-output routing filter (#233).
        * Auto-detected from `response_format: { type: "json_schema" }`
@@ -323,6 +332,7 @@ export async function createRouter(ctx: RouterContext) {
       requires_structured_output,
       response_format,
       tools,
+      prompt_version_id: promptVersionId,
       ...rest
     } = body;
     const request = rest as CompletionRequest;
@@ -517,6 +527,7 @@ export async function createRouter(ctx: RouterContext) {
           userId: attribution.userId,
           apiTokenId: attribution.apiTokenId,
           abTestId: routingResult.abTestId || null,
+          promptVersionId: promptVersionId || null,
         })
         .run();
       publishLive({
@@ -731,6 +742,7 @@ export async function createRouter(ctx: RouterContext) {
                     userId: attribution.userId,
                     apiTokenId: attribution.apiTokenId,
                     abTestId: routingResult.abTestId || null,
+                    promptVersionId: promptVersionId || null,
                   })
                   .run();
 
@@ -908,6 +920,7 @@ export async function createRouter(ctx: RouterContext) {
         userId: attribution.userId,
         apiTokenId: attribution.apiTokenId,
         abTestId: routingResult.abTestId || null,
+        promptVersionId: promptVersionId || null,
       })
       .run();
 

--- a/packages/gateway/src/routes/rollouts.ts
+++ b/packages/gateway/src/routes/rollouts.ts
@@ -1,0 +1,246 @@
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { promptRollouts, promptTemplates, promptVersions } from "@provara/db";
+import { and, eq, desc } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { getTenantId, tenantFilter } from "../auth/tenant.js";
+import {
+  resolveVersion,
+  evaluateRollout,
+  applyDecision,
+  type RolloutCriteria,
+} from "../prompts/rollouts.js";
+
+/**
+ * Prompt canary rollout routes (#264). Mounted at /v1/rollouts. The
+ * weighted-pick resolve endpoint lives here (not /v1/prompts/:id) to avoid
+ * colliding with the existing prompts sub-app route shape.
+ */
+export function createRolloutRoutes(db: Db) {
+  const app = new Hono();
+
+  // Start a canary rollout. Body: { templateId, canaryVersionId, rolloutPct, criteria }.
+  // Rejects if an active rollout already exists for the template.
+  app.post("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{
+      templateId?: string;
+      canaryVersionId?: string;
+      rolloutPct?: number;
+      criteria?: Partial<RolloutCriteria>;
+    }>();
+
+    if (!body.templateId || !body.canaryVersionId) {
+      return c.json(
+        { error: { message: "`templateId` and `canaryVersionId` are required", type: "validation_error" } },
+        400,
+      );
+    }
+
+    const tc = tenantFilter(promptTemplates.tenantId, tenantId);
+    const template = await db
+      .select()
+      .from(promptTemplates)
+      .where(tc ? and(eq(promptTemplates.id, body.templateId), tc) : eq(promptTemplates.id, body.templateId))
+      .get();
+    if (!template) {
+      return c.json({ error: { message: "Template not found", type: "not_found" } }, 404);
+    }
+    if (!template.publishedVersionId) {
+      return c.json(
+        {
+          error: {
+            message: "Template has no published version to use as the stable baseline",
+            type: "validation_error",
+          },
+        },
+        400,
+      );
+    }
+
+    const canary = await db
+      .select()
+      .from(promptVersions)
+      .where(and(eq(promptVersions.id, body.canaryVersionId), eq(promptVersions.templateId, body.templateId)))
+      .get();
+    if (!canary) {
+      return c.json(
+        { error: { message: "Canary version not found for this template", type: "not_found" } },
+        404,
+      );
+    }
+    if (canary.id === template.publishedVersionId) {
+      return c.json(
+        { error: { message: "Canary must differ from the currently published version", type: "validation_error" } },
+        400,
+      );
+    }
+
+    const pct = body.rolloutPct;
+    if (typeof pct !== "number" || pct <= 0 || pct >= 100 || !Number.isFinite(pct)) {
+      return c.json(
+        { error: { message: "`rolloutPct` must be between 1 and 99", type: "validation_error" } },
+        400,
+      );
+    }
+    const c0 = body.criteria || {};
+    const criteria: RolloutCriteria = {
+      min_samples:
+        Number.isFinite(c0.min_samples) && (c0.min_samples as number) >= 1
+          ? (c0.min_samples as number)
+          : 20,
+      max_avg_score_delta:
+        Number.isFinite(c0.max_avg_score_delta) && (c0.max_avg_score_delta as number) >= 0
+          ? (c0.max_avg_score_delta as number)
+          : 0.3,
+      window_hours:
+        Number.isFinite(c0.window_hours) && (c0.window_hours as number) >= 1
+          ? (c0.window_hours as number)
+          : 24,
+    };
+
+    const existing = await db
+      .select()
+      .from(promptRollouts)
+      .where(
+        and(eq(promptRollouts.templateId, body.templateId), eq(promptRollouts.status, "active")),
+      )
+      .get();
+    if (existing) {
+      return c.json(
+        {
+          error: {
+            message: "An active rollout already exists for this template. Promote or revert it first.",
+            type: "conflict",
+            rolloutId: existing.id,
+          },
+        },
+        409,
+      );
+    }
+
+    const id = nanoid();
+    await db
+      .insert(promptRollouts)
+      .values({
+        id,
+        tenantId,
+        templateId: body.templateId,
+        canaryVersionId: body.canaryVersionId,
+        stableVersionId: template.publishedVersionId,
+        rolloutPct: Math.round(pct),
+        criteria,
+      })
+      .run();
+
+    return c.json({ id, status: "active", rolloutPct: Math.round(pct), criteria }, 201);
+  });
+
+  // List rollouts; optional ?templateId= filter.
+  app.get("/", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const templateId = c.req.query("templateId");
+    const tc = tenantFilter(promptRollouts.tenantId, tenantId);
+    const conditions = [
+      tc,
+      templateId ? eq(promptRollouts.templateId, templateId) : undefined,
+    ].filter((c): c is NonNullable<typeof c> => c !== undefined);
+    const where = conditions.length > 0 ? and(...conditions) : undefined;
+    const rows = await db
+      .select()
+      .from(promptRollouts)
+      .where(where)
+      .orderBy(desc(promptRollouts.startedAt))
+      .all();
+    return c.json({ rollouts: rows });
+  });
+
+  // Client-facing: resolve a template to its current serving version.
+  // Returns { versionId, messages, rolloutId?, variant? }. Callers then pass
+  // `versionId` as `prompt_version_id` when POSTing /v1/chat/completions
+  // so the rollout eval loop sees per-version feedback.
+  app.post("/resolve/:templateId", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const { templateId } = c.req.param();
+    const resolved = await resolveVersion(db, templateId, tenantId);
+    if (!resolved) {
+      return c.json(
+        {
+          error: {
+            message: "Template has no resolvable version (no rollout, no published version, or not found)",
+            type: "not_found",
+          },
+        },
+        404,
+      );
+    }
+    return c.json(resolved);
+  });
+
+  // Manual promote / revert — bypasses criteria evaluation when operators
+  // have seen enough qualitative signal and want to ship or pull the canary
+  // without waiting for the scheduler.
+  app.post("/:id/promote", async (c) => {
+    const { id } = c.req.param();
+    const rollout = await db.select().from(promptRollouts).where(eq(promptRollouts.id, id)).get();
+    if (!rollout || rollout.status !== "active") {
+      return c.json({ error: { message: "Rollout not active", type: "not_found" } }, 404);
+    }
+    await applyDecision(db, id, {
+      outcome: "promote",
+      reason: "manual-promote",
+      stats: {
+        canarySamples: 0,
+        stableSamples: 0,
+        canaryAvgScore: null,
+        stableAvgScore: null,
+      },
+    });
+    return c.json({ ok: true });
+  });
+
+  app.post("/:id/revert", async (c) => {
+    const { id } = c.req.param();
+    const rollout = await db.select().from(promptRollouts).where(eq(promptRollouts.id, id)).get();
+    if (!rollout || rollout.status !== "active") {
+      return c.json({ error: { message: "Rollout not active", type: "not_found" } }, 404);
+    }
+    await applyDecision(db, id, {
+      outcome: "revert",
+      reason: "manual-revert",
+      stats: {
+        canarySamples: 0,
+        stableSamples: 0,
+        canaryAvgScore: null,
+        stableAvgScore: null,
+      },
+    });
+    return c.json({ ok: true });
+  });
+
+  // Preview: what would the scheduler decide right now? Used by the UI
+  // "Current signal" panel.
+  app.get("/:id/evaluation", async (c) => {
+    const { id } = c.req.param();
+    const rollout = await db.select().from(promptRollouts).where(eq(promptRollouts.id, id)).get();
+    if (!rollout) {
+      return c.json({ error: { message: "Rollout not found", type: "not_found" } }, 404);
+    }
+    if (rollout.status !== "active") {
+      return c.json({
+        outcome: "continue",
+        reason: `rollout is ${rollout.status}`,
+        stats: {
+          canarySamples: 0,
+          stableSamples: 0,
+          canaryAvgScore: null,
+          stableAvgScore: null,
+        },
+      });
+    }
+    const decision = await evaluateRollout(db, id);
+    return c.json(decision);
+  });
+
+  return app;
+}


### PR DESCRIPTION
Closes #264.

## Summary
Ship a new prompt version to X% of traffic, monitor feedback scores per version, auto-promote on pass or auto-revert on regression. Operators can override manually.

**DB (migration 0040)**:
- `prompt_rollouts` — canary/stable pair, rolloutPct, criteria JSON, active | promoted | reverted lifecycle
- `requests.prompt_version_id` — enables per-version stat attribution

**Gateway**:
- `packages/gateway/src/prompts/rollouts.ts` — `resolveVersion`, `evaluateRollout`, `applyDecision`, `runRolloutEvaluationCycle`
- `packages/gateway/src/routes/rollouts.ts` — mounted at `/v1/rollouts` (avoids collision with `/v1/admin/prompts` sub-app):
  - `POST /v1/rollouts` create
  - `GET /v1/rollouts?templateId=` list
  - `POST /v1/rollouts/resolve/:templateId` client-facing weighted pick
  - `POST /v1/rollouts/:id/{promote,revert}` manual overrides
  - `GET /v1/rollouts/:id/evaluation` preview next decision
- `/v1/chat/completions` accepts `prompt_version_id` and logs it (cache-hit + non-stream + stream paths)
- Hourly `prompt-rollout-eval` scheduler job

**UI**:
- Canary rollout panel on the prompt template detail drawer (start form, active rollout w/ live stats + next-pass prediction polled 10s, historical rollouts)
- Version rendering picks up Canary badge (amber) + Stable baseline badge

**Docs**: `features/prompt-canary-deploys.mdx` covers flow, client integration, criteria semantics, manual overrides, follow-ups.

## Criteria semantics
Promotion rule: `canary_avg - stable_avg >= -max_avg_score_delta`. Asymmetric tolerance is intentional — most prompt changes are iterative refinements, not radical improvements. Set `max_avg_score_delta: 0` for a strictly-better gate.

## Deferred to follow-ups
- Cost delta criteria, p95 latency criteria (currently quality-only)
- Sticky user assignment (weighted random is per-request today)
- Gradual ramp-up (5% → 25% → 50%)

## Test plan
- [x] `tsc --noEmit` clean in gateway + web
- [ ] Create a template with v1 + v2, publish v1, start a canary rollout of v2 at 25%
- [ ] Hit `/v1/rollouts/resolve/:templateId` many times — confirm weighted split roughly matches
- [ ] Pass `prompt_version_id` on `/v1/chat/completions`, submit feedback, wait for min_samples to accumulate
- [ ] Verify scheduler auto-promotes or auto-reverts based on score delta
- [ ] Verify Promote now / Revert now manual buttons work

🤖 Generated with [Claude Code](https://claude.com/claude-code)