### PR TITLE
fix: extend first-chunk timeout for user-pinned providers

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -685,7 +685,13 @@ export async function createRouter(ctx: RouterContext) {
       ...routingResult.fallbacks,
     ];
 
-    const CONNECT_TIMEOUT_MS = 10_000;  // For initial connection / first chunk
+    // First-chunk timeout for adaptive/ab-test routing, where we want to fail
+    // over fast if the primary is dead. When the user explicitly pinned the
+    // provider (user-override → empty fallbacks), there's nothing to fail
+    // over to — honor the pin with a generous timeout that covers cold
+    // model-load on self-hosted Ollama/vLLM (Qwen3-36B etc. can take 30-60s
+    // to stream a first chunk on a cold start).
+    const CONNECT_TIMEOUT_MS = routingResult.routedBy === "user-override" ? 120_000 : 10_000;
     const COMPLETION_TIMEOUT_MS = 120_000; // For full non-streaming response
     const failedProviders = new Set<string>();
     const attemptErrors: { provider: string; model: string; error: string }[] = [];


### PR DESCRIPTION
## Summary
The streaming attempt loop has a 10s \`CONNECT_TIMEOUT\` on the first yielded chunk so adaptive routing can fail over fast if the primary is dead. When the user explicitly pinned a (provider, model) — \`routedBy=user-override\` — #282 sets an empty \`fallbacks\` array, so timing out early has nothing to fail over to. It just kills the request.

Extend the first-chunk window to 120s for user-pinned routes only. Covers cold-start on self-hosted inference (Qwen3-36B and similar thinking models on cold Ollama/vLLM can easily take 30-60s before the first SSE byte). Adaptive and A/B-test paths keep the 10s gate so dead providers still fail over fast.

## Test plan
- [x] Typecheck clean
- [ ] Pin Qwen3.6:latest in the Playground on a cold Ollama, confirm the request completes instead of bailing at 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)