### PR TITLE
fix: plumb OLLAMA_API_KEY so remote hosts populate models list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ ZAI_API_KEY=
 # Ollama (OPTIONAL — always enabled)
 # ──────────────────────────────────────────────
 # OLLAMA_BASE_URL=http://localhost:11434/v1
+# OLLAMA_API_KEY=   # Only needed for authenticated/remote Ollama hosts
 
 # ──────────────────────────────────────────────
 # Database (Turso / libSQL)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ OpenAI, Anthropic, Google, Mistral, xAI, Z.ai, Ollama. Each adapter lives in `pa
 - `XAI_API_KEY`
 - `ZAI_API_KEY`
 - `OLLAMA_BASE_URL` (defaults to `http://localhost:11434/v1`)
+- `OLLAMA_API_KEY` (optional; only for authenticated/remote Ollama hosts)
 
 Ollama is always registered. DB-stored keys (encrypted with `PROVARA_MASTER_KEY`) take precedence over env vars.
 

--- a/README.md
+++ b/README.md
@@ -888,6 +888,7 @@ PROVARA_EMAIL_FROM="Provara <noreply@yourdomain.com>"
 | `XAI_API_KEY` | No | Or manage via dashboard |
 | `ZAI_API_KEY` | No | Or manage via dashboard |
 | `OLLAMA_BASE_URL` | No | Default: `http://localhost:11434/v1` |
+| `OLLAMA_API_KEY` | No | Only needed for authenticated/remote Ollama hosts |
 | `GOOGLE_CLIENT_ID` | Multi-tenant | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | Multi-tenant | Google OAuth client secret |
 | `GITHUB_CLIENT_ID` | Multi-tenant | GitHub OAuth client ID |

--- a/apps/docs/content/docs/configuration/environment.mdx
+++ b/apps/docs/content/docs/configuration/environment.mdx
@@ -24,6 +24,7 @@ Set at least one. Each provider registers only if its key is present.
 | `XAI_API_KEY` | xAI (Grok) |
 | `ZAI_API_KEY` | Z.ai |
 | `OLLAMA_BASE_URL` | Ollama (defaults to `http://localhost:11434/v1`) |
+| `OLLAMA_API_KEY` | Ollama (only for authenticated/remote hosts) |
 
 DB-stored keys (added via `/dashboard/api-keys`) take precedence over env vars. Env vars are for operators; DB keys are for tenants.
 

--- a/apps/docs/content/docs/configuration/providers.mdx
+++ b/apps/docs/content/docs/configuration/providers.mdx
@@ -22,7 +22,7 @@ Providers auto-register at gateway startup based on:
 1. **Env vars** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.
 2. **DB-stored keys** — added via `/dashboard/api-keys`, encrypted with `PROVARA_MASTER_KEY`. DB keys take precedence over env vars.
 
-Ollama is always registered (points at `OLLAMA_BASE_URL`, default `http://localhost:11434/v1`).
+Ollama is always registered (points at `OLLAMA_BASE_URL`, default `http://localhost:11434/v1`). Set `OLLAMA_API_KEY` only if your Ollama host requires bearer auth (e.g. a remote deployment).
 
 ## Adding a provider
 

