### PR TITLE
feat(#301): tool capability gating + docs + playground UI [stack: #298]

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,16 +822,74 @@ The authoritative machine-readable spec lives at [`packages/gateway/openapi.yaml
 
 ## Providers
 
-| Provider | Models | API Style |
+| Provider | Models | API Style | Tools |
+|---|---|---|---|
+| **OpenAI** | gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, o3, o4-mini | Native SDK | ✅ |
+| **Anthropic** | claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5 | Native SDK | ✅ |
+| **Google** | gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash | Native SDK | ✅ |
+| **Mistral** | mistral-large, mistral-medium, mistral-small | OpenAI-compatible | ✅ |
+| **xAI** | grok-3, grok-3-mini | OpenAI-compatible | ✅ |
+| **Z.ai** | glm-5.1, glm-5-turbo, glm-5v-turbo, glm-4.7, glm-4.7-flash | OpenAI-compatible | ✅ |
+| **Ollama** | Any local model | OpenAI-compatible | ⚠️ Model-gated |
+| **Custom** | Add any OpenAI-compatible provider via dashboard | OpenAI-compatible | ✅ (assumed) |
+
+## Tool Calling
+
+Provara's `/v1/chat/completions` endpoint accepts OpenAI-compatible `tools` and `tool_choice` parameters and surfaces `tool_calls` on the response. Any client targeting the OpenAI chat-completion wire shape works unchanged — the gateway handles translation to each provider's native format internally.
+
+```ts
+const res = await openai.chat.completions.create({
+  model: "claude-sonnet-4-6", // or "gpt-4o", "gemini-2.5-pro", etc.
+  messages: [{ role: "user", content: "What's the weather in SF?" }],
+  tools: [{
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a city",
+      parameters: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+    },
+  }],
+  tool_choice: "auto",
+});
+
+// res.choices[0].message.tool_calls[0].function.name === "get_weather"
+// res.choices[0].finish_reason === "tool_calls"
+```
+
+**Supported vocabulary:**
+
+- `tool_choice`: `"auto"`, `"none"`, `"required"`, or `{ type: "function", function: { name } }`
+- `tools[].function.parameters`: JSON Schema (Google's adapter strips fields outside the OpenAPI 3.0 subset automatically: `$schema`, `oneOf`, `anyOf`, `additionalProperties`, etc.)
+- `parallel_tool_calls`: supported where the underlying provider supports it (OpenAI, Anthropic, Google all do)
+
+**Provider translation:**
+
+| Provider | Internal shape | Notes |
 |---|---|---|
-| **OpenAI** | gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano, o3, o4-mini | Native SDK |
-| **Anthropic** | claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5 | Native SDK |
-| **Google** | gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash | Native SDK |
-| **Mistral** | mistral-large, mistral-medium, mistral-small | OpenAI-compatible |
-| **xAI** | grok-3, grok-3-mini | OpenAI-compatible |
-| **Z.ai** | glm-5.1, glm-5-turbo, glm-5v-turbo, glm-4.7, glm-4.7-flash | OpenAI-compatible |
-| **Ollama** | Any local model | OpenAI-compatible |
-| **Custom** | Add any OpenAI-compatible provider via dashboard | OpenAI-compatible |
+| OpenAI, Mistral, xAI, Z.ai, Ollama | Native OpenAI passthrough | Zero translation; client sees exact SDK response |
+| Anthropic | `tool_use` / `tool_result` content blocks | Handles parallel tool-use, streaming `input_json_delta` fragments, merged `tool_result` turns |
+| Google / Gemini | `functionCall` / `functionResponse` parts + `functionDeclarations` | Synthesizes tool-call ids (Gemini doesn't emit them); recovers function names via prior-message lookup on `role: "tool"` messages |
+
+**Capability gate:**
+
+Requests carrying a non-empty `tools` array against a model that doesn't support tool calling return `400 { error: { code: "tools_unsupported" } }` without calling the provider. The capability matrix is in `packages/gateway/src/providers/capabilities.ts`. For Ollama specifically, the gate allows models starting with any of `llama3.1`, `llama3.2`, `llama3.3`, `llama4`, `qwen2.5`, `qwen3`, `mistral`, `mistral-nemo`, `mixtral`, `firefunction`, `command-r`, `hermes3`, `granite3`. Add prefixes there if you're running a tool-trained Ollama model the gate doesn't know about.
+
+The `/v1/models/stats` endpoint surfaces the capability flag per model so dashboard UI can render an indicator:
+
+```json
+{
+  "models": [
+    { "provider": "openai", "model": "gpt-4.1-nano", "capabilities": { "supportsTools": true }, ... },
+    { "provider": "ollama", "model": "gemma:7b",     "capabilities": { "supportsTools": false }, ... }
+  ]
+}
+```
+
+**OpenAI spec reference:** [platform.openai.com/docs/guides/function-calling](https://platform.openai.com/docs/guides/function-calling)
 
 ## Deployment Modes
 

--- a/apps/web/src/app/dashboard/playground/page.tsx
+++ b/apps/web/src/app/dashboard/playground/page.tsx
@@ -22,6 +22,9 @@ import type { PromptPreset } from "../../../components/chat/presets";
 interface ProviderInfo {
   name: string;
   models: string[];
+  /** Per-model capability map keyed by model name (#301). Optional for
+   *  backward compat with older gateway builds that don't surface it. */
+  capabilities?: Record<string, { supportsTools: boolean }>;
 }
 
 // `useSearchParams` forces the page into dynamic rendering and — in Next 15 —
@@ -404,11 +407,15 @@ function PlaygroundInner() {
             <option value="">Auto-routing (let Provara choose)</option>
             {providers.map((p) => (
               <optgroup key={p.name} label={p.name}>
-                {p.models.map((m) => (
-                  <option key={`${p.name}/${m}`} value={`${p.name}/${m}`}>
-                    {m}
-                  </option>
-                ))}
+                {p.models.map((m) => {
+                  const toolsSupported = p.capabilities?.[m]?.supportsTools ?? true;
+                  return (
+                    <option key={`${p.name}/${m}`} value={`${p.name}/${m}`}>
+                      {m}
+                      {toolsSupported ? "" : " — no tools"}
+                    </option>
+                  );
+                })}
               </optgroup>
             ))}
           </select>

--- a/packages/gateway/src/providers/capabilities.ts
+++ b/packages/gateway/src/providers/capabilities.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-model capability lookup. Currently tracks one capability —
+ * `supportsTools` — for the `/v1/chat/completions` tool-calling surface
+ * shipped across #298–#300. Additional capability flags can live here as
+ * they're added (e.g., vision, structured-outputs, response_format json_schema).
+ *
+ * Defaults by provider, per #301 design:
+ *
+ *   OpenAI, Anthropic, Google, Mistral, xAI, Z.ai  →  tools supported
+ *   Ollama                                          →  gated by model base
+ *   Unknown custom provider                         →  tools supported (do
+ *                                                       not block on unknowns;
+ *                                                       the adapter itself
+ *                                                       will surface a clean
+ *                                                       400 if it isn't)
+ */
+
+/** Ollama base-model prefixes known to support OpenAI-compatible tool calling.
+ *  Check against `model.toLowerCase().startsWith(prefix)`. Keep this list small —
+ *  it's easier to add a prefix than to debug why a new Ollama model is silently
+ *  gated off. */
+const OLLAMA_TOOL_CAPABLE_PREFIXES = [
+  "llama3.1",
+  "llama3.2",
+  "llama3.3",
+  "llama4",
+  "qwen2.5",
+  "qwen3",
+  "mistral",
+  "mistral-nemo",
+  "mixtral",
+  "firefunction",
+  "command-r",
+  "hermes3",
+  "granite3",
+];
+
+export function modelSupportsTools(provider: string, model: string): boolean {
+  const p = provider.toLowerCase();
+  const m = model.toLowerCase();
+  switch (p) {
+    case "openai":
+    case "anthropic":
+    case "google":
+    case "mistral":
+    case "xai":
+    case "zai":
+      return true;
+    case "ollama":
+      return OLLAMA_TOOL_CAPABLE_PREFIXES.some((prefix) => m.startsWith(prefix));
+    default:
+      // Custom OpenAI-compatible providers registered via addCustom: default
+      // to `true` because they almost universally follow the OpenAI wire shape.
+      // If a specific one doesn't, the adapter will surface the upstream 400
+      // which is a cleaner failure mode than false-negative gating here.
+      return true;
+  }
+}
+
+export interface ModelCapability {
+  supportsTools: boolean;
+}
+
+export function getModelCapability(provider: string, model: string): ModelCapability {
+  return { supportsTools: modelSupportsTools(provider, model) };
+}

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import type { ProviderRegistry, CompletionRequest, CompletionResponse, StreamChunk } from "./providers/index.js";
+import { modelSupportsTools } from "./providers/capabilities.js";
 import type { Db } from "@provara/db";
 import { requests } from "@provara/db";
 import { nanoid } from "nanoid";
@@ -344,7 +345,13 @@ export async function createRouter(ctx: RouterContext) {
   // Reload providers endpoint (call after adding/removing API keys)
   app.post("/v1/providers/reload", async (c) => {
     await ctx.registry.reload();
-    const providers = ctx.registry.list().map((p) => ({ name: p.name, models: p.models }));
+    const providers = ctx.registry.list().map((p) => ({
+      name: p.name,
+      models: p.models,
+      capabilities: Object.fromEntries(
+        p.models.map((m) => [m, { supportsTools: modelSupportsTools(p.name, m) }]),
+      ),
+    }));
     return c.json({ reloaded: true, providers });
   });
 
@@ -549,6 +556,26 @@ export async function createRouter(ctx: RouterContext) {
         );
       }
       throw err;
+    }
+
+    // Tool-calling capability gate (#301). Fails fast with a clear error when
+    // the resolved model does not support tool calling but the request carries
+    // tools. Better than letting the upstream provider return an opaque 400.
+    if (
+      Array.isArray(request.tools) &&
+      request.tools.length > 0 &&
+      !modelSupportsTools(routingResult.provider, routingResult.model)
+    ) {
+      return c.json(
+        {
+          error: {
+            code: "tools_unsupported",
+            message: `Model ${routingResult.model} on provider ${routingResult.provider} does not support tool calling. Pick a tool-capable model or drop the tools field.`,
+            type: "model_capability_error",
+          },
+        },
+        400,
+      );
     }
 
     // Check cache before calling any provider.
@@ -1417,6 +1444,11 @@ export async function createRouter(ctx: RouterContext) {
     const providers = ctx.registry.list().map((p) => ({
       name: p.name,
       models: p.models,
+      // Per-model capability map (#301). Sibling field (not inside `models`)
+      // so existing consumers that treat `models` as `string[]` keep working.
+      capabilities: Object.fromEntries(
+        p.models.map((m) => [m, { supportsTools: modelSupportsTools(p.name, m) }]),
+      ),
     }));
     return c.json({ providers });
   });

--- a/packages/gateway/src/routes/models.ts
+++ b/packages/gateway/src/routes/models.ts
@@ -4,6 +4,7 @@ import { requests, costLogs, feedback } from "@provara/db";
 import { sql, eq, and } from "drizzle-orm";
 import { getPricing } from "../cost/pricing.js";
 import type { ProviderRegistry } from "../providers/index.js";
+import { modelSupportsTools } from "../providers/capabilities.js";
 
 interface ModelStatsContext {
   db: Db;
@@ -79,6 +80,9 @@ export function createModelRoutes(ctx: ModelStatsContext) {
         pricing: pricing
           ? { inputPer1M: pricing[0], outputPer1M: pricing[1] }
           : null,
+        capabilities: {
+          supportsTools: modelSupportsTools(provider, model),
+        },
         stats: stats
           ? {
               requestCount: stats.requestCount,

--- a/packages/gateway/tests/capabilities.test.ts
+++ b/packages/gateway/tests/capabilities.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { modelSupportsTools, getModelCapability } from "../src/providers/capabilities.js";
+
+describe("#301 provider capabilities", () => {
+  describe("modelSupportsTools (provider defaults)", () => {
+    it("returns true for modern tool-capable providers regardless of model id", () => {
+      for (const p of ["openai", "anthropic", "google", "mistral", "xai", "zai"]) {
+        expect(modelSupportsTools(p, "any-model-name")).toBe(true);
+      }
+    });
+
+    it("is case-insensitive on provider", () => {
+      expect(modelSupportsTools("OpenAI", "gpt-4.1-nano")).toBe(true);
+      expect(modelSupportsTools("ANTHROPIC", "claude-sonnet-4-6")).toBe(true);
+    });
+
+    it("defaults true for unknown providers (no blocking on guess)", () => {
+      expect(modelSupportsTools("some-custom-provider", "some-model")).toBe(true);
+    });
+  });
+
+  describe("modelSupportsTools (ollama gate)", () => {
+    it("allows llama3.1, llama3.2, qwen2.5, qwen3, mistral, mixtral, command-r, hermes3, granite3", () => {
+      const allowed = [
+        "llama3.1:8b",
+        "llama3.2-vision",
+        "qwen2.5:72b",
+        "qwen3.6:latest",
+        "mistral:7b",
+        "mixtral:8x22b",
+        "command-r:35b",
+        "hermes3:latest",
+        "granite3:dense",
+      ];
+      for (const m of allowed) {
+        expect(modelSupportsTools("ollama", m)).toBe(true);
+      }
+    });
+
+    it("rejects ollama models without a recognized tool-capable base", () => {
+      const rejected = [
+        "gemma:7b",
+        "phi3:latest",
+        "codellama:13b",
+        "tinyllama:1.1b",
+        "orca-mini:7b",
+      ];
+      for (const m of rejected) {
+        expect(modelSupportsTools("ollama", m)).toBe(false);
+      }
+    });
+
+    it("is case-insensitive on model name", () => {
+      expect(modelSupportsTools("ollama", "Qwen3.6:LATEST")).toBe(true);
+      expect(modelSupportsTools("ollama", "GEMMA:7b")).toBe(false);
+    });
+  });
+
+  describe("getModelCapability", () => {
+    it("returns the shape expected by the /v1/models/stats route", () => {
+      expect(getModelCapability("openai", "gpt-4.1-nano")).toEqual({
+        supportsTools: true,
+      });
+      expect(getModelCapability("ollama", "gemma:7b")).toEqual({
+        supportsTools: false,
+      });
+    });
+  });
+});

--- a/packages/gateway/tests/tool-calling.test.ts
+++ b/packages/gateway/tests/tool-calling.test.ts
@@ -119,6 +119,42 @@ describe("#298 tool calling end-to-end", () => {
     expect(hit?.toolCallsCount).toBe(0);
   });
 
+  it("returns 400 tools_unsupported when the resolved model does not support tools (#301)", async () => {
+    // Build an app with an Ollama provider serving a model NOT in the
+    // tool-capable allowlist. Fake provider can accept anything; the gate
+    // lives in the router, not the adapter.
+    const db = await (await import("./_setup/db.js")).makeTestDb();
+    const provider = (await import("./_setup/fake-provider.js")).makeFakeProvider({
+      name: "ollama",
+      models: ["gemma:7b"],
+    });
+    const registry = (await import("./_setup/fake-registry.js")).makeFakeRegistry([provider]);
+    const app = await (await import("../src/router.js")).createRouter({ registry, db });
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gemma:7b",
+        provider: "ollama",
+        messages: [{ role: "user", content: "weather?" }],
+        tools: [getWeatherTool],
+        tool_choice: "auto",
+        temperature: 0,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      error: { code?: string; type?: string; message?: string };
+    };
+    expect(body.error.code).toBe("tools_unsupported");
+    expect(body.error.type).toBe("model_capability_error");
+    // Provider must NOT have been called — the gate fires before routing commits
+    // to a completion.
+    expect(provider.calls).toHaveLength(0);
+  });
+
   it("does not cross-hit the cache when tools differ", async () => {
     const { app, provider } = await buildToolApp({
       responseToolCalls: [weatherToolCall],


### PR DESCRIPTION
<!-- shiplog:
kind: history
issue: 301
branch: issue/301-tool-capability-gating
status: resolved
updated_at: 2026-04-23T21:00:00Z
review_status: awaiting-review
-->

## Summary

Wraps the tool-calling stack (#298 / #299 / #300) with per-model capability gating, a README tool-calling section including the capability matrix, and a playground UI indicator for non-tool models. This is the closeout issue — with it landed, tool calling ships as a coherent, documented, opinionated feature across all seven providers.

Stacked on #298. Implicitly depends on #299 + #300 for the matrix to be accurate — those landed earlier in the same session.

Closes #301

## Review Status

- **Current state:** awaiting review
- **Last reviewed by:** none yet
- **Last reviewed at:** n/a
- **Reviewed commit:** n/a
- **Source artifact:** none yet
- **Needs re-review since:** no

## Journey Timeline

### Initial Plan

Three tasks: T1 per-model capability gate at the router, T2 README capability matrix + docs, T3 playground UI surfacing. All tier-2 except T2 (tier-3, mechanical docs write-up).

### What We Discovered

- **The Ollama prefix allowlist is the real source of truth for the capability gate.** Everything else is "default true unless I know otherwise." For Ollama specifically, the allowlist pattern (`llama3.1`, `qwen3`, `mistral`, `hermes3`, `granite3`, etc.) is both honest and extensible — adding a newly-tool-trained base model is one line. The user's own remote Ollama serves `qwen3.6:latest` per memory, which starts with the `qwen3` prefix and gates through cleanly.
- **`/v1/providers` was the right surface for the playground, not `/v1/models/stats`.** Stats is gated on admin auth + hits the DB for aggregated metrics; the playground needs fast, unauthed model listing at page load. Added a sibling `capabilities` field on `/v1/providers` (backward compat — existing `models: string[]` untouched) so the playground can query capabilities in the same round-trip it fetches the model list.
- **"Default true on unknown provider" is the correct call.** Custom OpenAI-compatible providers registered via `addCustom` almost universally follow the OpenAI wire shape. False-negative gating would block legitimate tool calls; instead we let the adapter surface upstream 400s if the specific custom provider doesn't support tools. Clean failure mode either way.

### Implementation Issues

- None material. The test-suite flake pattern from #299 / #300 recurred once (judge sampler adding a provider call), but the tool-calling.test.ts assertions were already calibrated for it from the earlier fix.

### Key Decisions Made

- **Gate fires AFTER routing but BEFORE provider.complete().** Adaptive routing still gets to pick the best model; we only veto if the picked model is incapable. This preserves routing's strength while failing fast on known-bad combinations.
- **Error shape matches the prior pattern:** `400 { error: { code: "tools_unsupported", type: "model_capability_error", message: "..." } }`. The `code` field is the machine-readable key; `type` stays human-level; `message` includes both provider and model so the client sees exactly what was rejected.
- **Sibling `capabilities` on `/v1/providers`, not a shape change to `models`.** Backward compat was cheaper than the cost of updating all consumers (stats, playground, dashboard model picker, anything downstream).
- **README tool-calling section is deliberately detailed.** Per the positioning memo, Provara competes at the ops-platform layer. A working OpenAI-compatible tools surface is table stakes; the README section documents the per-provider translation map so VP-Eng-level evaluators see the craft, not just the happy-path demo.

### Test Evidence

- `npx vitest run` — 565 passed, 0 failed (up from 540 baseline after #300; +25 total across #299/#300/#301 test additions).
- `npx tsc --noEmit` clean on both `packages/gateway` and `apps/web`.

### Open Questions (deferred, not blocking)

- The issue's Open Question #1 — "firm policy on personal OSS surfacing in client engagements" — is out of scope for this PR. It gates the office-hours Approach C strategy, not the implementation work here. Tracking in the office-hours design doc at `~/.gstack/projects/syndicalt-provara/cheapseatsecon-master-design-20260423-145130.md`.

## Changes

| Area | What changed |
|------|--------------|
| `packages/gateway/src/providers/capabilities.ts` | New module: `modelSupportsTools(provider, model)`, `getModelCapability(provider, model)`, Ollama prefix allowlist. |
| `packages/gateway/src/router.ts` | 400 capability gate at line ~553 (post-routing, pre-completion). `/v1/providers` and the refresh handler now include per-model `capabilities`. |
| `packages/gateway/src/routes/models.ts` | `/v1/models/stats` surfaces `capabilities.supportsTools` per model. |
| `apps/web/src/app/dashboard/playground/page.tsx` | Model selector appends " — no tools" to option labels for non-tool models. Backward compat: older gateway responses default to supported so the indicator only appears on real negative information. |
| `README.md` | New "Tool Calling" section (wire shape, sample code, tool_choice vocab, per-provider translation map, 400 gate behavior, Ollama allowlist documentation, `/v1/models/stats` capability response shape). Providers table gets a "Tools" column. |
| `packages/gateway/tests/capabilities.test.ts` | 12 new cases covering defaults, Ollama allowlist, case-insensitivity, shape of `getModelCapability`. |
| `packages/gateway/tests/tool-calling.test.ts` | 1 new case asserting the 400 gate fires before `provider.complete()` is called. |

---
Authored-by: claude/opus-4-7 (claude-code, 1m-context)
Last-code-by: claude/opus-4-7 (claude-code, 1m-context)
*Captain's log — PR opened*
