### PR TITLE
fix: strip embedded control chars from api keys + refresh on reload

### DIFF
--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -31,11 +31,14 @@ await runMigrations(db, resolve(process.cwd(), "packages/db/drizzle"));
 await hydrateJudgeConfig(db);
 await hydrateRoutingConfig(db);
 
-const dbKeys = await getDecryptedKeys(db);
+// Re-fetch dbKeys on every registry load() so dashboard edits take effect on
+// /v1/providers/reload without requiring a full restart.
 const registry = await createProviderRegistry({
-  getKeys: () => dbKeys,
+  getKeys: () => getDecryptedKeys(db),
   getCustomProviders: () => loadCustomProviders(db),
 });
+// Snapshot for the router, which uses it for the embedding provider lookup.
+const dbKeys = await getDecryptedKeys(db);
 const scheduler = createScheduler(db);
 
 // Intelligence-tier scheduler jobs only register on Cloud deployments (#168).

--- a/packages/gateway/src/routes/api-keys.ts
+++ b/packages/gateway/src/routes/api-keys.ts
@@ -170,14 +170,23 @@ export async function getDecryptedKeys(db: Db): Promise<Record<string, string>> 
 
   for (const k of keys) {
     try {
-      // Defensive trim: existing rows saved before the POST-handler trim may
-      // carry a trailing newline from a paste, which node-fetch rejects as an
-      // illegal HTTP header value.
-      result[k.name] = decrypt({
+      const raw = decrypt({
         encrypted: k.encryptedValue,
         iv: k.iv,
         authTag: k.authTag,
-      }).trim();
+      });
+      // HTTP header values must be visible ASCII (0x21-0x7E) + SP/HTAB.
+      // Strip anything outside that range — any stored key that carries an
+      // embedded CR/LF or other control char from a bad paste would
+      // otherwise crash node-fetch's Headers validator (#287 root cause).
+      // The trim handles edge whitespace; the replace handles embedded.
+      const sanitized = raw.replace(/[^\x20-\x7E\t]/g, "").trim();
+      if (sanitized !== raw) {
+        console.warn(
+          `[api-keys] key "${k.name}" had ${raw.length - sanitized.length} illegal char(s) stripped on read — update the entry to remove them`,
+        );
+      }
+      result[k.name] = sanitized;
     } catch {
       // Skip keys that can't be decrypted
     }


### PR DESCRIPTION
## Summary
#287's edge-trim alone didn't fix the \"is not a legal HTTP header value\" crash on the next deploy. Two plausible causes, and this PR addresses both:

1. **Embedded illegal chars.** \`.trim()\` only handles edge whitespace. If the stored key has a CR/LF or other control char in the middle (Windows paste, some clipboard tools), node-fetch still rejects it. \`getDecryptedKeys\` now strips any byte outside \`0x20-0x7E + tab\` and logs a warning when it fires.

2. **Stale dbKeys closure.** \`getKeys: () => dbKeys\` captured a snapshot at startup — dashboard-edited keys required a full restart before \`/v1/providers/reload\` picked them up. Now \`getKeys: () => getDecryptedKeys(db)\` re-queries on every registry load.

## Test plan
- [x] Typecheck clean
- [ ] Redeploy; if the Ollama stream still fails, log will include \`[api-keys] key \"OLLAMA_API_KEY\" had N illegal char(s) stripped on read\` — that confirms diagnosis
- [ ] Edit a key via dashboard → click Reload → new value is active without a container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)