--- a/apps/web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/web/src/app/dashboard/api-keys/page.tsx
@@ -24,6 +24,7 @@ const KNOWN_KEYS = [
   { name: "MISTRAL_API_KEY", provider: "mistral", placeholder: "..." },
   { name: "XAI_API_KEY", provider: "xai", placeholder: "xai-..." },
   { name: "ZAI_API_KEY", provider: "zai", placeholder: "..." },
+  { name: "OLLAMA_API_KEY", provider: "ollama", placeholder: "sk-ollama-... (remote only)" },
 ];
 
 function AddKeyForm({ onSaved }: { onSaved: () => void }) {

--- a/packages/gateway/src/providers/index.ts
+++ b/packages/gateway/src/providers/index.ts
@@ -46,6 +46,7 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
     const mistralKey = dbKeys["MISTRAL_API_KEY"] || process.env.MISTRAL_API_KEY;
     const xaiKey = dbKeys["XAI_API_KEY"] || process.env.XAI_API_KEY;
     const zaiKey = dbKeys["ZAI_API_KEY"] || process.env.ZAI_API_KEY;
+    const ollamaKey = dbKeys["OLLAMA_API_KEY"] || process.env.OLLAMA_API_KEY;
 
     if (openaiKey) providers.push(createOpenAIProvider(openaiKey));
     if (anthropicKey) providers.push(createAnthropicProvider(anthropicKey));
@@ -54,8 +55,9 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
     if (xaiKey) providers.push(createXAIProvider(xaiKey));
     if (zaiKey) providers.push(createZAIProvider(zaiKey));
 
-    // Ollama is always available (local)
-    providers.push(createOllamaProvider());
+    // Ollama is always available (local or remote). OLLAMA_API_KEY is
+    // optional — unauthenticated local instances ignore the bearer header.
+    providers.push(createOllamaProvider(undefined, ollamaKey));
 
     // Load custom providers from DB
     const customProviders = (await config?.getCustomProviders?.()) || [];

--- a/packages/gateway/src/providers/ollama.ts
+++ b/packages/gateway/src/providers/ollama.ts
@@ -1,11 +1,34 @@
 import { createOpenAICompatibleProvider } from "./openai-compatible.js";
 import type { Provider } from "./types.js";
 
-export function createOllamaProvider(baseURL?: string): Provider {
-  return createOpenAICompatibleProvider({
+export function createOllamaProvider(baseURL?: string, apiKey?: string): Provider {
+  const url = baseURL || process.env.OLLAMA_BASE_URL || "http://localhost:11434/v1";
+  const key = apiKey || process.env.OLLAMA_API_KEY || "ollama";
+
+  const provider = createOpenAICompatibleProvider({
     name: "ollama",
-    baseURL: baseURL || process.env.OLLAMA_BASE_URL || "http://localhost:11434/v1",
-    apiKey: "ollama",
-    models: [], // Ollama accepts any model
+    baseURL: url,
+    apiKey: key,
+    models: [],
   });
+
+  // Prefer Ollama's native /api/tags over /v1/models — it's the canonical
+  // endpoint for listing pulled models and surfaces auth failures cleanly.
+  provider.listModels = async () => {
+    try {
+      const tagsURL = url.replace(/\/v1\/?$/, "") + "/api/tags";
+      const res = await fetch(tagsURL, {
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      if (!res.ok) return provider.models;
+      const data = (await res.json()) as { models?: Array<{ name: string }> };
+      const discovered = data.models?.map((m) => m.name) ?? [];
+      if (discovered.length > 0) provider.models = discovered;
+      return provider.models;
+    } catch {
+      return provider.models;
+    }
+  };
+
+  return provider;
 }


### PR DESCRIPTION
## Summary
- Remote/authenticated Ollama hosts were silently failing model discovery: adapter hardcoded \`apiKey: \"ollama\"\`, so \`/v1/models\` got 401'd, \`listModels\` returned empty, and the Providers page rendered "Any model (local)" while the Playground optgroup had no children.
- \`createOllamaProvider\` now accepts an optional API key (read from \`OLLAMA_API_KEY\` in DB/env) and uses Ollama's native \`/api/tags\` endpoint for model discovery.
- Added \`OLLAMA_API_KEY\` to the dashboard's Known Keys list, \`.env.example\`, CLAUDE.md, README, and docs.

## Test plan
- [ ] Add \`OLLAMA_API_KEY\` via \`/dashboard/api-keys\` (or \`.env\`) pointing at the remote Ollama host
- [ ] Restart gateway; confirm startup log shows \`ollama: N models\`
- [ ] Providers page lists the actual model names (e.g. \`Qwen3.6:latest\`) instead of "Any model (local)"
- [ ] Playground model picker lists models under the Ollama optgroup and completes a chat request
- [ ] Plain local Ollama (no \`OLLAMA_API_KEY\`) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)