### PR TITLE
fix: honor user-pinned (provider, model) strictly — no silent fallback

### DIFF
--- a/packages/gateway/src/routing/index.ts
+++ b/packages/gateway/src/routing/index.ts
@@ -185,6 +185,10 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
     const overrideComplexity: Complexity = request.complexityHint || "medium";
 
     if (request.provider && request.model) {
+      // Explicit pin — honor it strictly. An empty fallback chain surfaces
+      // errors instead of silently swapping providers, which defeats the
+      // whole point of pinning (and produced surprising "I pinned X but got
+      // Y" reports from the Playground).
       return {
         provider: request.provider,
         model: request.model,
@@ -193,9 +197,7 @@ export async function createRoutingEngine(config: RoutingEngineConfig) {
         routedBy: "user-override",
         usedFallback: false,
         usedLlmFallback: false,
-        fallbacks: allFallbacks.filter(
-          (t) => !(t.provider === request.provider && t.model === request.model)
-        ),
+        fallbacks: [],
       };
     }
 

--- a/packages/gateway/tests/router.test.ts
+++ b/packages/gateway/tests/router.test.ts
@@ -94,7 +94,7 @@ describe("routing engine", () => {
   });
 
   describe("fallback chain", () => {
-    it("excludes the chosen target from the fallback list", async () => {
+    it("returns an empty fallback list for explicit (provider, model) pins so the pin is honored strictly", async () => {
       const db = await makeTestDb();
       const registry = makeFakeRegistry([
         makeFakeProvider({ name: "openai", models: ["gpt-4.1-nano"] }),
@@ -108,15 +108,7 @@ describe("routing engine", () => {
         model: "claude-sonnet-4-6",
       });
 
-      expect(
-        result.fallbacks.some(
-          (t) => t.provider === "anthropic" && t.model === "claude-sonnet-4-6",
-        ),
-      ).toBe(false);
-      // But openai/gpt-4.1-nano should appear as a valid fallback target
-      expect(
-        result.fallbacks.some((t) => t.provider === "openai" && t.model === "gpt-4.1-nano"),
-      ).toBe(true);
+      expect(result.fallbacks).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary
- When a caller pins both \`provider\` and \`model\`, the routing engine returned a full \`fallbacks\` array of every other capable target. Primary failure → fallback loop silently picked a different provider → user gets an answer from a model they didn't ask for.
- **Playground repro**: user pinned \`Qwen3.6:latest\` (Ollama) but a misconfigured Ollama row made auth fail. The gateway silently fell back to OpenAI and returned a \`gpt-4.1-nano\` response. From the user's POV, pinning didn't work.
- Pinning now means pinning. User-override targets return an empty fallback list, so a primary failure surfaces as an error the caller can act on.
- Scope: only explicit (provider, model) pins. Model-only pins resolved via \`getForModel\` and adaptive/A-B routing are unchanged.

## Test plan
- [x] Updated \`router.test.ts\` fallback-chain test to assert the new behavior
- [x] \`npx vitest run tests/router.test.ts tests/structured-output-routing.test.ts\` — 14/14 pass
- [ ] Playground: pin a model on a misconfigured provider, confirm the error surfaces instead of silently switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)