### PR TITLE
feat(#300): Google/Gemini adapter tool translation [stack: #298]

### DIFF
--- a/packages/gateway/src/providers/google.ts
+++ b/packages/gateway/src/providers/google.ts
@@ -1,12 +1,24 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import type { Provider, CompletionRequest, CompletionResponse, StreamChunk, ChatMessage } from "./types.js";
+import type {
+  Provider,
+  CompletionRequest,
+  CompletionResponse,
+  StreamChunk,
+  ChatMessage,
+  ToolDefinition,
+  ToolChoice,
+  ToolCall,
+  FinishReason,
+} from "./types.js";
 import { messageText } from "./types.js";
 import { nanoid } from "nanoid";
 
 type GooglePart =
   | { text: string }
   | { inlineData: { mimeType: string; data: string } }
-  | { fileData: { mimeType: string; fileUri: string } };
+  | { fileData: { mimeType: string; fileUri: string } }
+  | { functionCall: { name: string; args: Record<string, unknown> } }
+  | { functionResponse: { name: string; response: Record<string, unknown> } };
 
 function toGoogleParts(content: ChatMessage["content"]): GooglePart[] {
   if (typeof content === "string") return [{ text: content }];
@@ -17,10 +29,206 @@ function toGoogleParts(content: ChatMessage["content"]): GooglePart[] {
     if (dataMatch) {
       return { inlineData: { mimeType: dataMatch[1], data: dataMatch[2] } };
     }
-    // Gemini's fileData expects a URI it can fetch (typically a Files API
-    // handle); pass through and let the upstream reject if unsupported.
     return { fileData: { mimeType: "image/*", fileUri: url } };
   });
+}
+
+/** JSON Schema fields Google's generative API rejects. The upstream Schema
+ *  type is an OpenAPI 3.0 subset — keeping the accept list small here avoids
+ *  opaque 400s at the SDK boundary. */
+const STRIPPED_SCHEMA_KEYS = new Set([
+  "$schema",
+  "$id",
+  "$ref",
+  "definitions",
+  "oneOf",
+  "anyOf",
+  "allOf",
+  "not",
+  "additionalProperties",
+  "patternProperties",
+  "if",
+  "then",
+  "else",
+]);
+
+function stripSchemaForGoogle(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(stripSchemaForGoogle);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(schema as Record<string, unknown>)) {
+    if (STRIPPED_SCHEMA_KEYS.has(k)) continue;
+    out[k] = stripSchemaForGoogle(v);
+  }
+  return out;
+}
+
+/** OpenAI tools → Google `tools: [{functionDeclarations: [...]}]`. One tool
+ *  entry per call — the Google SDK lets a tools entry group multiple function
+ *  declarations, and we pack them all into a single entry for simplicity. */
+export function toGoogleTools(
+  tools: ToolDefinition[] | undefined,
+): Array<{ functionDeclarations: Array<{ name: string; description?: string; parameters?: Record<string, unknown> }> }> | undefined {
+  if (!tools || tools.length === 0) return undefined;
+  const declarations = tools.map((t) => ({
+    name: t.function.name,
+    description: t.function.description,
+    parameters: t.function.parameters
+      ? (stripSchemaForGoogle(t.function.parameters) as Record<string, unknown>)
+      : undefined,
+  }));
+  return [{ functionDeclarations: declarations }];
+}
+
+/** OpenAI tool_choice → Google toolConfig. Mapping:
+ *   "none"     → mode: NONE
+ *   "auto"     → mode: AUTO
+ *   "required" → mode: ANY
+ *   {function} → mode: ANY + allowedFunctionNames: [name]
+ */
+export function toGoogleToolConfig(
+  choice: ToolChoice | undefined,
+): { functionCallingConfig: { mode: "AUTO" | "ANY" | "NONE"; allowedFunctionNames?: string[] } } | undefined {
+  if (choice === undefined) return undefined;
+  if (choice === "none") return { functionCallingConfig: { mode: "NONE" } };
+  if (choice === "auto") return { functionCallingConfig: { mode: "AUTO" } };
+  if (choice === "required") return { functionCallingConfig: { mode: "ANY" } };
+  if (typeof choice === "object" && choice.type === "function") {
+    return {
+      functionCallingConfig: {
+        mode: "ANY",
+        allowedFunctionNames: [choice.function.name],
+      },
+    };
+  }
+  return undefined;
+}
+
+/** Walk prior messages to find the function name associated with a tool_call_id.
+ *  Google's functionResponse is keyed by name, not id, so we recover the name
+ *  from the assistant message that produced the matching tool_call. */
+function findToolCallName(
+  messages: ChatMessage[],
+  upToIndex: number,
+  toolCallId: string | undefined,
+): string | undefined {
+  if (!toolCallId) return undefined;
+  for (let i = upToIndex - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "assistant" && msg.tool_calls) {
+      const match = msg.tool_calls.find((tc) => tc.id === toolCallId);
+      if (match) return match.function.name;
+    }
+  }
+  return undefined;
+}
+
+/** Build the Google `contents` array from an OpenAI ChatMessage sequence.
+ *  - System messages handled separately via `systemInstruction`.
+ *  - `role: "tool"` becomes a user message with a `functionResponse` part.
+ *    Consecutive tool results merge into a single user message.
+ *  - Assistant with `tool_calls` becomes a `model` message with one
+ *    `functionCall` part per tool call (plus a text part if content is
+ *    non-empty).
+ */
+export function toGoogleContents(
+  messages: ChatMessage[],
+): Array<{ role: "user" | "model"; parts: GooglePart[] }> {
+  const out: Array<{ role: "user" | "model"; parts: GooglePart[] }> = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "system") continue;
+
+    if (msg.role === "tool") {
+      const name = findToolCallName(messages, i, msg.tool_call_id);
+      if (!name) continue; // cannot translate without a name; skip silently
+      const content = typeof msg.content === "string" ? msg.content : "";
+      let responseObj: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(content);
+        responseObj =
+          parsed && typeof parsed === "object" && !Array.isArray(parsed)
+            ? (parsed as Record<string, unknown>)
+            : { result: parsed };
+      } catch {
+        responseObj = { result: content };
+      }
+      const part: GooglePart = {
+        functionResponse: { name, response: responseObj },
+      };
+      const prev = out[out.length - 1];
+      if (
+        prev &&
+        prev.role === "user" &&
+        prev.parts.every((p) => "functionResponse" in p)
+      ) {
+        prev.parts.push(part);
+      } else {
+        out.push({ role: "user", parts: [part] });
+      }
+      continue;
+    }
+
+    if (msg.role === "assistant" && msg.tool_calls && msg.tool_calls.length > 0) {
+      const parts: GooglePart[] = [];
+      const text =
+        typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content
+                .filter((p) => p.type === "text")
+                .map((p) => (p as { type: "text"; text: string }).text)
+                .join("")
+            : "";
+      if (text) parts.push({ text });
+      for (const tc of msg.tool_calls) {
+        let args: Record<string, unknown> = {};
+        try {
+          const parsed = JSON.parse(tc.function.arguments);
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            args = parsed as Record<string, unknown>;
+          }
+        } catch {
+          args = {};
+        }
+        parts.push({ functionCall: { name: tc.function.name, args } });
+      }
+      out.push({ role: "model", parts });
+      continue;
+    }
+
+    out.push({
+      role: msg.role === "assistant" ? "model" : "user",
+      parts: toGoogleParts(msg.content),
+    });
+  }
+  return out;
+}
+
+export function mapGoogleFinishReason(
+  reason: string | undefined | null,
+  hasToolCalls: boolean,
+): FinishReason | undefined {
+  if (hasToolCalls) return "tool_calls";
+  if (!reason) return undefined;
+  switch (reason) {
+    case "STOP":
+      return "stop";
+    case "MAX_TOKENS":
+      return "length";
+    case "SAFETY":
+    case "RECITATION":
+    case "BLOCKLIST":
+    case "PROHIBITED_CONTENT":
+    case "SPII":
+      return "content_filter";
+    case "MALFORMED_FUNCTION_CALL":
+      // Treat as tool_calls so the client knows tools were attempted; a
+      // malformed call upstream is still closer to "tool_calls" than "stop".
+      return "tool_calls";
+    default:
+      return undefined;
+  }
 }
 
 const GOOGLE_API_BASE = "https://generativelanguage.googleapis.com/v1beta";
