### PR TITLE
diag: validate provider apiKey + baseURL at construction with char codes

### DIFF
--- a/packages/gateway/src/providers/openai-compatible.ts
+++ b/packages/gateway/src/providers/openai-compatible.ts
@@ -12,6 +12,28 @@ export interface OpenAICompatibleConfig {
 }
 
 export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): Provider {
+  // Validate apiKey and baseURL at construction time. Some configurations
+  // carry control chars (CR/LF/NUL) from bad pastes or env-var escaping;
+  // node-fetch would otherwise throw deep inside the SDK with an opaque
+  // "Connection error." when we actually call the provider. Log loudly
+  // here so operators can pinpoint the offending entry.
+  if (config.apiKey) {
+    const illegal = config.apiKey.match(/[^\x20-\x7E\t]/g);
+    if (illegal) {
+      const codes = [...new Set(illegal.map((c) => `0x${c.charCodeAt(0).toString(16).padStart(2, "0")}`))].join(",");
+      console.warn(
+        `[provider:${config.name}] apiKey contains ${illegal.length} illegal header char(s) [${codes}] — the OpenAI SDK will reject this as "not a legal HTTP header value". Re-enter the key via /dashboard/api-keys.`,
+      );
+    }
+  }
+  if (config.baseURL) {
+    try {
+      new URL(config.baseURL);
+    } catch {
+      console.warn(`[provider:${config.name}] baseURL is not a valid URL: ${JSON.stringify(config.baseURL)}`);
+    }
+  }
+
   const client = new OpenAI({
     apiKey: config.apiKey,
     baseURL: config.baseURL,


### PR DESCRIPTION
## Summary
Even after #287 (trim) and #288 (strip control chars + refresh on reload), the Ollama stream still fails with \"is not a legal HTTP header value\". Either the fix isn't deployed yet, or a header other than \`Authorization\` is carrying the bad byte (env vars like \`OPENAI_ORG_ID\`/\`OPENAI_PROJECT_ID\` leak into the SDK's default headers; same for custom deployments).

Added construction-time validation in \`createOpenAICompatibleProvider\`: if \`apiKey\` contains any byte outside \`0x20-0x7E\` + tab, log which provider, how many illegal chars, and their hex codes (deduped). Also validates \`baseURL\` parses as a URL.

Fires at startup and on \`/v1/providers/reload\`. Non-destructive — only logs.

## Expected outcomes
- Log shows \`[provider:ollama] apiKey contains N illegal header char(s) [0x0a]\` → re-enter the key
- Log shows nothing for ollama → apiKey is clean, look for leaked env vars (\`OPENAI_ORG_ID\`, \`OPENAI_PROJECT_ID\`) or mid-request mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)