### PR TITLE
fix: stop dropping empty-content chunks from thinking-model streams

### DIFF
--- a/packages/gateway/src/providers/openai-compatible.ts
+++ b/packages/gateway/src/providers/openai-compatible.ts
@@ -73,12 +73,17 @@ export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): 
       });
 
       for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta?.content || "";
-        const done = chunk.choices[0]?.finish_reason === "stop";
+        const choice = chunk.choices[0];
+        if (!choice) continue;
 
-        // Skip empty non-final chunks
-        if (!delta && !done) continue;
+        const delta = choice.delta?.content || "";
+        const done = choice.finish_reason === "stop";
 
+        // Don't skip empty-content chunks. Thinking models (Ollama's Qwen3,
+        // DeepSeek-R1 etc.) stream reasoning with content:"" for the whole
+        // thinking pass — sometimes 30+ seconds — before any visible content.
+        // Dropping those starves the router's first-chunk timeout and kills
+        // the connection with a spurious "Connection error".
         yield {
           content: delta,
           done,


### PR DESCRIPTION
## Summary
- The OpenAI-compatible stream adapter skipped any chunk where \`choice.delta.content\` was empty and \`finish_reason\` wasn't \`stop\`. Intended as a noise filter for role-only SDK chunks.
- Thinking models (Qwen3, DeepSeek-R1, etc.) stream their whole reasoning pass with \`content: \"\"\` (the tokens ride on a non-standard \`reasoning\` field) for up to 30+ seconds before the first visible-content chunk arrives.
- The router's streaming attempt loop has a 10-second \`CONNECT_TIMEOUT\` on the first yielded chunk — so the adapter had nothing to yield, the timeout fired, and the request failed with the OpenAI SDK's opaque \"Connection error.\".
- **Playground repro**: pin Ollama's \`Qwen3.6:latest\` → curl confirms the host streams fine, but the gateway bails after ~10s with Connection error.
- Fix: forward every chunk with a valid choice; empty deltas become no-op SSE events that satisfy the router's first-chunk gate without changing client-visible output for non-thinking models.

## Test plan
- [x] \`npx vitest run\` — 522/522 pass
- [ ] Pin \`Qwen3.6:latest\` in the Playground; confirm a response completes instead of 10s-timing-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)