### PR TITLE
fix: plumb OLLAMA_BASE_URL via dashboard keys for containerized deploys

### DIFF
--- a/apps/web/src/app/dashboard/api-keys/page.tsx
+++ b/apps/web/src/app/dashboard/api-keys/page.tsx
@@ -25,6 +25,7 @@ const KNOWN_KEYS = [
   { name: "XAI_API_KEY", provider: "xai", placeholder: "xai-..." },
   { name: "ZAI_API_KEY", provider: "zai", placeholder: "..." },
   { name: "OLLAMA_API_KEY", provider: "ollama", placeholder: "sk-ollama-... (remote only)" },
+  { name: "OLLAMA_BASE_URL", provider: "ollama", placeholder: "https://ollama.example.com/v1" },
 ];
 
 function AddKeyForm({ onSaved }: { onSaved: () => void }) {

--- a/packages/gateway/src/providers/index.ts
+++ b/packages/gateway/src/providers/index.ts
@@ -47,6 +47,7 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
     const xaiKey = dbKeys["XAI_API_KEY"] || process.env.XAI_API_KEY;
     const zaiKey = dbKeys["ZAI_API_KEY"] || process.env.ZAI_API_KEY;
     const ollamaKey = dbKeys["OLLAMA_API_KEY"] || process.env.OLLAMA_API_KEY;
+    const ollamaBaseURL = dbKeys["OLLAMA_BASE_URL"] || process.env.OLLAMA_BASE_URL;
 
     if (openaiKey) providers.push(createOpenAIProvider(openaiKey));
     if (anthropicKey) providers.push(createAnthropicProvider(anthropicKey));
@@ -57,7 +58,7 @@ export async function createProviderRegistry(config?: RegistryConfig): Promise<P
 
     // Ollama is always available (local or remote). OLLAMA_API_KEY is
     // optional — unauthenticated local instances ignore the bearer header.
-    providers.push(createOllamaProvider(undefined, ollamaKey));
+    providers.push(createOllamaProvider(ollamaBaseURL, ollamaKey));
 
     // Load custom providers from DB. A custom with the same name (case-
     // insensitive) as a built-in replaces it — admins creating a custom


### PR DESCRIPTION
## Summary
- Containerized gateway deployments don't load \`.env\` locally, so OLLAMA_BASE_URL was effectively unreachable without a redeploy.
- \`OLLAMA_BASE_URL\` now resolves from the API Keys DB table first, env var second, \`http://localhost:11434/v1\` last — same precedence as the provider API keys.
- Added to the API Keys page \`KNOWN_KEYS\` so users can discover the option from the dropdown.

## Test plan
- [ ] Set OLLAMA_BASE_URL + OLLAMA_API_KEY via \`/dashboard/api-keys\` on a running container (no env, no restart beyond gateway reload)
- [ ] Remove any stale custom \"Ollama\" provider row blocking the built-in adapter
- [ ] Startup log shows \`ollama: N models\` and the Providers page lists the actual model

🤖 Generated with [Claude Code](https://claude.com/claude-code)