### PR TITLE
chore: gate logProviderErrorStack behind PROVARA_DEBUG_PROVIDER_ERRORS

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -82,10 +82,11 @@ function redactSecrets(s: string): string {
 
 // Emit a redacted stack trace for the whole error chain so we can identify
 // *where* a surprising cause (e.g. a TypeError with a bearer-string message)
-// is being thrown from — undici internals, an outbound proxy, or our own
-// code. Kept separate from describeProviderError so the short summary still
-// fits cleanly in single-line logs.
+// is being thrown from. Heavy for steady-state prod, so gated behind
+// PROVARA_DEBUG_PROVIDER_ERRORS — enable only when actively diagnosing.
+// The short summary from describeProviderError is always logged.
 function logProviderErrorStack(err: unknown, label: string): void {
+  if (process.env.PROVARA_DEBUG_PROVIDER_ERRORS !== "true") return;
   const chain: string[] = [];
   let cur: unknown = err;
   let depth = 0;


### PR DESCRIPTION
## Summary
PR #286 added a 4-deep error-chain stack dump that was critical for diagnosing the \"Bearer ... is not a legal HTTP header value\" bug chain (#287–#291). Now that we've landed the fixes, the stack dump is ~20 lines per failure — too heavy for steady-state prod.

Gated behind \`PROVARA_DEBUG_PROVIDER_ERRORS=true\`. The short one-line summary from \`describeProviderError\` (with redaction + status + code) still logs on every failure and remains the default signal.

## Test plan
- [x] Typecheck clean
- [ ] Set \`PROVARA_DEBUG_PROVIDER_ERRORS=true\` in env when actively diagnosing; stack dumps reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)