### PR TITLE
fix: Evals respects pinned judge config + auto-selects match scorer

### DIFF
--- a/apps/web/src/app/dashboard/evals/page.tsx
+++ b/apps/web/src/app/dashboard/evals/page.tsx
@@ -280,7 +280,18 @@ export default function EvalsPage() {
             </select>
             <select
               value={runProviderModel}
-              onChange={(e) => setRunProviderModel(e.target.value)}
+              onChange={(e) => {
+                const v = e.target.value;
+                setRunProviderModel(v);
+                // Classifier output is a label string — judge-grading it makes
+                // no sense (always scores 1/5). Auto-flip to exact-match when
+                // the classifier is picked; flip back to judge for model
+                // targets if the user previously had classifier selected.
+                if (v === CLASSIFIER_TARGET) setRunScorer("exact-match");
+                else if (runScorer === "exact-match" && runProviderModel === CLASSIFIER_TARGET) {
+                  setRunScorer("llm-judge");
+                }
+              }}
               className="bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm"
             >
               <option value="">Target…</option>

--- a/packages/gateway/src/routes/evals.ts
+++ b/packages/gateway/src/routes/evals.ts
@@ -8,6 +8,7 @@ import type { ProviderRegistry } from "../providers/index.js";
 import type { ChatMessage } from "../providers/types.js";
 import { logCost } from "../cost/index.js";
 import { classifyRequest } from "../classifier/index.js";
+import { resolveJudgeTarget } from "../routing/judge.js";
 
 /** Special sentinel target: runs the Provara classifier instead of a model.
  *  Output shape is "taskType/complexity" (e.g. "coding/medium") for
@@ -87,25 +88,9 @@ function parseJudgeResponse(raw: string): number | null {
   return null;
 }
 
-function pickJudgeTarget(registry: ProviderRegistry): { provider: string; model: string } | null {
-  // Prefer a known reliable grader; fall back to any available provider.
-  const preferred: { provider: string; models: string[] }[] = [
-    { provider: "openai", models: ["gpt-4.1-mini", "gpt-4o-mini"] },
-    { provider: "anthropic", models: ["claude-haiku-4-5-20251001"] },
-  ];
-  for (const pref of preferred) {
-    const provider = registry.get(pref.provider);
-    if (!provider) continue;
-    for (const model of pref.models) {
-      if (provider.models.includes(model)) return { provider: pref.provider, model };
-    }
-  }
-  const first = registry.list()[0];
-  if (first && first.models.length > 0) {
-    return { provider: first.name, model: first.models[0] };
-  }
-  return null;
-}
+// Judge target is resolved via the shared resolveJudgeTarget helper so Evals
+// respects the dashboard-pinned judge config (routing/judge.ts). Previously
+// we hardcoded an openai/anthropic preference list here and ignored the pin.
 
 /** Produce the target's output for a case. For normal targets this is a
  *  chat completion; for the classifier sentinel it's the predicted labels
@@ -176,7 +161,7 @@ async function executeRun(
     return;
   }
 
-  const judgeTarget = scorer === "llm-judge" ? pickJudgeTarget(registry) : null;
+  const judgeTarget = scorer === "llm-judge" ? resolveJudgeTarget(registry) : null;
   const CONCURRENCY = 4;
   let totalScoreSum = 0;
   let totalScoreCount = 0;

--- a/packages/gateway/src/routing/judge.ts
+++ b/packages/gateway/src/routing/judge.ts
@@ -167,7 +167,12 @@ export interface JudgeContext {
   model: string;
 }
 
-function resolveJudgeTarget(registry: ProviderRegistry): { provider: string; model: string } | null {
+/** Resolve the judge target for this run. Honors the dashboard-pinned
+ *  (provider, model) from the global judge config; falls back to cheapest
+ *  available if the pin isn't in the registry. Shared between the main
+ *  quality-judging path and the Evals runner so both respect the same
+ *  operator config. */
+export function resolveJudgeTarget(registry: ProviderRegistry): { provider: string; model: string } | null {
   if (judgeProvider && judgeModel) {
     const pinned = registry.get(judgeProvider);
     if (pinned && pinned.models.includes(judgeModel)) {


### PR DESCRIPTION
## Summary
Two related fixes from a UAT report:

1. **Pinned judge ignored by Evals.** The Evals runner had its own hardcoded judge picker (openai/gpt-4.1-mini → anthropic/claude-haiku), so the dashboard-pinned judge set via \`/routing/feedback\` was silently bypassed. Extracted \`resolveJudgeTarget\` from \`routing/judge.ts\` (already honors the pin with a cheapest fallback) and shared it — main-path and Evals-path judging now use one source of truth.

2. **Classifier target + LLM judge always 0%.** The inline warning from #293 wasn't strong enough. First user to try it picked \"Provara classifier\" with the default \"LLM judge\" scorer; every case scored 1/5 because the judge rates label strings like \`coding/medium (conf=0.84)\` as bad chat responses (correctly). Now picking the classifier auto-switches the scorer to \`exact-match\`. Manual override still works if an operator really wants judge-graded classifier output.

## Test plan
- [x] Typecheck (gateway + web) clean
- [x] Gateway vitest 522/522 pass
- [ ] In the UI, pick \"Provara classifier\" → confirm scorer auto-flips to Exact match
- [ ] Run an llm-judge eval against a model target → confirm the pinned judge (e.g. xAI/grok-4-1-fast-reasoning) is used, not openai

🤖 Generated with [Claude Code](https://claude.com/claude-code)