### PR TITLE
Add fallback for model refusals

### DIFF
--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -104,6 +104,18 @@ function logProviderErrorStack(err: unknown, label: string): void {
   console.warn(`[provider-error-stack ${label}]\n${redactSecrets(chain.join("\n--- caused by ---\n"))}`);
 }
 
+function isRetryableModelRefusal(response: Pick<CompletionResponse, "finish_reason">): boolean {
+  return response.finish_reason === "content_filter";
+}
+
+function isRetryableStreamRefusal(chunk: StreamChunk): boolean {
+  return chunk.done && chunk.finish_reason === "content_filter";
+}
+
+function describeModelRefusal(finishReason: string | undefined): string {
+  return `Model refused with finish_reason=${finishReason ?? "unknown"}`;
+}
+
 function describeProviderError(err: unknown): string {
   if (!(err instanceof Error)) return redactSecrets(String(err));
   const parts: string[] = [];
@@ -1006,7 +1018,8 @@ export async function createRouter(ctx: RouterContext) {
       let usedFallback = routingResult.usedFallback;
       let lastError: unknown;
 
-      for (const attempt of attempts) {
+      for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+        const attempt = attempts[attemptIndex];
         if (failedProviders.has(attempt.provider)) continue;
         const provider = ctx.registry.get(attempt.provider);
         if (!provider) continue;
@@ -1024,6 +1037,14 @@ export async function createRouter(ctx: RouterContext) {
             ),
           ]);
 
+          const firstChunkRefused = !first.done && isRetryableStreamRefusal(first.value);
+          if (firstChunkRefused && attemptIndex < attempts.length - 1) {
+            const msg = describeModelRefusal(first.value.finish_reason);
+            attemptErrors.push({ provider: attempt.provider, model: attempt.model, error: msg });
+            console.warn(`Provider ${attempt.provider}/${attempt.model} refused:`, msg);
+            continue;
+          }
+
           if (first.done) continue;
 
           usedProvider = attempt.provider;
@@ -1038,9 +1059,14 @@ export async function createRouter(ctx: RouterContext) {
               let fullContent = "";
               let usage = { inputTokens: 0, outputTokens: 0 };
 
-              const emitChunk = (chunk: { content: string; done: boolean; usage?: { inputTokens: number; outputTokens: number } }) => {
+              const emitChunk = (chunk: StreamChunk) => {
                 fullContent += chunk.content;
                 if (chunk.usage) usage = chunk.usage;
+                const sseDelta: Record<string, unknown> = chunk.done ? {} : {};
+                if (!chunk.done && chunk.content) sseDelta.content = chunk.content;
+                if (chunk.tool_calls && chunk.tool_calls.length > 0) {
+                  sseDelta.tool_calls = chunk.tool_calls;
+                }
                 const sseData = JSON.stringify({
                   id: `chatcmpl-${requestId}`,
                   object: "chat.completion.chunk",
@@ -1048,8 +1074,8 @@ export async function createRouter(ctx: RouterContext) {
                   model: usedModel,
                   choices: [{
                     index: 0,
-                    delta: chunk.done ? {} : { content: chunk.content },
-                    finish_reason: chunk.done ? "stop" : null,
+                    delta: sseDelta,
+                    finish_reason: chunk.done ? chunk.finish_reason ?? "stop" : null,
                   }],
                 });
                 controller.enqueue(encoder.encode(`data: ${sseData}\n\n`));
@@ -1234,7 +1260,8 @@ export async function createRouter(ctx: RouterContext) {
     let lastError: unknown;
     let latencyMs = 0;
 
-    for (const attempt of attempts) {
+    for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+      const attempt = attempts[attemptIndex];
       if (failedProviders.has(attempt.provider)) continue;
       const provider = ctx.registry.get(attempt.provider);
       if (!provider) continue;
@@ -1247,6 +1274,12 @@ export async function createRouter(ctx: RouterContext) {
             setTimeout(() => reject(new Error(`Timed out after ${COMPLETION_TIMEOUT_MS}ms`)), COMPLETION_TIMEOUT_MS)
           ),
         ]);
+        if (isRetryableModelRefusal(result) && attemptIndex < attempts.length - 1) {
+          const msg = describeModelRefusal(result.finish_reason);
+          attemptErrors.push({ provider: attempt.provider, model: attempt.model, error: msg });
+          console.warn(`Provider ${attempt.provider}/${attempt.model} refused:`, msg);
+          continue;
+        }
         response = result;
         latencyMs = Math.round(performance.now() - start);
         usedProvider = attempt.provider;

--- a/packages/gateway/tests/_setup/fake-provider.ts
+++ b/packages/gateway/tests/_setup/fake-provider.ts
@@ -13,6 +13,8 @@ export interface FakeProviderOptions {
   failWith?: Error;
   /** Override the response content. Defaults to a canned reply. */
   responseContent?: string;
+  /** Override the terminal finish reason for complete() and stream(). */
+  finishReason?: CompletionResponse["finish_reason"];
   /** When set, the fake returns these tool_calls on complete() / streams
    *  an equivalent delta plus a `tool_calls` finish_reason on stream(). */
   responseToolCalls?: ToolCall[];
@@ -51,7 +53,7 @@ export function makeFakeProvider(opts: FakeProviderOptions): Provider & {
         tool_calls: opts.responseToolCalls,
         finish_reason: opts.responseToolCalls && opts.responseToolCalls.length > 0
           ? "tool_calls"
-          : "stop",
+          : opts.finishReason ?? "stop",
         usage: { inputTokens: 10, outputTokens: 15 },
         latencyMs: 5,
       };
@@ -79,8 +81,17 @@ export function makeFakeProvider(opts: FakeProviderOptions): Provider & {
         return;
       }
       const content = opts.responseContent ?? `fake reply from ${opts.name}/${request.model}`;
+      if (opts.finishReason === "content_filter") {
+        yield { content, done: true, finish_reason: "content_filter", usage: { inputTokens: 10, outputTokens: 15 } };
+        return;
+      }
       yield { content, done: false };
-      yield { content: "", done: true, usage: { inputTokens: 10, outputTokens: 15 } };
+      yield {
+        content: "",
+        done: true,
+        finish_reason: opts.finishReason,
+        usage: { inputTokens: 10, outputTokens: 15 },
+      };
     },
   };
 

--- a/packages/gateway/tests/refusal-fallback.test.ts
+++ b/packages/gateway/tests/refusal-fallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { requests } from "@provara/db";
+import { createRouter } from "../src/router.js";
+import { makeTestDb } from "./_setup/db.js";
+import { makeFakeProvider } from "./_setup/fake-provider.js";
+import { makeFakeRegistry } from "./_setup/fake-registry.js";
+
+async function buildRefusalFallbackApp() {
+  const db = await makeTestDb();
+  const primary = makeFakeProvider({
+    name: "openai",
+    models: ["gpt-4.1-nano"],
+    responseContent: "",
+    finishReason: "content_filter",
+  });
+  const fallback = makeFakeProvider({
+    name: "anthropic",
+    models: ["claude-haiku-4-5-20251001"],
+    responseContent: "fallback answer",
+  });
+  const registry = makeFakeRegistry([primary, fallback]);
+  const app = await createRouter({ registry, db });
+  return { app, db, primary, fallback };
+}
+
+describe("model refusal fallback", () => {
+  it("retries the fallback chain when a non-streaming model returns content_filter", async () => {
+    const { app, db, primary, fallback } = await buildRefusalFallbackApp();
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "",
+        messages: [{ role: "user", content: "answer this" }],
+        routing_hint: "general",
+        temperature: 0.7,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      choices: Array<{ message: { content: string }; finish_reason: string }>;
+      _provara: {
+        provider: string;
+        routing: { usedFallback: boolean };
+        errors?: Array<{ provider: string; model: string; error: string }>;
+      };
+    };
+
+    expect(body.choices[0].message.content).toBe("fallback answer");
+    expect(body.choices[0].finish_reason).toBe("stop");
+    expect(body._provara.provider).toBe("anthropic");
+    expect(body._provara.routing.usedFallback).toBe(true);
+    expect(body._provara.errors?.[0]).toMatchObject({
+      provider: "openai",
+      model: "gpt-4.1-nano",
+      error: "Model refused with finish_reason=content_filter",
+    });
+    expect(primary.calls.length).toBeGreaterThanOrEqual(1);
+    expect(fallback.calls.length).toBeGreaterThanOrEqual(1);
+
+    const rows = await db.select().from(requests).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].provider).toBe("anthropic");
+    expect(rows[0].usedFallback).toBe(true);
+    expect(rows[0].fallbackErrors).toContain("content_filter");
+  });
+
+  it("falls back before committing a stream when the first provider returns content_filter", async () => {
+    const { app, primary, fallback } = await buildRefusalFallbackApp();
+
+    const res = await app.request("/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "",
+        messages: [{ role: "user", content: "stream this" }],
+        routing_hint: "general",
+        stream: true,
+        temperature: 0.7,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Provara-Provider")).toBe("anthropic");
+    expect(res.headers.get("X-Provara-Errors")).toContain("content_filter");
+
+    const text = await res.text();
+    expect(text).toContain("fallback answer");
+    expect(text).toContain("data: [DONE]");
+    expect(primary.calls.length).toBeGreaterThanOrEqual(1);
+    expect(fallback.calls.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- retry fallback candidates when a provider returns finish_reason=content_filter
- preserve terminal finish_reason in non-pinned streaming responses
- add HTTP-level tests for non-streaming and streaming refusal fallback

## Verification
- npm test --workspace @provara/gateway -- tests/refusal-fallback.test.ts tests/tool-calling.test.ts
- npm run build --workspace @provara/gateway