### PR TITLE
fix: wrap playground in Suspense for useSearchParams

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { gatewayClientFetch, gatewayFetchRaw } from "../../../lib/gateway-client";
 import { ChatInput, type ChatInputHandle } from "../../../components/chat/ChatInput";
@@ -24,7 +24,11 @@ interface ProviderInfo {
   models: string[];
 }
 
-export default function PlaygroundPage() {
+// `useSearchParams` forces the page into dynamic rendering and — in Next 15 —
+// requires a Suspense boundary above it or the static prerender fails. The
+// real page lives in `PlaygroundInner`; the default export wraps it in
+// Suspense so the build can still statically generate the shell.
+function PlaygroundInner() {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [selectedModel, setSelectedModel] = useSessionPersist("pg:model", "");
   const [selectedProvider, setSelectedProvider] = useSessionPersist("pg:provider", "");
@@ -613,5 +617,13 @@ export default function PlaygroundPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function PlaygroundPage() {
+  return (
+    <Suspense fallback={<div className="p-8 text-zinc-400">Loading playground…</div>}>
+      <PlaygroundInner />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
Deployment `ef6dacb5-1614-4c02-9d2e-5f29eb493598` failed with:
> useSearchParams() should be wrapped in a suspense boundary at page "/dashboard/playground"

Introduced by #271 (fork-from-log) — I added `useSearchParams()` directly in `PlaygroundPage` without a Suspense wrapper, which Next 15 treats as a prerender error.

Standard fix: rename the page component to `PlaygroundInner`, export a default that wraps it in `<Suspense>`. The build statically generates the shell; Suspense defers the searchParams read to client render.

Verified locally — `next build` now includes `/dashboard/playground` in the static-page set and exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)