### PR TITLE
fix: persist activeConversationId so hard refresh doesn't duplicate

### DIFF
--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -39,7 +39,15 @@ function PlaygroundInner() {
   const [input, setInput] = useState("");
   const [showSettings, setShowSettings] = useState(false);
   const [showConversations, setShowConversations] = useState(true);
-  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  // Persist activeConversationId to sessionStorage alongside the message
+  // transcript in useChatSession. Without this, a hard refresh re-hydrated
+  // messages but lost the conversation ID, so the auto-save effect below
+  // saw `activeConversationId === null` and called `saved.create(...)`,
+  // duplicating the conversation on every refresh.
+  const [activeConversationId, setActiveConversationId] = useSessionPersist<string | null>(
+    "pg:activeConversationId",
+    null,
+  );
   const inputRef = useRef<ChatInputHandle>(null);
 
   const session = useChatSession();


### PR DESCRIPTION
## Summary
Customer UAT: hard-refreshing the Playground duplicated the current conversation in the sidebar.

## Root cause
Two-hook interaction:
- `useChatSession` already persists `session.messages` to sessionStorage, so messages survive a refresh.
- `activeConversationId` was plain `useState(null)` — NOT persisted, so it reset to `null` on refresh.

The auto-save effect runs after refresh, sees messages present and `activeConversationId === null`, and takes the "fresh unsaved session" branch → `saved.create(...)` → duplicate row in the sidebar.

## Fix
Swap `useState` for `useSessionPersist` (already used for model/provider/systemPrompt) under key `pg:activeConversationId`. After refresh the ID rehydrates, the auto-save effect takes the `update()` branch, no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)