### PR TITLE
fix(#309): show Probe for all eligible lonely-low cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Profiles can be set per API token (via `/v1/admin/tokens`) so a production workl
 
 Some cells of the matrix end up with a single scored model that's just *bad* — a 1.8 sitting alone at the top of a column with no challenger to dethrone it. Provara surfaces these on the dashboard with a red border and a one-click **Probe** button that spawns a 50/50 A/B test against a capability-matched challenger. The picker prefers a different provider family and excludes models already scored in the cell, so the probe gathers genuinely new signal. Available on every tier — uses the standard A/B-test infrastructure, not the auto-A/B scheduler.
 
+The button surfaces as soon as the cell has ≥ `PROVARA_LOW_SCORE_MIN_SAMPLES` (default `2`) samples on its incumbent — a deliberately lower bar than the routing-time `MIN_SAMPLES` floor (default `5`). A human reviewing the matrix can apply judgment that the router can't, and Probe is reversible; routing-time decisions can't be.
+
 For Pro+ tenants, the same detection wires into the routing path itself: when a request lands in a cell whose incumbent is at or below `PROVARA_LOW_SCORE_THRESHOLD` (default `2.5`), the ε-greedy exploration rate jumps from the base 10% to `PROVARA_LOW_SCORE_EXPLORATION_RATE` (default 50%). Free traffic stays on the base rate, so this is a paid-tier differentiator.
 
 ## Silent-Regression Detection

--- a/apps/web/src/components/adaptive-heatmap.tsx
+++ b/apps/web/src/components/adaptive-heatmap.tsx
@@ -222,24 +222,27 @@ export function AdaptiveHeatmap({
                         : "border-zinc-800"
                   }`}
                 >
-                  {hasAutoAb && (
-                    <span className="absolute top-1 right-1 z-20 text-[10px] px-1 py-0.5 rounded bg-indigo-900/70 text-indigo-200 font-medium pointer-events-none">
-                      A/B
-                    </span>
-                  )}
-                  {lowScore && !hasAutoAb && onSpawnChallenger && (
-                    <button
-                      type="button"
-                      disabled={isSpawning}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void onSpawnChallenger(tt, cx);
-                      }}
-                      className="absolute top-1 right-1 z-20 text-[10px] px-1.5 py-0.5 rounded bg-rose-900/80 hover:bg-rose-800 text-rose-100 font-medium transition-colors disabled:opacity-60 disabled:cursor-wait"
-                      title={`Spawn a 50/50 A/B test pitting ${lowScore.incumbent.model} against a fresh challenger.`}
-                    >
-                      {isSpawning ? "…" : "Probe"}
-                    </button>
+                  {(hasAutoAb || (lowScore && onSpawnChallenger)) && (
+                    <div className="mb-1 flex justify-end">
+                      {hasAutoAb ? (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-indigo-900/70 text-indigo-200 font-medium pointer-events-none">
+                          A/B
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled={isSpawning}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            void onSpawnChallenger?.(tt, cx);
+                          }}
+                          className="text-[10px] px-1.5 py-0.5 rounded bg-rose-900/80 hover:bg-rose-800 text-rose-100 font-medium transition-colors disabled:opacity-60 disabled:cursor-wait"
+                          title={`Spawn a 50/50 A/B test pitting ${lowScore!.incumbent.model} against a fresh challenger.`}
+                        >
+                          {isSpawning ? "..." : "Probe"}
+                        </button>
+                      )}
+                    </div>
                   )}
                   {scores.length === 0 ? (
                     <div className="h-full flex items-center justify-center text-xs text-zinc-600">

--- a/packages/gateway/src/routing/adaptive/challenger.ts
+++ b/packages/gateway/src/routing/adaptive/challenger.ts
@@ -63,10 +63,9 @@ export interface LowScoreCell {
 }
 
 /**
- * Find cells whose top-scoring model is at or below
- * `LOW_SCORE_THRESHOLD` and is the only candidate with at least
- * `LOW_SCORE_MIN_SAMPLES_FOR_PROBE` samples. Result is sorted by
- * qualityScore ascending so the worst cells surface first.
+ * Find cells with exactly one sufficiently-sampled model at or below
+ * `LOW_SCORE_THRESHOLD`. Result is sorted by qualityScore ascending so
+ * the worst cells surface first.
  *
  * The probe-floor (2 samples by default) is intentionally lower than
  * `MIN_SAMPLES` (5, the bar for hot-path adaptive routing). A user
@@ -106,15 +105,14 @@ export async function findLowScoringCells(
   for (const [, cellRows] of byCell) {
     const eligible = cellRows.filter((r) => r.sampleCount >= minSamples);
     if (eligible.length === 0) continue;
-    const sorted = [...eligible].sort((a, b) => b.qualityScore - a.qualityScore);
-    const top = sorted[0];
-    if (top.qualityScore > threshold) continue;
-    // Lonely-loser semantics: only flag when there is no second
-    // eligible model that could already serve as a credible challenger.
-    // If two models both clear the floor and both score low, the
-    // existing `findTieCells` path (or the user) can pit them against
-    // each other directly; we don't need to dilute the signal here.
-    if (eligible.length > 1) continue;
+    // Lonely-loser semantics: flag a cell when exactly one model has
+    // enough samples and still scores low. The cell may also contain
+    // healthier scored models; those are not the problem this probe is
+    // trying to fix. If multiple eligible models are low, a manual A/B
+    // test is clearer than picking one loser implicitly.
+    const lowEligible = eligible.filter((r) => r.qualityScore <= threshold);
+    if (lowEligible.length !== 1) continue;
+    const top = lowEligible[0];
     out.push({
       taskType: top.taskType,
       complexity: top.complexity,

--- a/packages/gateway/src/routing/adaptive/challenger.ts
+++ b/packages/gateway/src/routing/adaptive/challenger.ts
@@ -3,7 +3,6 @@ import { modelScores, abTests, abTestVariants } from "@provara/db";
 import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { isVisionCapable } from "../model-capabilities.js";
-import { MIN_SAMPLES } from "./scoring.js";
 import { POOL_KEY } from "./score-store.js";
 import type { RouteTarget } from "../types.js";
 
@@ -25,6 +24,31 @@ function numEnv(v: string | undefined, fallback: number): number {
  */
 export const LOW_SCORE_THRESHOLD = numEnv(process.env.PROVARA_LOW_SCORE_THRESHOLD, 2.5);
 
+/**
+ * Sample-count floor for the manual "Probe" button (Track 3).
+ *
+ * Decoupled from `MIN_SAMPLES` — the floor that gates *automatic*
+ * adaptive routing — because the use cases differ:
+ *
+ *   - `MIN_SAMPLES` (5 default) is a hot-path stability bar. The
+ *     adaptive router won't route based on a cell's EMA until it has
+ *     enough samples to trust the score isn't noise. Same logic
+ *     applies to Track 2's auto exploration boost — every request
+ *     hits that path, so a flaky boost on a 1-sample fluke would burn
+ *     traffic.
+ *   - `LOW_SCORE_MIN_SAMPLES_FOR_PROBE` (2 default) is a UI floor. A
+ *     human reviewing the matrix can apply judgment that the router
+ *     can't, and clicking Probe is reversible — it just spawns an A/B
+ *     test that gathers more samples. We want the button to surface
+ *     as soon as the score is *plausibly* low, not only after the
+ *     stricter routing threshold is met. Two samples is enough to
+ *     rule out a single-call fluke; below that we still skip.
+ */
+export const LOW_SCORE_MIN_SAMPLES_FOR_PROBE = Math.max(
+  1,
+  Math.floor(numEnv(process.env.PROVARA_LOW_SCORE_MIN_SAMPLES, 2)),
+);
+
 export interface LowScoreCell {
   taskType: string;
   complexity: string;
@@ -39,22 +63,29 @@ export interface LowScoreCell {
 }
 
 /**
- * Find cells whose top-scoring model is below `LOW_SCORE_THRESHOLD` and
- * is the only sufficiently-sampled candidate. The bar for "sufficiently
- * sampled" is `MIN_SAMPLES` — under that we can't trust the low score
- * isn't just noise. Result is sorted by qualityScore ascending so the
- * worst cells surface first.
+ * Find cells whose top-scoring model is at or below
+ * `LOW_SCORE_THRESHOLD` and is the only candidate with at least
+ * `LOW_SCORE_MIN_SAMPLES_FOR_PROBE` samples. Result is sorted by
+ * qualityScore ascending so the worst cells surface first.
  *
- * Tenant scope: this scans the pool (`tenantKey IS NULL`) by default —
- * the matching UI lives on the dashboard's pooled view. A future per-
- * tenant variant can pass `options.tenantKey` once tenant-scoped
+ * The probe-floor (2 samples by default) is intentionally lower than
+ * `MIN_SAMPLES` (5, the bar for hot-path adaptive routing). A user
+ * reviewing the dashboard can act on early signal — the Probe button
+ * spawns an A/B test, which is reversible and gathers more samples —
+ * while the routing-time auto-boost (Track 2 in `router.ts`) sticks
+ * with the stricter `MIN_SAMPLES` floor.
+ *
+ * Tenant scope: this scans the pool (`tenantId = POOL_KEY`) by default
+ * — the matching UI lives on the dashboard's pooled view. A future
+ * per-tenant variant can pass `options.tenantId` once tenant-scoped
  * dashboards exist.
  */
 export async function findLowScoringCells(
   db: Db,
-  options: { threshold?: number; tenantId?: string | null } = {},
+  options: { threshold?: number; minSamples?: number; tenantId?: string | null } = {},
 ): Promise<LowScoreCell[]> {
   const threshold = options.threshold ?? LOW_SCORE_THRESHOLD;
+  const minSamples = options.minSamples ?? LOW_SCORE_MIN_SAMPLES_FOR_PROBE;
   const tenantId = options.tenantId ?? POOL_KEY;
 
   const rows = await db
@@ -73,16 +104,16 @@ export async function findLowScoringCells(
 
   const out: LowScoreCell[] = [];
   for (const [, cellRows] of byCell) {
-    const eligible = cellRows.filter((r) => r.sampleCount >= MIN_SAMPLES);
+    const eligible = cellRows.filter((r) => r.sampleCount >= minSamples);
     if (eligible.length === 0) continue;
     const sorted = [...eligible].sort((a, b) => b.qualityScore - a.qualityScore);
     const top = sorted[0];
     if (top.qualityScore > threshold) continue;
-    // Lonely-loser semantics: only flag when there is no second eligible
-    // model that could already serve as a credible challenger. If two
-    // models are both above MIN_SAMPLES and both low, the existing
-    // `findTieCells` path (or the user) can already pit them against
-    // each other; we don't need to dilute the signal here.
+    // Lonely-loser semantics: only flag when there is no second
+    // eligible model that could already serve as a credible challenger.
+    // If two models both clear the floor and both score low, the
+    // existing `findTieCells` path (or the user) can pit them against
+    // each other directly; we don't need to dilute the signal here.
     if (eligible.length > 1) continue;
     out.push({
       taskType: top.taskType,

--- a/packages/gateway/tests/adaptive-admin-routes.test.ts
+++ b/packages/gateway/tests/adaptive-admin-routes.test.ts
@@ -194,7 +194,7 @@ describe("POST /v1/admin/adaptive/spawn-challenger", () => {
     await seedScore(db, "summarization", "simple", "openai", "gpt-4.1-nano", 1.8);
     // Add a previously-scored google model — it should not be picked
     // even though google is a different family.
-    await seedScore(db, "summarization", "simple", "google", "gemini-2.0-flash", 4.0, 2); // below MIN_SAMPLES so cell is still lonely
+    await seedScore(db, "summarization", "simple", "google", "gemini-2.0-flash", 4.0, 1); // 1 sample is below the probe floor — cell is still lonely
     const registry = makeRegistry([
       makeProvider("openai", ["gpt-4.1-nano"]),
       makeProvider("google", ["gemini-2.0-flash", "gemini-2.5-flash"]),

--- a/packages/gateway/tests/adaptive-admin-routes.test.ts
+++ b/packages/gateway/tests/adaptive-admin-routes.test.ts
@@ -95,6 +95,25 @@ describe("GET /v1/admin/adaptive/low-score-cells", () => {
     const body = await res.json();
     expect(body.cells).toEqual([]);
   });
+
+  it("returns cells with one low model even when other sampled models are healthy", async () => {
+    await seedScore(db, "coding", "complex", "anthropic", "claude-opus-4-6", 5.0);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4.1-mini", 4.7);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4.1-nano", 1.5);
+
+    const registry = makeRegistry([
+      makeProvider("anthropic", ["claude-opus-4-6"]),
+      makeProvider("openai", ["gpt-4.1-mini", "gpt-4.1-nano"]),
+    ]);
+    const app = buildApp(db, registry);
+    const res = await app.request("/v1/admin/adaptive/low-score-cells");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cells).toHaveLength(1);
+    expect(body.cells[0].taskType).toBe("coding");
+    expect(body.cells[0].complexity).toBe("complex");
+    expect(body.cells[0].incumbent.model).toBe("gpt-4.1-nano");
+  });
 });
 
 describe("POST /v1/admin/adaptive/spawn-challenger", () => {

--- a/packages/gateway/tests/challenger.test.ts
+++ b/packages/gateway/tests/challenger.test.ts
@@ -5,6 +5,7 @@ import type { Db } from "@provara/db";
 import { makeTestDb } from "./_setup/db.js";
 import {
   LOW_SCORE_THRESHOLD,
+  LOW_SCORE_MIN_SAMPLES_FOR_PROBE,
   findLowScoringCells,
   pickChallenger,
   spawnChallengerTest,
@@ -57,13 +58,39 @@ describe("findLowScoringCells", () => {
     expect(cells[0].incumbent.qualityScore).toBeCloseTo(1.8);
   });
 
-  it("ignores cells where the only model is below MIN_SAMPLES", async () => {
+  it("ignores cells where the only model is below the probe-sample floor", async () => {
     const db = await makeTestDb();
-    // Low score, but not enough samples to trust it.
+    // 1 sample is below LOW_SCORE_MIN_SAMPLES_FOR_PROBE (default 2)
+    // — too few to rule out a fluke.
     await seedScore(db, "vision", "simple", "openai", "gpt-4.1-mini", 1.0, 1);
 
     const cells = await findLowScoringCells(db);
     expect(cells).toHaveLength(0);
+  });
+
+  it("flags cells whose only model has at least the probe-sample floor (below MIN_SAMPLES is ok)", async () => {
+    const db = await makeTestDb();
+    // 2 samples — meets the probe floor (default 2) but stays below
+    // MIN_SAMPLES (default 5). The dashboard's manual button should
+    // surface, even though Track 2 auto exploration would not boost
+    // this cell yet.
+    expect(LOW_SCORE_MIN_SAMPLES_FOR_PROBE).toBeLessThan(MIN_SAMPLES);
+    await seedScore(db, "vision", "complex", "openai", "gpt-4.1-mini", 1.5, 2);
+
+    const cells = await findLowScoringCells(db);
+    expect(cells).toHaveLength(1);
+    expect(cells[0].taskType).toBe("vision");
+    expect(cells[0].incumbent.sampleCount).toBe(2);
+  });
+
+  it("respects an explicit minSamples override", async () => {
+    const db = await makeTestDb();
+    await seedScore(db, "vision", "simple", "openai", "gpt-4.1-mini", 1.5, 3);
+
+    const strict = await findLowScoringCells(db, { minSamples: 5 });
+    expect(strict).toHaveLength(0);
+    const relaxed = await findLowScoringCells(db, { minSamples: 1 });
+    expect(relaxed).toHaveLength(1);
   });
 
   it("respects the threshold option override", async () => {

--- a/packages/gateway/tests/challenger.test.ts
+++ b/packages/gateway/tests/challenger.test.ts
@@ -40,7 +40,7 @@ async function seedScore(
 }
 
 describe("findLowScoringCells", () => {
-  it("flags lonely-low cells with a single sufficiently-sampled model", async () => {
+  it("flags lonely-low cells with a single sufficiently-sampled low model", async () => {
     const db = await makeTestDb();
     // Lonely-low candidate: one model below threshold, well-sampled.
     await seedScore(db, "summarization", "simple", "openai", "gpt-4.1-nano", 1.8);
@@ -56,6 +56,19 @@ describe("findLowScoringCells", () => {
     expect(cells[0].taskType).toBe("summarization");
     expect(cells[0].incumbent.model).toBe("gpt-4.1-nano");
     expect(cells[0].incumbent.qualityScore).toBeCloseTo(1.8);
+  });
+
+  it("flags a single low model even when the cell has healthy sampled models", async () => {
+    const db = await makeTestDb();
+    await seedScore(db, "coding", "complex", "anthropic", "claude-opus-4-6", 5.0);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4.1-mini", 4.7);
+    await seedScore(db, "coding", "complex", "openai", "gpt-4.1-nano", 1.5);
+
+    const cells = await findLowScoringCells(db);
+    expect(cells).toHaveLength(1);
+    expect(cells[0].taskType).toBe("coding");
+    expect(cells[0].complexity).toBe("complex");
+    expect(cells[0].incumbent.model).toBe("gpt-4.1-nano");
   });
 
   it("ignores cells where the only model is below the probe-sample floor", async () => {


### PR DESCRIPTION
<!-- shiplog: status=resolved; issue=309; branch=fix/probe-min-samples -->

## Summary

Closes #309.

This PR fixes the Adaptive Routing Probe UAT issue in two steps:

- Keeps the earlier sparse-cell fix: the manual Probe detector uses `LOW_SCORE_MIN_SAMPLES_FOR_PROBE` (default 2) instead of the routing hot-path `MIN_SAMPLES` floor.
- Fixes the UAT-visible gap: cells are eligible when exactly one sufficiently sampled model is low-scoring, even if other sampled models in the same cell are healthy.
- Moves the Probe and A/B controls into normal heatmap layout so they no longer cover the score strip.

## Review Status

User requested commit, PR, and merge in this session. Merge will proceed under that explicit direction after checks are green.

## Journey Timeline

- UAT screenshot showed Probe only on one quadrant while other cells had single low-scoring outliers.
- Root cause: `findLowScoringCells` evaluated the top eligible model as the cell verdict, so any healthy peer suppressed the Probe action.
- UI issue: Probe was absolutely positioned over the top strip and could obscure the score.

## Changes

- `packages/gateway/src/routing/adaptive/challenger.ts`: detect exactly one sufficiently sampled low model per cell.
- `apps/web/src/components/adaptive-heatmap.tsx`: render Probe/A-B controls above strips instead of overlaying them.
- Gateway tests cover healthy-peer cells and the admin endpoint response.

## Testing / Verification

- [x] `npm test -w packages/gateway -- challenger.test.ts adaptive-admin-routes.test.ts`
- [x] `npx tsc --noEmit` in `apps/web`
- [x] `npx tsc --noEmit -p packages/gateway`

## Knowledge for Future Reference

Manual Probe eligibility is intentionally looser than automatic routing decisions because it creates a reversible A/B test rather than changing production routing immediately.

Authored-by: GPT-5 (Codex)
Last-code-by: GPT-5 (Codex)
