### PR TITLE
diag: unwrap provider error cause so "Connection error." surfaces root

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -67,6 +67,28 @@ interface RouterContext {
   scheduler?: Scheduler;
 }
 
+// The OpenAI SDK wraps network failures in APIConnectionError with the
+// generic message "Connection error.", burying the real cause on `.cause`
+// (an undici/fetch error with code + message). HTTP errors surface as
+// APIError subclasses with `status`. Unwrap both so provider failures
+// produce actionable log lines like:
+//   "Connection error. (caused by ECONNRESET: socket hang up)"
+//   "429 Rate limit exceeded"
+function describeProviderError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [];
+  const status = (err as { status?: number }).status;
+  if (typeof status === "number") parts.push(`${status}`);
+  parts.push(err.message);
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const code = (cause as { code?: string }).code;
+    const causeMsg = code ? `${code}: ${cause.message}` : cause.message;
+    parts.push(`(caused by ${causeMsg})`);
+  }
+  return parts.join(" ");
+}
+
 export async function createRouter(ctx: RouterContext) {
   const app = new Hono();
   const routingEngine = await createRoutingEngine({ registry: ctx.registry, db: ctx.db });
@@ -843,14 +865,14 @@ export async function createRouter(ctx: RouterContext) {
         } catch (err) {
           lastError = err;
           failedProviders.add(attempt.provider);
-          const msg = err instanceof Error ? err.message : String(err);
+          const msg = describeProviderError(err);
           attemptErrors.push({ provider: attempt.provider, model: attempt.model, error: msg });
           console.warn(`Provider ${attempt.provider}/${attempt.model} stream failed:`, msg);
           continue;
         }
       }
 
-      const errMsg = lastError instanceof Error ? lastError.message : "All providers failed";
+      const errMsg = lastError ? describeProviderError(lastError) : "All providers failed";
       return c.json({ error: { message: errMsg, type: "provider_error" } }, 502);
     }
 
@@ -884,7 +906,7 @@ export async function createRouter(ctx: RouterContext) {
       } catch (err) {
         lastError = err;
         failedProviders.add(attempt.provider);
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = describeProviderError(err);
         attemptErrors.push({ provider: attempt.provider, model: attempt.model, error: msg });
         console.warn(`Provider ${attempt.provider}/${attempt.model} failed:`, msg);
         continue;


### PR DESCRIPTION
## Summary
The OpenAI SDK wraps network failures in \`APIConnectionError\` with the generic message \`Connection error.\`, burying the actual reason (\`ECONNRESET\`, \`ENOTFOUND\`, TLS handshake failure, proxy stripping SSE, etc.) on \`.cause\`. HTTP-level errors surface as \`APIError\` subclasses with \`.status\`. We were logging only \`.message\`, so operators had no way to tell a DNS failure apart from a 429 apart from a proxy dropping streaming responses.

\`describeProviderError\` unwraps both layers and is now used in the streaming and non-streaming attempt-loop catch blocks, as well as the 502 body.

## Test plan
- [x] Typecheck clean
- [ ] On the next Ollama streaming failure, the log line shows the underlying \`(caused by ...)\` hint instead of bare \"Connection error.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)