### PR TITLE
fix: dedupe custom vs built-in providers + mask raw API keys in UI

### DIFF
--- a/apps/web/src/app/dashboard/providers/page.tsx
+++ b/apps/web/src/app/dashboard/providers/page.tsx
@@ -18,6 +18,19 @@ interface CustomProvider {
   createdAt: string;
 }
 
+// An apiKeyRef is meant to be a short symbolic name (e.g. "OLLAMA_API_KEY").
+// If a user pastes a raw secret into the field instead, we mask it — the
+// plaintext shouldn't be visible on a shared dashboard.
+function looksLikeRawKey(ref: string): boolean {
+  return ref.length > 40 || /^sk-|^xai-|^AIza/.test(ref);
+}
+
+function maskApiKeyRef(ref: string): string {
+  if (!looksLikeRawKey(ref)) return ref;
+  if (ref.length <= 8) return "••••";
+  return `${ref.slice(0, 4)}••••${ref.slice(-4)}`;
+}
+
 const WELL_KNOWN_PROVIDERS = [
   { name: "together", baseURL: "https://api.together.xyz/v1", keyName: "TOGETHER_API_KEY" },
   { name: "groq", baseURL: "https://api.groq.com/openai/v1", keyName: "GROQ_API_KEY" },
@@ -248,7 +261,12 @@ function CustomProviderCard({ provider, onUpdate }: { provider: CustomProvider; 
       </div>
       <p className="text-xs text-zinc-500 font-mono mb-1">{provider.baseURL}</p>
       {provider.apiKeyRef && (
-        <p className="text-xs text-zinc-500 mb-1">Key: <code className="bg-zinc-800 px-1 rounded">{provider.apiKeyRef}</code></p>
+        <p className="text-xs text-zinc-500 mb-1">
+          Key: <code className="bg-zinc-800 px-1 rounded">{maskApiKeyRef(provider.apiKeyRef)}</code>
+          {looksLikeRawKey(provider.apiKeyRef) && (
+            <span className="ml-2 text-amber-400">⚠ raw key stored — edit to use a reference name</span>
+          )}
+        </p>
       )}
       <p className="text-xs text-zinc-400">
         {provider.models.length > 0 ? provider.models.join(", ") : "No models — run discovery"}

--- a/packages/gateway/src/providers/index.ts
+++ b/packages/gateway/src/providers/index.ts
@@ -59,12 +59,17 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
     // optional — unauthenticated local instances ignore the bearer header.
     providers.push(createOllamaProvider(undefined, ollamaKey));
 
-    // Load custom providers from DB
+    // Load custom providers from DB. A custom with the same name (case-
+    // insensitive) as a built-in replaces it — admins creating a custom
+    // named e.g. "ollama" want their override to win, not be silently dropped.
     const customProviders = (await config?.getCustomProviders?.()) || [];
     for (const cp of customProviders) {
-      // Skip if a built-in provider already exists with this name
-      if (!providers.some((p) => p.name === cp.name)) {
-        providers.push(createOpenAICompatibleProvider(cp));
+      const idx = providers.findIndex((p) => p.name.toLowerCase() === cp.name.toLowerCase());
+      const provider = createOpenAICompatibleProvider(cp);
+      if (idx >= 0) {
+        providers[idx] = provider;
+      } else {
+        providers.push(provider);
       }
     }
   }

--- a/packages/gateway/src/routes/providers.ts
+++ b/packages/gateway/src/routes/providers.ts
@@ -63,11 +63,23 @@ export function createProviderCrudRoutes(db: Db) {
       );
     }
 
-    // Resolve API key for validation
+    // Resolve API key for validation. apiKeyRef must be a name that exists in
+    // the api_keys table — reject raw secrets pasted into the field.
     let apiKey = "";
     if (body.apiKeyRef) {
       const keys = await getDecryptedKeys(db);
-      apiKey = keys[body.apiKeyRef] || "";
+      if (!(body.apiKeyRef in keys)) {
+        return c.json(
+          {
+            error: {
+              message: `No API key named "${body.apiKeyRef}" found. Add it on the API Keys page first, then reference it here by name (do not paste the raw secret).`,
+              type: "validation_error",
+            },
+          },
+          400
+        );
+      }
+      apiKey = keys[body.apiKeyRef];
     }
 
     // Validate OpenAI compatibility before saving
@@ -144,6 +156,21 @@ export function createProviderCrudRoutes(db: Db) {
     const provider = await db.select().from(customProviders).where(whereClause).get();
     if (!provider) {
       return c.json({ error: { message: "Provider not found", type: "not_found" } }, 404);
+    }
+
+    if (body.apiKeyRef !== undefined && body.apiKeyRef !== null && body.apiKeyRef !== "") {
+      const keys = await getDecryptedKeys(db);
+      if (!(body.apiKeyRef in keys)) {
+        return c.json(
+          {
+            error: {
+              message: `No API key named "${body.apiKeyRef}" found. Add it on the API Keys page first, then reference it here by name (do not paste the raw secret).`,
+              type: "validation_error",
+            },
+          },
+          400
+        );
+      }
     }
 
     const updates: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
UAT surfaced three related issues on the Providers page:

1. **Duplicate \"Ollama\" cards in the built-in section** — built-in \`ollama\` coexisted with a custom named \`Ollama\` because the dedupe check was case-sensitive. Now case-insensitive, and customs *replace* built-ins with the same name (admins who create an override want it to win).
2. **Raw API key exposed in plaintext** — \`apiKeyRef\` is meant to be a symbolic name like \`OLLAMA_API_KEY\`, but a user pasted the raw \`sk-ollama-...\` secret into the field. The card now masks anything that looks like a raw secret (>40 chars, or \`sk-\`/\`xai-\`/\`AIza\` prefix) and shows a ⚠ warning.
3. **No validation on save** — the POST/PATCH routes accepted any string for \`apiKeyRef\`. They now verify it resolves to an existing \`api_keys\` entry and return a clear error otherwise.

## Test plan
- [ ] Custom provider with name matching a built-in (case-insensitive) replaces the built-in instead of duplicating
- [ ] Existing DB row with a raw secret in \`apiKeyRef\` renders masked (\`sk-o••••504f0\`) with a ⚠ warning
- [ ] POSTing a custom provider with a bogus \`apiKeyRef\` returns 400 with the guidance message
- [ ] PATCHing an existing provider with a bogus \`apiKeyRef\` returns the same 400
- [ ] Normal flow (reference a real API Keys entry) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)