### PR TITLE
feat(#311): add prompt injection firewall preset

### DIFF
--- a/apps/docs/content/docs/features/guardrails.mdx
+++ b/apps/docs/content/docs/features/guardrails.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guardrails
-description: PII detection, content policies, and custom regex rules with redact / flag / block actions.
+description: PII detection, prompt injection firewalling, content policies, and custom regex rules with redact / flag / block actions.
 ---
 
 Guardrails sit in the request path alongside the classifier and rate limiter. Rules are stored per-tenant; each rule can target input, output, or both.
@@ -8,9 +8,16 @@ Guardrails sit in the request path alongside the classifier and rate limiter. Ru
 ## Built-in detectors
 
 - **PII** — SSN, credit card, email, phone, IP address
+- **Prompt Injection Firewall** — signature-based checks for instruction override, system prompt extraction, role takeover, and delimiter injection attempts
 - **Content** — built-in policy presets
 - **Regex** — custom tenant-defined patterns
 - **Token limit** — refuse requests exceeding a max token count
+
+## Prompt Injection Firewall
+
+The Prompt Injection Firewall is an opt-in preset backed by built-in input rules. It blocks common jailbreak and prompt-leakage signatures before the request reaches provider routing.
+
+This first version is intentionally fast and deterministic: it uses signatures, not an LLM judge. It catches obvious attacks such as "ignore previous instructions", "show your system prompt", role takeover prompts, and fake system-message delimiters. Semantic detection for retrieved context, tool output, and tool-call alignment is planned as a higher-tier firewall mode.
 
 ## Actions
 

--- a/apps/web/src/app/dashboard/guardrails/page.tsx
+++ b/apps/web/src/app/dashboard/guardrails/page.tsx
@@ -34,7 +34,7 @@ const TYPE_LABELS: Record<string, string> = {
   content: "Content Policy",
   regex: "Custom Regex",
   token_limit: "Token Limit",
-  jailbreak: "Jailbreak Detection",
+  jailbreak: "Prompt Injection Firewall",
 };
 
 function AddRuleForm({ onCreated }: { onCreated: () => void }) {
@@ -188,6 +188,14 @@ export default function GuardrailsPage() {
     fetchData();
   }
 
+  async function configurePromptInjectionFirewall(enabled: boolean) {
+    await gatewayFetchRaw("/v1/admin/guardrails/presets/prompt-injection-firewall", {
+      method: "PATCH",
+      body: JSON.stringify({ enabled }),
+    });
+    fetchData();
+  }
+
   useEffect(() => { fetchData(); }, []);
 
   if (loading) {
@@ -200,16 +208,52 @@ export default function GuardrailsPage() {
 
   const builtInRules = rules.filter((r) => r.builtIn);
   const customRules = rules.filter((r) => !r.builtIn);
+  const firewallRules = builtInRules.filter((r) => r.type === "jailbreak");
+  const enabledFirewallRules = firewallRules.filter((r) => r.enabled).length;
+  const firewallEnabled = firewallRules.length > 0 && enabledFirewallRules === firewallRules.length;
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
       <div className="flex justify-between items-center">
         <div>
           <h1 className="text-2xl font-bold">Guardrails</h1>
-          <p className="text-sm text-zinc-400 mt-1">Input/output filtering for PII detection, content policies, and custom patterns.</p>
+          <p className="text-sm text-zinc-400 mt-1">Gateway enforcement for PII, content policies, prompt injection signatures, and custom patterns.</p>
         </div>
         <AddRuleForm onCreated={fetchData} />
       </div>
+
+      <section className="bg-zinc-900 border border-zinc-800 rounded-lg p-5">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold">Prompt Injection Firewall</h2>
+              <span className={`text-xs px-2 py-0.5 rounded border ${
+                firewallEnabled
+                  ? "bg-emerald-900/40 text-emerald-300 border-emerald-800/50"
+                  : enabledFirewallRules > 0
+                    ? "bg-amber-900/40 text-amber-300 border-amber-800/50"
+                    : "bg-zinc-800 text-zinc-500 border-zinc-700"
+              }`}>
+                {enabledFirewallRules}/{firewallRules.length} rules enabled
+              </span>
+            </div>
+            <p className="text-sm text-zinc-400 mt-1 max-w-2xl">
+              Blocks common instruction override, system prompt extraction, role takeover, and delimiter injection attempts before provider routing.
+            </p>
+          </div>
+          <button
+            onClick={() => configurePromptInjectionFirewall(!firewallEnabled)}
+            disabled={firewallRules.length === 0}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 ${
+              firewallEnabled
+                ? "bg-zinc-800 hover:bg-zinc-700 text-zinc-300"
+                : "bg-blue-600 hover:bg-blue-500 text-white"
+            }`}
+          >
+            {firewallEnabled ? "Disable Firewall" : "Enable Firewall"}
+          </button>
+        </div>
+      </section>
 
       {/* Built-in Rules */}
       <section>

--- a/packages/gateway/src/guardrails/patterns.ts
+++ b/packages/gateway/src/guardrails/patterns.ts
@@ -1,4 +1,6 @@
-// Built-in PII detection patterns + jailbreak/prompt-injection signatures.
+export const PROMPT_INJECTION_FIREWALL_TYPE = "jailbreak" as const;
+
+// Built-in PII detection patterns + prompt-injection firewall signatures.
 // All patterns compile with `gi` flags in engine.ts, so case-insensitivity is
 // free — patterns stay readable.
 export const BUILTIN_RULES = [
@@ -52,12 +54,13 @@ export const BUILTIN_RULES = [
     action: "block" as const,
   },
 
-  // Jailbreak / prompt-injection detection (#265). Disabled by default;
-  // tenants opt in from the dashboard once they understand the false-positive
-  // tradeoff. Input-side only — output-side detection is a separate problem.
+  // Prompt Injection Firewall (#311). Disabled by default; tenants opt in
+  // from the dashboard once they understand the false-positive tradeoff.
+  // Input-side only for the MVP — retrieved/tool-output scanning is tracked
+  // as follow-up work in the firewall roadmap.
   {
     name: "Jailbreak — instruction override",
-    type: "jailbreak" as const,
+    type: PROMPT_INJECTION_FIREWALL_TYPE,
     pattern:
       "\\b(?:ignore\\s+(?:all\\s+|your\\s+|previous\\s+|prior\\s+|earlier\\s+|the\\s+)*(?:instructions?|prompts?|rules?|system\\s+prompts?)|forget\\s+(?:everything|all)\\s+(?:above|before)|disregard\\s+(?:the\\s+|your\\s+|previous\\s+)?(?:instructions?|rules?))\\b",
     target: "input" as const,
@@ -65,7 +68,7 @@ export const BUILTIN_RULES = [
   },
   {
     name: "Jailbreak — system prompt extraction",
-    type: "jailbreak" as const,
+    type: PROMPT_INJECTION_FIREWALL_TYPE,
     pattern:
       "\\b(?:reveal|show|print|output|repeat|display)\\s+(?:me\\s+)?(?:your|the)\\s+(?:system\\s+prompt|initial\\s+prompt|instructions?|rules?|guidelines?|original\\s+prompt)\\b",
     target: "input" as const,
@@ -73,7 +76,7 @@ export const BUILTIN_RULES = [
   },
   {
     name: "Jailbreak — role reversal / mode switch",
-    type: "jailbreak" as const,
+    type: PROMPT_INJECTION_FIREWALL_TYPE,
     pattern:
       "\\b(?:you\\s+are\\s+now\\s+(?:DAN|DUDE|STAN|Do\\s+Anything\\s+Now|Developer\\s+Mode|Admin\\s+Mode|Jailbroken)|pretend\\s+(?:you\\s+are|to\\s+be)\\s+(?:an?\\s+|the\\s+)?(?:unrestricted|uncensored|unfiltered|jailbroken|unlocked)|enable\\s+(?:developer|debug|admin|god|sudo)\\s+mode)\\b",
     target: "input" as const,
@@ -81,7 +84,7 @@ export const BUILTIN_RULES = [
   },
   {
     name: "Jailbreak — delimiter injection",
-    type: "jailbreak" as const,
+    type: PROMPT_INJECTION_FIREWALL_TYPE,
     pattern:
       "(?:#{2,}\\s*(?:new\\s+instructions?|end\\s+of\\s+system|override|system\\s+prompt)|</(?:system|instructions?)>|\\[\\s*SYSTEM\\s*\\]|\\n\\s*SYSTEM\\s*:)",
     target: "input" as const,

--- a/packages/gateway/src/routes/guardrails.ts
+++ b/packages/gateway/src/routes/guardrails.ts
@@ -5,6 +5,7 @@ import { eq, and, desc, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getTenantId, tenantFilter } from "../auth/tenant.js";
 import { ensureBuiltInRules } from "../guardrails/engine.js";
+import { PROMPT_INJECTION_FIREWALL_TYPE } from "../guardrails/patterns.js";
 
 export function createGuardrailRoutes(db: Db) {
   const app = new Hono();
@@ -60,6 +61,64 @@ export function createGuardrailRoutes(db: Db) {
 
     const rule = await db.select().from(guardrailRules).where(eq(guardrailRules.id, id)).get();
     return c.json({ rule }, 201);
+  });
+
+  // Configure the built-in Prompt Injection Firewall preset in one action.
+  app.patch("/presets/prompt-injection-firewall", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<{ enabled?: boolean; action?: "block" | "redact" | "flag" }>();
+    const validActions = new Set(["block", "redact", "flag"]);
+
+    if (body.enabled === undefined && body.action === undefined) {
+      return c.json(
+        { error: { message: "enabled or action is required", type: "validation_error" } },
+        400,
+      );
+    }
+    if (body.action !== undefined && !validActions.has(body.action)) {
+      return c.json(
+        { error: { message: "Invalid action", type: "validation_error" } },
+        400,
+      );
+    }
+
+    await ensureBuiltInRules(db, tenantId);
+
+    const updates: Record<string, unknown> = {};
+    if (body.enabled !== undefined) updates.enabled = body.enabled;
+    if (body.action !== undefined) updates.action = body.action;
+
+    const tenantClause = tenantFilter(guardrailRules.tenantId, tenantId);
+    const whereClause = tenantClause
+      ? and(
+          eq(guardrailRules.type, PROMPT_INJECTION_FIREWALL_TYPE),
+          eq(guardrailRules.builtIn, true),
+          tenantClause,
+        )
+      : and(
+          eq(guardrailRules.type, PROMPT_INJECTION_FIREWALL_TYPE),
+          eq(guardrailRules.builtIn, true),
+        );
+
+    await db.update(guardrailRules).set(updates).where(whereClause).run();
+
+    const rules = await db
+      .select()
+      .from(guardrailRules)
+      .where(whereClause)
+      .all();
+
+    const enabledCount = rules.filter((rule) => rule.enabled).length;
+    return c.json({
+      preset: {
+        id: "prompt-injection-firewall",
+        name: "Prompt Injection Firewall",
+        totalRules: rules.length,
+        enabledRules: enabledCount,
+        action: body.action,
+      },
+      rules,
+    });
   });
 
   // Toggle a rule on/off

--- a/packages/gateway/tests/guardrails-firewall.test.ts
+++ b/packages/gateway/tests/guardrails-firewall.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { guardrailRules } from "@provara/db";
+import { and, eq } from "drizzle-orm";
+import { createGuardrailRoutes } from "../src/routes/guardrails.js";
+import { PROMPT_INJECTION_FIREWALL_TYPE } from "../src/guardrails/patterns.js";
+import { __testSetTenant } from "../src/auth/tenant.js";
+import { makeTestDb } from "./_setup/db.js";
+
+function appFor(db: Parameters<typeof createGuardrailRoutes>[0], tenantId: string) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    __testSetTenant(c.req.raw, tenantId);
+    await next();
+  });
+  app.route("/", createGuardrailRoutes(db));
+  return app;
+}
+
+describe("prompt injection firewall preset", () => {
+  it("bulk-enables the built-in prompt injection rules for a tenant", async () => {
+    const db = await makeTestDb();
+    const app = appFor(db, "tenant-firewall");
+
+    const before = await app.request("/");
+    expect(before.status).toBe(200);
+
+    let rules = await db
+      .select()
+      .from(guardrailRules)
+      .where(
+        and(
+          eq(guardrailRules.tenantId, "tenant-firewall"),
+          eq(guardrailRules.type, PROMPT_INJECTION_FIREWALL_TYPE),
+          eq(guardrailRules.builtIn, true),
+        ),
+      )
+      .all();
+    expect(rules.length).toBeGreaterThan(0);
+    expect(rules.every((rule) => !rule.enabled)).toBe(true);
+
+    const res = await app.request("/presets/prompt-injection-firewall", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: true }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      preset: { id: string; totalRules: number; enabledRules: number };
+    };
+    expect(body.preset.id).toBe("prompt-injection-firewall");
+    expect(body.preset.enabledRules).toBe(body.preset.totalRules);
+
+    rules = await db
+      .select()
+      .from(guardrailRules)
+      .where(
+        and(
+          eq(guardrailRules.tenantId, "tenant-firewall"),
+          eq(guardrailRules.type, PROMPT_INJECTION_FIREWALL_TYPE),
+          eq(guardrailRules.builtIn, true),
+        ),
+      )
+      .all();
+    expect(rules.every((rule) => rule.enabled)).toBe(true);
+  });
+
+  it("rejects invalid preset actions", async () => {
+    const db = await makeTestDb();
+    const app = appFor(db, "tenant-firewall");
+
+    const res = await app.request("/presets/prompt-injection-firewall", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "quarantine" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { type: string } };
+    expect(body.error.type).toBe("validation_error");
+  });
+});

--- a/packages/gateway/tests/spend-routes.test.ts
+++ b/packages/gateway/tests/spend-routes.test.ts
@@ -577,9 +577,13 @@ describe("GET /v1/spend/trajectory (#219/T4)", () => {
 
   it("returns MTD cost and projection for a Team tenant", async () => {
     const owner = await seedOwner(db, "t-team", "team");
-    // Two spends in the current month.
-    await seedRequestAndCost(db, "m1", { tenantId: "t-team", provider: "openai", model: "gpt-4.1-nano", cost: 2.5, createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000) });
-    await seedRequestAndCost(db, "m2", { tenantId: "t-team", provider: "openai", model: "gpt-4.1-nano", cost: 1.5, createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000) });
+    // Two spends in the current month. Keep them within the current day so
+    // this remains stable on the first day of a new month.
+    const now = new Date();
+    const monthStart = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
+    const currentMonthTs = Math.max(monthStart + 1_000, now.getTime() - 60_000);
+    await seedRequestAndCost(db, "m1", { tenantId: "t-team", provider: "openai", model: "gpt-4.1-nano", cost: 2.5, createdAt: new Date(currentMonthTs) });
+    await seedRequestAndCost(db, "m2", { tenantId: "t-team", provider: "openai", model: "gpt-4.1-nano", cost: 1.5, createdAt: new Date(currentMonthTs) });
 
     const app = buildApp(db);
     const res = await app.request("/v1/spend/trajectory?period=month", {


### PR DESCRIPTION
## Summary
- Adds a first-class Prompt Injection Firewall preset over the existing jailbreak/prompt-injection built-in rules.
- Adds a preset API for enabling/disabling the firewall rules in one action.
- Adds dashboard and docs copy that positions the current implementation as signature-based, not semantic/agent alignment yet.

## Roadmap State
- Addresses #311 by completing T1 and T2.
- Leaves T3 context-source scanning and T4 LLM judge mode in the roadmap issue.

## Verification
- npm test --workspace @provara/gateway -- tests/guardrails-firewall.test.ts
- npm run build --workspace @provara/gateway
- npm run build --workspace apps/web
- npm run build --workspace @provara/docs

Addresses #311 (completes T1, T2).

Last-code-by: codex/gpt-5 (codex)