### PR TITLE
feat(#329): add context optimizer v1

### DIFF
--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -1,0 +1,141 @@
+# Provara Context Optimizer Roadmap
+
+## Product Thesis
+
+Provara already controls the model path: routing, spend, quality, evals, guardrails, caching, and alerts. Context Optimizer adds the missing production layer for RAG and agentic systems: the context path.
+
+The product goal is to make retrieved context cheaper, safer, more accurate, and measurable before it reaches the model.
+
+## V1: Runtime Context Optimizer
+
+Optimize already-retrieved chunks at request time.
+
+Core capabilities:
+- Exact and near-duplicate removal.
+- Token savings estimation.
+- Source and citation preservation.
+- Prompt Injection Firewall risk scanning for retrieved context.
+- Per-request optimization report.
+
+Initial API:
+- `POST /v1/context/optimize`
+
+Paid tier:
+- Pro and higher through Intelligence access.
+
+## V1.1: Visibility
+
+Make optimization visible in the product.
+
+Capabilities:
+- Context savings analytics.
+- Duplicate-rate reporting.
+- Quarantined context reporting.
+- Request-detail integration.
+- Dashboard cards for input tokens, optimized tokens, dropped chunks, and risk flags.
+
+## V1.2: Quality Loop
+
+Prove that smaller context still answers correctly.
+
+Capabilities:
+- Before/after judge scoring.
+- Eval dataset support for raw context vs optimized context.
+- Quality delta reports.
+- Regression alerts when optimization reduces answer quality.
+
+## V2: Persistent Knowledge Distillation
+
+Move from per-request optimization to reusable canonical knowledge.
+
+Capabilities:
+- Batch document ingestion.
+- Canonical knowledge blocks.
+- Source references and provenance.
+- Versioning and diffs.
+- JSONL/vector-ready export.
+
+## V2.1: Governance
+
+Make optimized knowledge trustworthy for regulated teams.
+
+Capabilities:
+- Human review queue.
+- Approval states.
+- Audit logs.
+- Conflict detection.
+- PII and prompt-injection policy checks.
+- Approved-only export controls.
+
+## V2.2: Connectors
+
+Automatically ingest enterprise knowledge.
+
+Candidate connectors:
+- GitHub repositories.
+- Confluence.
+- Google Drive.
+- SharePoint.
+- Notion.
+- Zendesk or Intercom help centers.
+- S3 and local file upload.
+
+## V3: Retrieval Quality Layer
+
+Measure and improve RAG retrieval quality.
+
+Capabilities:
+- Retrieval trace ingestion.
+- Retrieval precision and unused-context metrics.
+- Duplicate, stale, and conflicting context rates.
+- Recommendations for source cleanup.
+- A/B tests for retrieval settings, rerankers, embedding models, and optimized vs raw context.
+
+## V3.1: Managed Vector Export
+
+Push optimized knowledge into customer-owned retrieval systems.
+
+Targets:
+- Pinecone.
+- Weaviate.
+- Qdrant.
+- Chroma.
+- pgvector.
+- OpenSearch.
+
+## V4: Context Policy Engine
+
+Enforce context rules per application.
+
+Policy examples:
+- Max context tokens.
+- Approved sources only.
+- Freshness limits.
+- Permission-aware source filters.
+- Prompt-injection quarantine.
+- PII redaction.
+- Block unreviewed knowledge.
+
+## Algorithm Ladder
+
+The roadmap should advance through these algorithmic layers:
+
+1. Semantic chunking.
+2. Embedding similarity and approximate search.
+3. Exact, fuzzy, and semantic deduplication.
+4. Clustering and canonicalization.
+5. Relevance scoring and reranking.
+6. Extractive and abstractive compression.
+7. Contradiction and conflict detection.
+8. Guardrail risk classification.
+9. Before/after quality evaluation.
+10. Active learning from feedback.
+11. Policy-aware context selection.
+
+## Packaging
+
+- Free: basic context token estimation and manual scan.
+- Pro: runtime optimization, exact/near dedupe, token savings, firewall scan.
+- Team: batch jobs, quality evaluation, retrieval analytics, basic connectors.
+- Enterprise: governance workflows, permission-aware connectors, vector export, audit reports, private deployment.
+

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -387,6 +387,51 @@ paths:
         "402":
           $ref: "#/components/responses/InsufficientTier"
 
+  /v1/context/optimize:
+    post:
+      tags: [Context Optimizer]
+      summary: Optimize runtime RAG context
+      description: |
+        Intelligence-tier endpoint that accepts already-retrieved context chunks
+        and returns a stateless optimization report. The first release performs
+        exact duplicate removal, preserves source IDs and metadata, and reports
+        estimated token savings.
+      operationId: optimizeContext
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContextOptimizeRequest"
+            examples:
+              ragContext:
+                summary: Dedupe retrieved chunks before model context assembly
+                value:
+                  chunks:
+                    - id: doc-1:chunk-4
+                      content: Refunds are available within 30 days.
+                      source: help-center
+                      metadata:
+                        url: https://example.com/refunds
+                    - id: doc-2:chunk-9
+                      content: refunds are available within 30 days.
+                      source: help-center-copy
+      responses:
+        "200":
+          description: Optimization report
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [optimization]
+                properties:
+                  optimization:
+                    $ref: "#/components/schemas/ContextOptimizationResult"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
   /v1/api-keys/status:
     get:
       tags: [API Keys]
@@ -1826,6 +1871,86 @@ components:
         capabilities:
           $ref: "#/components/schemas/FirewallCapabilities"
 
+    ContextChunk:
+      type: object
+      required: [id, content]
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+          minLength: 1
+        source:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+
+    ContextOptimizeRequest:
+      type: object
+      required: [chunks]
+      properties:
+        chunks:
+          type: array
+          minItems: 1
+          maxItems: 200
+          items:
+            $ref: "#/components/schemas/ContextChunk"
+
+    OptimizedContextChunk:
+      allOf:
+        - $ref: "#/components/schemas/ContextChunk"
+        - type: object
+          required: [sourceIds, inputTokens, outputTokens]
+          properties:
+            sourceIds:
+              type: array
+              items:
+                type: string
+            inputTokens:
+              type: integer
+            outputTokens:
+              type: integer
+
+    DroppedContextChunk:
+      type: object
+      required: [id, reason, duplicateOf, inputTokens]
+      properties:
+        id:
+          type: string
+        reason:
+          type: string
+          enum: [duplicate]
+        duplicateOf:
+          type: string
+        inputTokens:
+          type: integer
+
+    ContextOptimizationResult:
+      type: object
+      required: [optimized, dropped, metrics]
+      properties:
+        optimized:
+          type: array
+          items:
+            $ref: "#/components/schemas/OptimizedContextChunk"
+        dropped:
+          type: array
+          items:
+            $ref: "#/components/schemas/DroppedContextChunk"
+        metrics:
+          type: object
+          required: [inputChunks, outputChunks, droppedChunks, inputTokens, outputTokens, savedTokens, reductionPct]
+          properties:
+            inputChunks: { type: integer }
+            outputChunks: { type: integer }
+            droppedChunks: { type: integer }
+            inputTokens: { type: integer }
+            outputTokens: { type: integer }
+            savedTokens: { type: integer }
+            reductionPct:
+              type: number
+
     ChatMessage:
       type: object
       required: [role, content]
@@ -2161,6 +2286,8 @@ tags:
     description: User ratings, LLM judge scoring, and quality analytics.
   - name: Guardrails
     description: Tenant guardrail rules, Prompt Injection Firewall scans, settings, and events.
+  - name: Context Optimizer
+    description: Paid runtime context optimization for RAG and agentic systems.
   - name: Routing
     description: Routing engine configuration.
   - name: Providers

--- a/packages/gateway/src/context/optimizer.ts
+++ b/packages/gateway/src/context/optimizer.ts
@@ -1,0 +1,104 @@
+export interface ContextChunk {
+  id: string;
+  content: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OptimizedContextChunk {
+  id: string;
+  sourceIds: string[];
+  content: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface DroppedContextChunk {
+  id: string;
+  reason: "duplicate";
+  duplicateOf: string;
+  inputTokens: number;
+}
+
+export interface ContextOptimizationResult {
+  optimized: OptimizedContextChunk[];
+  dropped: DroppedContextChunk[];
+  metrics: {
+    inputChunks: number;
+    outputChunks: number;
+    droppedChunks: number;
+    inputTokens: number;
+    outputTokens: number;
+    savedTokens: number;
+    reductionPct: number;
+  };
+}
+
+export function estimateContextTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function normalizeForExactDedupe(content: string): string {
+  return content
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+export function optimizeContextChunks(chunks: ContextChunk[]): ContextOptimizationResult {
+  const seen = new Map<string, OptimizedContextChunk>();
+  const optimized: OptimizedContextChunk[] = [];
+  const dropped: DroppedContextChunk[] = [];
+  let inputTokens = 0;
+
+  for (const chunk of chunks) {
+    const tokenEstimate = estimateContextTokens(chunk.content);
+    inputTokens += tokenEstimate;
+
+    const key = normalizeForExactDedupe(chunk.content);
+    const existing = seen.get(key);
+    if (existing) {
+      existing.sourceIds.push(chunk.id);
+      dropped.push({
+        id: chunk.id,
+        reason: "duplicate",
+        duplicateOf: existing.id,
+        inputTokens: tokenEstimate,
+      });
+      continue;
+    }
+
+    const kept: OptimizedContextChunk = {
+      id: chunk.id,
+      sourceIds: [chunk.id],
+      content: chunk.content,
+      source: chunk.source,
+      metadata: chunk.metadata,
+      inputTokens: tokenEstimate,
+      outputTokens: tokenEstimate,
+    };
+    seen.set(key, kept);
+    optimized.push(kept);
+  }
+
+  const outputTokens = optimized.reduce((sum, chunk) => sum + chunk.outputTokens, 0);
+  const savedTokens = Math.max(0, inputTokens - outputTokens);
+  const reductionPct = inputTokens === 0 ? 0 : Number(((savedTokens / inputTokens) * 100).toFixed(2));
+
+  return {
+    optimized,
+    dropped,
+    metrics: {
+      inputChunks: chunks.length,
+      outputChunks: optimized.length,
+      droppedChunks: dropped.length,
+      inputTokens,
+      outputTokens,
+      savedTokens,
+      reductionPct,
+    },
+  };
+}
+

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -21,6 +21,7 @@ import { createDemoRoutes } from "./routes/demo.js";
 import { createTokenRoutes } from "./routes/tokens.js";
 import { createFeedbackRoutes } from "./routes/feedback.js";
 import { createConversationRoutes } from "./routes/conversations.js";
+import { createContextRoutes } from "./routes/context.js";
 import { createShareHandlers } from "./routes/shares.js";
 import { createRoutingConfigRoutes } from "./routes/routing-config.js";
 import { createRoutingIsolationRoutes } from "./routes/routing-isolation.js";
@@ -410,8 +411,10 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/regression/*", tierGate);
   app.use("/v1/cost-migrations/*", tierGate);
   app.use("/v1/evals/*", tierGate);
+  app.use("/v1/context/*", tierGate);
   app.route("/v1/regression", createRegressionRoutes(ctx.db, routingEngine.regressionCellTable));
   app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
+  app.route("/v1/context", createContextRoutes());
 
   // Mount analytics routes
   app.route("/v1/analytics", createAnalyticsRoutes(ctx.db, ctx.registry));

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -1,0 +1,70 @@
+import { Hono } from "hono";
+import { optimizeContextChunks, type ContextChunk } from "../context/optimizer.js";
+
+const MAX_CHUNKS = 200;
+const MAX_CHUNK_CHARS = 100_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateChunks(value: unknown): { chunks?: ContextChunk[]; error?: string } {
+  if (!Array.isArray(value)) return { error: "chunks must be an array" };
+  if (value.length === 0) return { error: "chunks must contain at least one item" };
+  if (value.length > MAX_CHUNKS) return { error: `chunks must contain at most ${MAX_CHUNKS} items` };
+
+  const chunks: ContextChunk[] = [];
+  for (const [index, item] of value.entries()) {
+    if (!isRecord(item)) return { error: `chunks[${index}] must be an object` };
+    if (typeof item.id !== "string" || item.id.trim().length === 0) {
+      return { error: `chunks[${index}].id is required` };
+    }
+    if (typeof item.content !== "string" || item.content.length === 0) {
+      return { error: `chunks[${index}].content is required` };
+    }
+    if (item.content.length > MAX_CHUNK_CHARS) {
+      return { error: `chunks[${index}].content exceeds ${MAX_CHUNK_CHARS} characters` };
+    }
+    if (item.source !== undefined && typeof item.source !== "string") {
+      return { error: `chunks[${index}].source must be a string` };
+    }
+    if (item.metadata !== undefined && !isRecord(item.metadata)) {
+      return { error: `chunks[${index}].metadata must be an object` };
+    }
+
+    chunks.push({
+      id: item.id,
+      content: item.content,
+      source: typeof item.source === "string" ? item.source : undefined,
+      metadata: isRecord(item.metadata) ? item.metadata : undefined,
+    });
+  }
+
+  return { chunks };
+}
+
+export function createContextRoutes() {
+  const app = new Hono();
+
+  app.post("/optimize", async (c) => {
+    const body = await c.req.json<{ chunks?: unknown }>().catch(() => null);
+    if (!body) {
+      return c.json(
+        { error: { message: "Invalid JSON body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    const parsed = validateChunks(body.chunks);
+    if (!parsed.chunks) {
+      return c.json(
+        { error: { message: parsed.error || "invalid chunks", type: "validation_error" } },
+        400,
+      );
+    }
+
+    return c.json({ optimization: optimizeContextChunks(parsed.chunks) });
+  });
+
+  return app;
+}

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import type { Db } from "@provara/db";
+import { optimizeContextChunks } from "../src/context/optimizer.js";
+import { createContextRoutes } from "../src/routes/context.js";
+import { makeTestDb } from "./_setup/db.js";
+import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
+
+vi.mock("../src/auth/tenant.js", () => ({
+  getTenantId: (req: Request) => req.headers.get("x-test-tenant"),
+}));
+
+import { requireIntelligenceTier } from "../src/auth/tier.js";
+
+function buildApp(db: Db) {
+  const app = new Hono();
+  app.use("/v1/context/*", requireIntelligenceTier(db));
+  app.route("/v1/context", createContextRoutes());
+  return app;
+}
+
+describe("context optimizer core", () => {
+  it("drops exact duplicate chunks and reports token savings", () => {
+    const result = optimizeContextChunks([
+      {
+        id: "chunk-1",
+        content: "Refunds are available within 30 days.",
+        source: "help-center",
+        metadata: { url: "https://example.com/refunds" },
+      },
+      {
+        id: "chunk-2",
+        content: "  refunds are available within 30 days.  ",
+        source: "help-center-copy",
+      },
+      {
+        id: "chunk-3",
+        content: "Enterprise plans include audit logs.",
+        source: "pricing",
+      },
+    ]);
+
+    expect(result.optimized).toHaveLength(2);
+    expect(result.dropped).toEqual([
+      expect.objectContaining({
+        id: "chunk-2",
+        reason: "duplicate",
+        duplicateOf: "chunk-1",
+      }),
+    ]);
+    expect(result.optimized[0]).toMatchObject({
+      id: "chunk-1",
+      sourceIds: ["chunk-1", "chunk-2"],
+      source: "help-center",
+      metadata: { url: "https://example.com/refunds" },
+    });
+    expect(result.metrics.inputChunks).toBe(3);
+    expect(result.metrics.outputChunks).toBe(2);
+    expect(result.metrics.savedTokens).toBeGreaterThan(0);
+    expect(result.metrics.reductionPct).toBeGreaterThan(0);
+  });
+});
+
+describe("POST /v1/context/optimize", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+    resetTierEnv();
+  });
+
+  afterEach(() => {
+    resetTierEnv();
+  });
+
+  it("requires Intelligence access", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    const app = buildApp(db);
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-free",
+      },
+      body: JSON.stringify({
+        chunks: [{ id: "a", content: "alpha" }],
+      }),
+    });
+
+    expect(res.status).toBe(402);
+    const body = await res.json() as { gate: { reason: string } };
+    expect(body.gate.reason).toBe("no_subscription");
+  });
+
+  it("returns an optimization report for paid tenants", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        chunks: [
+          { id: "a", content: "Context A", metadata: { doc: "one" } },
+          { id: "b", content: "context a" },
+          { id: "c", content: "Context C" },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: {
+        optimized: Array<{ id: string; sourceIds: string[]; metadata?: Record<string, unknown> }>;
+        dropped: Array<{ id: string; duplicateOf: string }>;
+        metrics: { inputChunks: number; outputChunks: number; droppedChunks: number };
+      };
+    };
+    expect(body.optimization.optimized).toHaveLength(2);
+    expect(body.optimization.optimized[0]).toMatchObject({
+      id: "a",
+      sourceIds: ["a", "b"],
+      metadata: { doc: "one" },
+    });
+    expect(body.optimization.dropped).toEqual([{ id: "b", reason: "duplicate", duplicateOf: "a", inputTokens: 3 }]);
+    expect(body.optimization.metrics).toMatchObject({
+      inputChunks: 3,
+      outputChunks: 2,
+      droppedChunks: 1,
+    });
+  });
+
+  it("validates chunks", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({ chunks: [{ id: "missing-content" }] }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { type: string; message: string } };
+    expect(body.error.type).toBe("validation_error");
+    expect(body.error.message).toContain("content is required");
+  });
+
+  it("rejects malformed JSON", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: { type: string; message: string } };
+    expect(body.error).toEqual({
+      type: "validation_error",
+      message: "Invalid JSON body",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the Context Optimizer roadmap artifact with product phases, packaging, and algorithm ladder.
- Adds a stateless exact-dedupe optimizer for runtime context chunks with token savings metrics and source ID preservation.
- Exposes `POST /v1/context/optimize` behind the Intelligence tier gate and documents it in OpenAPI.
- Covers the first sprint with focused API/core tests, including malformed JSON handling.

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts`
- `npx tsc --noEmit` in `packages/gateway`
- `npm test --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #329

Last-code-by: Codex/GPT-5 (codex)