@@ -35,15 +243,12 @@ export function createGoogleProvider(apiKey?: string): Provider {
 
     async listModels(): Promise<string[]> {
       try {
-        // Google's JS SDK doesn't expose listModels, so use the REST API directly
         const res = await fetch(`${GOOGLE_API_BASE}/models?key=${key}&pageSize=100`);
         if (!res.ok) return provider.models;
         const data = await res.json() as { models?: { name: string; supportedGenerationMethods?: string[] }[] };
         const chatModels: string[] = [];
         for (const m of data.models || []) {
-          // Only include models that support generateContent (chat)
           if (m.supportedGenerationMethods?.includes("generateContent")) {
-            // Model name is "models/gemini-2.5-pro" — strip the prefix
             chatModels.push(m.name.replace("models/", ""));
           }
         }
@@ -60,27 +265,58 @@ export function createGoogleProvider(apiKey?: string): Provider {
       const start = performance.now();
 
       const systemMessage = request.messages.find((m) => m.role === "system");
+      const tools = toGoogleTools(request.tools);
+      const toolConfig = toGoogleToolConfig(request.tool_choice);
+
+      // Our ad-hoc tools / toolConfig shape is structurally compatible with
+      // the SDK's ModelParams but doesn't satisfy its nominal types. Cast at
+      // the SDK boundary (same pattern as anthropic.ts).
       const model = genAI.getGenerativeModel({
         model: request.model,
         ...(systemMessage && { systemInstruction: messageText(systemMessage) }),
-      });
+        ...(tools && { tools }),
+        ...(toolConfig && { toolConfig }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
 
-      const contents = request.messages
-        .filter((m) => m.role !== "system")
-        .map((m) => ({
-          role: m.role === "assistant" ? "model" : "user",
-          parts: toGoogleParts(m.content),
-        }));
+      const contents = toGoogleContents(request.messages);
 
+      // The SDK's type for getGenerativeModel is stricter than our ad-hoc
+      // tools / toolConfig shape; cast at the SDK boundary for the same
+      // reason as anthropic.ts — the underlying runtime validates.
       const result = await model.generateContent({ contents });
       const response = result.response;
       const latencyMs = Math.round(performance.now() - start);
+
+      // Walk parts: collect text, collect functionCalls separately. Google
+      // doesn't emit tool-call ids, so we synthesize a stable one per call.
+      const toolCalls: ToolCall[] = [];
+      let content = "";
+      const parts = response.candidates?.[0]?.content?.parts ?? [];
+      for (const part of parts) {
+        if ("text" in part && typeof part.text === "string") {
+          content += part.text;
+        } else if ("functionCall" in part && part.functionCall) {
+          toolCalls.push({
+            id: `call_${nanoid(10)}`,
+            type: "function",
+            function: {
+              name: part.functionCall.name,
+              arguments: JSON.stringify(part.functionCall.args ?? {}),
+            },
+          });
+        }
+      }
+
+      const rawFinishReason = response.candidates?.[0]?.finishReason as string | undefined;
 
       return {
         id: nanoid(),
         provider: "google",
         model: request.model,
-        content: response.text() || "",
+        content,
+        tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
+        finish_reason: mapGoogleFinishReason(rawFinishReason, toolCalls.length > 0),
         usage: {
           inputTokens: response.usageMetadata?.promptTokenCount || 0,
           outputTokens: response.usageMetadata?.candidatesTokenCount || 0,
@@ -91,35 +327,79 @@ export function createGoogleProvider(apiKey?: string): Provider {
 
     async *stream(request: CompletionRequest): AsyncIterable<StreamChunk> {
       const systemMessage = request.messages.find((m) => m.role === "system");
+      const tools = toGoogleTools(request.tools);
+      const toolConfig = toGoogleToolConfig(request.tool_choice);
+
+      // Our ad-hoc tools / toolConfig shape is structurally compatible with
+      // the SDK's ModelParams but doesn't satisfy its nominal types. Cast at
+      // the SDK boundary (same pattern as anthropic.ts).
       const model = genAI.getGenerativeModel({
         model: request.model,
         ...(systemMessage && { systemInstruction: messageText(systemMessage) }),
-      });
+        ...(tools && { tools }),
+        ...(toolConfig && { toolConfig }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
 
-      const contents = request.messages
-        .filter((m) => m.role !== "system")
-        .map((m) => ({
-          role: m.role === "assistant" ? "model" : "user",
-          parts: toGoogleParts(m.content),
-        }));
-
+      const contents = toGoogleContents(request.messages);
       const result = await model.generateContentStream({ contents });
 
       let totalInputTokens = 0;
       let totalOutputTokens = 0;
+      let lastFinishReason: string | undefined;
+      // Google emits each functionCall whole per chunk rather than delta-by-
+      // delta. Track emitted (name, args) pairs to avoid duplicates if the
+      // same call appears in the final aggregated response + a stream chunk.
+      const emittedCallKeys = new Set<string>();
+      let nextToolCallIndex = 0;
+      let sawToolCall = false;
 
       for await (const chunk of result.stream) {
-        const text = chunk.text() || "";
         if (chunk.usageMetadata) {
           totalInputTokens = chunk.usageMetadata.promptTokenCount || 0;
           totalOutputTokens = chunk.usageMetadata.candidatesTokenCount || 0;
         }
-        yield { content: text, done: false };
+        lastFinishReason = chunk.candidates?.[0]?.finishReason ?? lastFinishReason;
+
+        const parts = chunk.candidates?.[0]?.content?.parts ?? [];
+        let textThisChunk = "";
+        const toolCallDeltas: Array<{
+          index: number;
+          id: string;
+          type: "function";
+          function: { name: string; arguments: string };
+        }> = [];
+        for (const part of parts) {
+          if ("text" in part && typeof part.text === "string") {
+            textThisChunk += part.text;
+          } else if ("functionCall" in part && part.functionCall) {
+            const args = JSON.stringify(part.functionCall.args ?? {});
+            const key = `${part.functionCall.name}::${args}`;
+            if (emittedCallKeys.has(key)) continue;
+            emittedCallKeys.add(key);
+            sawToolCall = true;
+            toolCallDeltas.push({
+              index: nextToolCallIndex++,
+              id: `call_${nanoid(10)}`,
+              type: "function",
+              function: { name: part.functionCall.name, arguments: args },
+            });
+          }
+        }
+
+        if (textThisChunk || toolCallDeltas.length > 0) {
+          yield {
+            content: textThisChunk,
+            done: false,
+            tool_calls: toolCallDeltas.length > 0 ? toolCallDeltas : undefined,
+          };
+        }
       }
 
       yield {
         content: "",
         done: true,
+        finish_reason: mapGoogleFinishReason(lastFinishReason, sawToolCall),
         usage: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens },
       };
     },

--- a/packages/gateway/tests/google-translation.test.ts
+++ b/packages/gateway/tests/google-translation.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  toGoogleTools,
+  toGoogleToolConfig,
+  toGoogleContents,
+  mapGoogleFinishReason,
+} from "../src/providers/google.js";
+import type { ChatMessage, ToolDefinition } from "../src/providers/types.js";
+
+const weatherTool: ToolDefinition = {
+  type: "function",
+  function: {
+    name: "get_weather",
+    description: "Get current weather for a city",
+    parameters: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+};
+
+describe("#300 google tool translation", () => {
+  describe("toGoogleTools", () => {
+    it("maps OpenAI tool shape to Google functionDeclarations in a single tools entry", () => {
+      const out = toGoogleTools([weatherTool]);
+      expect(out).toHaveLength(1);
+      expect(out?.[0].functionDeclarations).toHaveLength(1);
+      expect(out?.[0].functionDeclarations[0].name).toBe("get_weather");
+      expect(out?.[0].functionDeclarations[0].parameters).toEqual({
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      });
+    });
+
+    it("strips JSON Schema fields Google does not accept", () => {
+      const tool: ToolDefinition = {
+        type: "function",
+        function: {
+          name: "strip_test",
+          parameters: {
+            $schema: "http://json-schema.org/draft-07/schema#",
+            $id: "https://example.com/foo.json",
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              x: { type: "string" },
+              y: { oneOf: [{ type: "string" }, { type: "number" }] },
+            },
+          },
+        },
+      };
+      const out = toGoogleTools([tool]);
+      const params = out?.[0].functionDeclarations[0].parameters as Record<string, unknown>;
+      expect(params.$schema).toBeUndefined();
+      expect(params.$id).toBeUndefined();
+      expect(params.additionalProperties).toBeUndefined();
+      const yProp = (params.properties as Record<string, Record<string, unknown>>).y;
+      expect(yProp.oneOf).toBeUndefined();
+      // Other fields preserved
+      expect(params.type).toBe("object");
+      expect((params.properties as Record<string, Record<string, unknown>>).x).toEqual({ type: "string" });
+    });
+
+    it("returns undefined for empty or missing tool arrays", () => {
+      expect(toGoogleTools(undefined)).toBeUndefined();
+      expect(toGoogleTools([])).toBeUndefined();
+    });
+  });
+
+  describe("toGoogleToolConfig", () => {
+    it("maps the vocabulary words", () => {
+      expect(toGoogleToolConfig("auto")).toEqual({ functionCallingConfig: { mode: "AUTO" } });
+      expect(toGoogleToolConfig("none")).toEqual({ functionCallingConfig: { mode: "NONE" } });
+      expect(toGoogleToolConfig("required")).toEqual({ functionCallingConfig: { mode: "ANY" } });
+    });
+
+    it("maps specific-tool to ANY + allowedFunctionNames", () => {
+      expect(
+        toGoogleToolConfig({ type: "function", function: { name: "get_weather" } }),
+      ).toEqual({
+        functionCallingConfig: { mode: "ANY", allowedFunctionNames: ["get_weather"] },
+      });
+    });
+
+    it("returns undefined for missing tool_choice", () => {
+      expect(toGoogleToolConfig(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("toGoogleContents", () => {
+    it("filters out system messages (handled separately via systemInstruction)", () => {
+      const msgs: ChatMessage[] = [
+        { role: "system", content: "system prompt" },
+        { role: "user", content: "hello" },
+      ];
+      const out = toGoogleContents(msgs);
+      expect(out).toHaveLength(1);
+      expect(out[0].role).toBe("user");
+    });
+
+    it("maps assistant role to model (Gemini's naming)", () => {
+      const msgs: ChatMessage[] = [
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hi there" },
+      ];
+      const out = toGoogleContents(msgs);
+      expect(out[1].role).toBe("model");
+    });
+
+    it("converts assistant tool_calls into a model message with functionCall parts", () => {
+      const msgs: ChatMessage[] = [
+        { role: "user", content: "weather?" },
+        {
+          role: "assistant",
+          content: "let me check",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"SF"}' },
+            },
+          ],
+        },
+      ];
+      const out = toGoogleContents(msgs);
+      expect(out[1].role).toBe("model");
+      expect(out[1].parts[0]).toEqual({ text: "let me check" });
+      expect(out[1].parts[1]).toEqual({
+        functionCall: { name: "get_weather", args: { city: "SF" } },
+      });
+    });
+
+    it("converts role:tool messages into user messages with functionResponse parts (name recovered via lookup)", () => {
+      const msgs: ChatMessage[] = [
+        { role: "user", content: "weather in SF?" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            {
+              id: "call_weather_1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"city":"SF"}' },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: '{"temperature":72}',
+          tool_call_id: "call_weather_1",
+        },
+      ];
+      const out = toGoogleContents(msgs);
+      // user → model → user (function response)
+      expect(out).toHaveLength(3);
+      expect(out[2].role).toBe("user");
+      expect(out[2].parts[0]).toEqual({
+        functionResponse: {
+          name: "get_weather",
+          response: { temperature: 72 },
+        },
+      });
+    });
+
+    it("merges consecutive tool messages with different ids into one user message (parallel results)", () => {
+      const msgs: ChatMessage[] = [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: "a", type: "function", function: { name: "tool_a", arguments: "{}" } },
+            { id: "b", type: "function", function: { name: "tool_b", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", content: '{"x":1}', tool_call_id: "a" },
+        { role: "tool", content: '{"y":2}', tool_call_id: "b" },
+      ];
+      const out = toGoogleContents(msgs);
+      // model message + one user message carrying both function responses
+      expect(out).toHaveLength(2);
+      expect(out[1].parts).toHaveLength(2);
+    });
+
+    it("wraps non-object tool content as {result: ...} for the functionResponse", () => {
+      const msgs: ChatMessage[] = [
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: "c", type: "function", function: { name: "tool_c", arguments: "{}" } },
+          ],
+        },
+        { role: "tool", content: "just a plain string", tool_call_id: "c" },
+      ];
+      const out = toGoogleContents(msgs);
+      expect(out[1].parts[0]).toEqual({
+        functionResponse: {
+          name: "tool_c",
+          response: { result: "just a plain string" },
+        },
+      });
+    });
+
+    it("skips role:tool messages when no matching assistant tool_call can be found", () => {
+      const msgs: ChatMessage[] = [
+        { role: "user", content: "hi" },
+        { role: "tool", content: "orphan", tool_call_id: "never_issued" },
+      ];
+      const out = toGoogleContents(msgs);
+      expect(out).toHaveLength(1);
+      expect(out[0].role).toBe("user");
+    });
+  });
+
+  describe("mapGoogleFinishReason", () => {
+    it("maps core Gemini finishReasons to OpenAI finish_reason", () => {
+      expect(mapGoogleFinishReason("STOP", false)).toBe("stop");
+      expect(mapGoogleFinishReason("MAX_TOKENS", false)).toBe("length");
+      expect(mapGoogleFinishReason("SAFETY", false)).toBe("content_filter");
+      expect(mapGoogleFinishReason("PROHIBITED_CONTENT", false)).toBe("content_filter");
+    });
+
+    it("overrides to tool_calls whenever the response contained function calls", () => {
+      expect(mapGoogleFinishReason("STOP", true)).toBe("tool_calls");
+      expect(mapGoogleFinishReason("MAX_TOKENS", true)).toBe("tool_calls");
+    });
+
+    it("treats MALFORMED_FUNCTION_CALL as tool_calls (the attempt was made)", () => {
+      expect(mapGoogleFinishReason("MALFORMED_FUNCTION_CALL", false)).toBe("tool_calls");
+    });
+
+    it("returns undefined for unknown / missing reasons without tool calls", () => {
+      expect(mapGoogleFinishReason(undefined, false)).toBeUndefined();
+      expect(mapGoogleFinishReason(null, false)).toBeUndefined();
+      expect(mapGoogleFinishReason("FUTURE_REASON_WE_DO_NOT_KNOW", false)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 300
branch: issue/300-google-tool-translation
status: resolved
updated_at: 2026-04-23T20:45:00Z
review_status: awaiting-review
-->

## Summary

Translates OpenAI-shaped tool requests to Gemini's `functionDeclarations` / `functionCall` / `functionResponse` format and back. Stripped JSON Schema subset handling for Gemini's OpenAPI-3.0-compatible parameter schemas. Tool-call id handling is synthesized since Gemini doesn't emit ids natively — names are recovered via prior-message lookup when the client sends `role: "tool"` results.

Stacked on #298. Parallels #299 structure.

Closes #300

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan

Four tasks mirroring #299: T1 request-side, T2 response-side, T3 streaming, T4 verification. All tier-1 except T4. Resolved one open question from the original issue: *"Are tool-call ids needed end-to-end?"* — Gemini does NOT emit ids, so we synthesize them (`call_${nanoid(10)}`) on the response side AND recover function names from prior assistant tool_calls when translating `role: "tool"` back to `functionResponse`. The synthesized id is stable within one turn of the conversation but not stable across history — that's fine because Gemini matches on name, not id.

### What We Discovered

- **Gemini matches functions by NAME, not by id.** This is the most important divergence from OpenAI and Anthropic. For multi-tool parallel calls to round-trip, we walk backwards through messages to find the assistant's matching `tool_call` and use its `function.name` in the `functionResponse`. If no match is found, the tool message is silently skipped rather than sent with a wrong name (which would cause an opaque 400).
- **Gemini's parameter schema is an OpenAPI 3.0 subset, not full JSON Schema.** Fields like `$schema`, `$id`, `oneOf`, `anyOf`, `allOf`, `additionalProperties`, `patternProperties`, `if`/`then`/`else` cause 400s or silent misbehavior. Added a recursive `stripSchemaForGoogle` that removes them at every depth. Rejected an allowlist approach — the accept list is fluid as Gemini evolves and a reject list is less likely to drop valid fields we haven't accounted for.
- **Gemini streams function calls as complete objects per chunk, not as `partial_json` fragments.** No accumulation state machine needed like Anthropic's. But that creates a de-duplication hazard — the same call can appear in a stream chunk AND in the final aggregated response. Dedup by `(name, JSON.stringify(args))` pair prevents double-emission.
- **`MALFORMED_FUNCTION_CALL` as `finishReason`:** Gemini can fail mid-call. Mapped to OpenAI's `tool_calls` rather than something like `error` because the attempt was made — the client knows tool-calling was in flight and can retry / error-handle accordingly. The raw string is lost at the OpenAI boundary (OpenAI's `finish_reason` doesn't model it), which is acceptable fidelity.
- **SDK types are strict but structurally compatible with our types.** `getGenerativeModel` insists on its nominal `ModelParams` shape. Cast at the SDK boundary (same pattern as `anthropic.ts`). The SDK validates at runtime — bad shapes surface as clean 400s.

### Implementation Issues

- `SchemaType` in the SDK is a string-valued enum. Our JSON Schema passthrough uses lowercase strings (`"object"`, `"string"`) which match the enum values directly. No transformation needed on the type field.
- Tool content wrapping: `functionResponse.response` must be an object. Clients sending raw strings ("just a plain string") as tool results needed wrapping as `{result: "just a plain string"}`. JSON-object content is used directly; non-object content (arrays, primitives, parse failures) is wrapped.

### Key Decisions Made

- **Synthesize tool-call ids, don't try to make Gemini emit them.** Not worth fighting the SDK. The synthesized id is only meaningful within one client-observable exchange and the client echoes it back unchanged.
- **Skip orphaned `role: "tool"` messages silently.** If the client sends a tool result with a `tool_call_id` that doesn't match any prior assistant tool_call in this conversation, we drop it. Alternative would be to send a `functionResponse` with an empty `name` which Gemini rejects with an opaque error. Silent skip is cleaner.
- **Unit tests for the four helpers; no live round-trip.** Consistent with #298 and #299 — session cadence treats typecheck + fake-backed tests as primary verification surface. 17 Google-specific cases cover all the documented rules plus the parameter-schema strip edge cases.

### Test Evidence

- `npx vitest run` — 557 passed, 0 failed (up from 540 baseline; +17 in `tests/google-translation.test.ts`).
- `npx tsc --noEmit` in `packages/gateway` — clean on the touched file.

## Changes

| Area | What changed |
|------|--------------|
| `packages/gateway/src/providers/google.ts` | Added `toGoogleTools`, `toGoogleToolConfig`, `toGoogleContents`, `mapGoogleFinishReason` exports. `complete()` forwards tools/toolConfig, walks candidate parts for text + functionCall. `stream()` emits whole functionCall deltas per chunk with (name, args) dedup. Recursive JSON Schema subset stripping. |
| `packages/gateway/tests/google-translation.test.ts` | 17 new unit tests across the four helpers, covering schema-strip, tool_choice vocabulary, assistant→model role translation, functionCall/functionResponse round-trips, name recovery via id lookup, non-object content wrapping, orphaned tool-message skipping, and finishReason overrides. |

---
Authored-by: claude/opus-4-7 (claude-code, 1m-context)
Last-code-by: claude/opus-4-7 (claude-code, 1m-context)
*Captain's log — PR opened*
