### PR TITLE
fix: keepalive + structured errors for user-pinned streaming routes

### DIFF
--- a/apps/web/src/components/chat/use-chat-session.ts
+++ b/apps/web/src/components/chat/use-chat-session.ts
@@ -150,6 +150,7 @@ export function useChatSession() {
         let fullContent = "";
         let responseModel = "";
         let streamMeta: { latencyMs?: number; cost?: number; usage?: { inputTokens: number; outputTokens: number } } = {};
+        let inStreamError: string | null = null;
 
         while (true) {
           const { done, value } = await reader.read();
@@ -169,6 +170,14 @@ export function useChatSession() {
                 streamMeta = parsed._provara;
                 continue;
               }
+              // Pinned-streaming routes can fail after response headers are
+              // already sent (cold-start timeout, mid-stream provider error).
+              // The gateway emits a structured error event so we can render
+              // a real message instead of a raw "network error".
+              if (parsed.error?.message) {
+                inStreamError = parsed.error.message;
+                continue;
+              }
               if (!responseModel && parsed.model) responseModel = parsed.model;
               const delta = parsed.choices?.[0]?.delta?.content || "";
               fullContent += delta;
@@ -177,6 +186,17 @@ export function useChatSession() {
               // ignore malformed chunks
             }
           }
+        }
+
+        if (inStreamError && !fullContent) {
+          const errMessages: ChatMessage[] = [
+            ...workingMessages,
+            { role: "assistant", content: `Error: ${inStreamError}` },
+          ];
+          setMessages(errMessages);
+          setStreamingContent("");
+          persistMessages(errMessages);
+          return;
         }
 
         const finalMessages: ChatMessage[] = [

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -696,7 +696,227 @@ export async function createRouter(ctx: RouterContext) {
     const failedProviders = new Set<string>();
     const attemptErrors: { provider: string; model: string; error: string }[] = [];
 
-    // --- Streaming path ---
+    // --- Streaming path (user-pinned, single attempt) ---
+    // Open the SSE response immediately and emit keepalive comments while
+    // waiting for the provider's first chunk. Non-pinned routes use the
+    // fail-fast pattern below, which delays the response until we know the
+    // primary works so we can swap providers on failure. For a user-pinned
+    // route there's no fallback to swap to (#282 → empty fallbacks), and
+    // cloud ingress proxies close idle HTTPS connections after ~30s —
+    // self-hosted inference (cold Qwen3-36B, DeepSeek-R1) can easily take
+    // 60s+ for the first byte. Keepalives let the cold-start complete
+    // instead of failing with a browser "network error".
+    if (
+      request.stream &&
+      routingResult.routedBy === "user-override" &&
+      attempts.length === 1
+    ) {
+      const attempt = attempts[0];
+      const provider = ctx.registry.get(attempt.provider);
+      if (!provider) {
+        return c.json(
+          { error: { message: `Pinned provider "${attempt.provider}" not registered`, type: "provider_error" } },
+          502,
+        );
+      }
+
+      const usedProvider = attempt.provider;
+      const usedModel = attempt.model;
+      const usedFallback = false;
+      const requestId = nanoid();
+      const start = performance.now();
+
+      const sseStream = new ReadableStream({
+        async start(controller) {
+          const encoder = new TextEncoder();
+          let fullContent = "";
+          let usage = { inputTokens: 0, outputTokens: 0 };
+
+          // SSE comments ":..." are legal keepalives ignored by parsers.
+          // Cleared on the first real chunk or in finally{}.
+          const keepalive = setInterval(() => {
+            try { controller.enqueue(encoder.encode(": keepalive\n\n")); } catch { /* stream closed */ }
+          }, 10_000);
+
+          const emitChunk = (chunk: { content: string; done: boolean; usage?: { inputTokens: number; outputTokens: number } }) => {
+            fullContent += chunk.content;
+            if (chunk.usage) usage = chunk.usage;
+            const sseData = JSON.stringify({
+              id: `chatcmpl-${requestId}`,
+              object: "chat.completion.chunk",
+              created: Math.floor(Date.now() / 1000),
+              model: usedModel,
+              choices: [{
+                index: 0,
+                delta: chunk.done ? {} : { content: chunk.content },
+                finish_reason: chunk.done ? "stop" : null,
+              }],
+            });
+            controller.enqueue(encoder.encode(`data: ${sseData}\n\n`));
+          };
+
+          try {
+            // Immediate byte so the client sees the stream is alive even
+            // before the provider warms up.
+            controller.enqueue(encoder.encode(": connecting\n\n"));
+
+            let firstReceived = false;
+            for await (const chunk of provider.stream({ ...request, model: attempt.model })) {
+              if (!firstReceived) {
+                clearInterval(keepalive);
+                firstReceived = true;
+              }
+              emitChunk(chunk);
+            }
+
+            const streamLatencyMs = Math.round(performance.now() - start);
+            const streamCost = calculateCost(usedModel, usage.inputTokens, usage.outputTokens);
+            const metaEvent = JSON.stringify({
+              _provara: {
+                model: usedModel,
+                provider: usedProvider,
+                latencyMs: streamLatencyMs,
+                cost: streamCost,
+                usage,
+              },
+            });
+            controller.enqueue(encoder.encode(`data: ${metaEvent}\n\n`));
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+
+            await ctx.db.insert(requests).values({
+              id: requestId,
+              provider: usedProvider,
+              model: usedModel,
+              prompt: promptJson,
+              response: fullContent,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              latencyMs: streamLatencyMs,
+              taskType: routingResult.taskType,
+              complexity: routingResult.complexity,
+              routedBy: routingResult.routedBy,
+              usedFallback,
+              fallbackErrors: null,
+              tenantId,
+              userId: attribution.userId,
+              apiTokenId: attribution.apiTokenId,
+              abTestId: routingResult.abTestId || null,
+              promptVersionId: promptVersionId || null,
+            }).run();
+
+            if (routingResult.taskType && routingResult.complexity) {
+              routingEngine.adaptive.updateLatency(
+                routingResult.taskType,
+                routingResult.complexity,
+                usedProvider,
+                usedModel,
+                streamLatencyMs,
+              );
+            }
+
+            logCost(ctx.db, {
+              requestId,
+              provider: usedProvider,
+              model: usedModel,
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              tenantId,
+              userId: attribution.userId,
+              apiTokenId: attribution.apiTokenId,
+            }).then((streamCost2) => {
+              publishLive({
+                id: requestId,
+                provider: usedProvider,
+                model: usedModel,
+                taskType: routingResult.taskType,
+                complexity: routingResult.complexity,
+                routedBy: routingResult.routedBy,
+                cached: false,
+                usedFallback,
+                latencyMs: streamLatencyMs,
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                cost: streamCost2,
+                tenantId,
+                userId: attribution.userId,
+                apiTokenId: attribution.apiTokenId,
+                promptPreview: buildPromptPreview(promptJson),
+                createdAt: new Date().toISOString(),
+              });
+            }).catch(() => {});
+
+            if (!skipCache) {
+              const completedResponse: CompletionResponse = {
+                id: requestId,
+                provider: usedProvider,
+                model: usedModel,
+                content: fullContent,
+                usage,
+                latencyMs: streamLatencyMs,
+              };
+              putCache(request.messages, usedProvider, usedModel, completedResponse);
+              if (semanticCache) {
+                void semanticCache
+                  .put(request.messages, tenantId, usedProvider, usedModel, completedResponse)
+                  .catch((err) => {
+                    console.warn(
+                      "[semantic-cache] writeback failed:",
+                      err instanceof Error ? err.message : err,
+                    );
+                  });
+              }
+            }
+
+            judge.maybeJudge({
+              requestId,
+              tenantId,
+              messages: request.messages,
+              responseContent: fullContent,
+              taskType: routingResult.taskType,
+              complexity: routingResult.complexity,
+              provider: usedProvider,
+              model: usedModel,
+            }).catch(() => {});
+          } catch (err) {
+            // The response headers are already committed, so we can't 502
+            // — instead emit a structured error event in the stream that
+            // the client renders as a real error message. Without this
+            // the browser sees only an abrupt close ("network error").
+            const msg = describeProviderError(err);
+            console.warn(`Provider ${usedProvider}/${usedModel} pinned stream failed:`, msg);
+            logProviderErrorStack(err, `${usedProvider}/${usedModel} pinned stream`);
+            try {
+              const errorEvent = JSON.stringify({ error: { message: msg, type: "provider_error" } });
+              controller.enqueue(encoder.encode(`data: ${errorEvent}\n\n`));
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            } catch { /* stream already closed */ }
+            try { controller.close(); } catch { /* already closed */ }
+          } finally {
+            clearInterval(keepalive);
+          }
+        },
+      });
+
+      const streamHeaders: Record<string, string> = {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "X-Provara-Model": usedModel,
+        "X-Provara-Provider": usedProvider,
+        "X-Provara-Request-Id": requestId,
+        // Disable intermediate buffering so SSE events stream in real time.
+        // Nginx honors this; Cloudflare Enterprise does too. Harmless where
+        // unrecognized.
+        "X-Accel-Buffering": "no",
+      };
+      if (guardrailViolations.size > 0) {
+        streamHeaders["X-Provara-Guardrail"] = JSON.stringify([...guardrailViolations]);
+      }
+      return new Response(sseStream, { headers: streamHeaders });
+    }
+
+    // --- Streaming path (fail-fast for adaptive / multi-attempt routes) ---
     if (request.stream) {
       let usedProvider = routingResult.provider;
       let usedModel = routingResult.model;


### PR DESCRIPTION
## Summary
Pinned streams were dying with browser \"network error\" when a cold self-hosted model (Qwen3-36B, DeepSeek-R1) took longer than the cloud ingress' idle timeout (~30s) to emit its first byte. The gateway was blocking on \"pull first chunk before committing to the response\" — no bytes flowed to the client during the cold-start wait, so the ingress closed the connection as idle.

For user-pinned routes (\`routedBy=user-override\`, empty fallbacks from #282) there's no provider to fail over to, so the delay was pure downside.

**Split the streaming path:**
- **User-pinned (single attempt)** — open the SSE response immediately, write \`: connecting\` + periodic \`: keepalive\` comments while the provider warms up, clear the keepalive on the first real chunk, stream normally. On mid-stream failure, emit a structured error event (\`data: {\"error\":{\"message\":...}}\`) so the client can render a real message — can't 502 once headers are out.
- **Adaptive / A-B / fallback-capable** — unchanged. 10s first-chunk gate still fails over fast.

**Client** (\`use-chat-session.ts\`) parses the error event and surfaces it as an assistant error message, same shape as the existing pre-stream error path.

## Test plan
- [x] Typecheck clean (gateway + web)
- [x] Gateway vitest 522/522 pass
- [ ] Pin Qwen3.6:latest on cold Ollama — completes without \"network error\"
- [ ] Trigger an in-stream failure (kill the Ollama host after request starts) — client shows the structured error instead of silent close
- [ ] Non-pinned adaptive route still completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)