### PR TITLE
fix(#335): align context dashboard layout

### DIFF
--- a/apps/web/src/app/dashboard/context/page.tsx
+++ b/apps/web/src/app/dashboard/context/page.tsx
@@ -1,5 +1,9 @@
 import { ContextOptimizerPanel } from "../../../components/context-optimizer-panel";
 
 export default function ContextOptimizerPage() {
-  return <ContextOptimizerPanel />;
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <ContextOptimizerPanel />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Wraps `/dashboard/context` in the same centered `max-w-7xl` dashboard container used by the existing bounded pages.
- Keeps the Context Optimizer panel content unchanged.

## Verification
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit` in `apps/web`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #335

Last-code-by: Codex/GPT-5 (codex)
