### PR TITLE
feat(#343): add context optimizer quality loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable Provara changes are tracked here.
   - Dashboard page at `/dashboard/context` with summary cards and recent optimization events.
   - Demo tenant seed data for screenshot-ready Context Optimizer examples.
   - Optional retrieved-context risk scanning with active Guardrails rules, flagged/quarantined result buckets, persisted source IDs, and dashboard risk metrics.
+  - Context Optimizer quality loop with `POST /v1/context/evaluate`, persisted `context_quality_events`, demo quality rows, and dashboard quality delta/regression visibility.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
 - Optional semantic and hybrid prompt-injection scan modes using the configured judge model.
@@ -28,7 +29,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, and risk-aware optimization as shipped checkpoints, with quality scoring as the next planned layer.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, and V1.2 quality scoring as shipped checkpoints, with retrieval analytics as the next planned layer.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -43,11 +44,12 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility and risk reporting, run database migrations through `0046_context_optimization_risk`.
+- For Context Optimizer visibility, risk reporting, and quality scoring, run database migrations through `0047_context_quality_events`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
   - `context_optimization_events`
+  - `context_quality_events`
 - Existing tenants keep the safe default firewall settings:
   - `defaultScanMode: "signature"`
   - `toolCallAlignment: "block"`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -41,6 +41,32 @@ export interface ContextOptimizationEvent {
   createdAt: string;
 }
 
+export interface ContextQualitySummary {
+  eventCount: number;
+  regressedCount: number;
+  avgRawScore: number | null;
+  avgOptimizedScore: number | null;
+  avgDelta: number | null;
+  latestAt: string | null;
+}
+
+export interface ContextQualityEvent {
+  id: string;
+  tenantId: string | null;
+  rawScore: number;
+  optimizedScore: number;
+  delta: number;
+  regressed: boolean;
+  regressionThreshold: number;
+  judgeProvider: string;
+  judgeModel: string;
+  promptHash: string;
+  rawSourceIds: string[];
+  optimizedSourceIds: string[];
+  rationale: string | null;
+  createdAt: string;
+}
+
 interface GateState {
   message: string;
   upgradeUrl?: string;
@@ -49,6 +75,8 @@ interface GateState {
 interface LoadState {
   summary: ContextOptimizationSummary | null;
   events: ContextOptimizationEvent[];
+  qualitySummary: ContextQualitySummary | null;
+  qualityEvents: ContextQualityEvent[];
   loading: boolean;
   error: string | null;
   gate: GateState | null;
@@ -60,6 +88,11 @@ function formatInteger(value: number): string {
 
 function formatPercent(value: number): string {
   return `${value.toFixed(value % 1 === 0 ? 0 : 2)}%`;
+}
+
+function formatScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "n/a";
+  return value.toFixed(value % 1 === 0 ? 0 : 2);
 }
 
 function formatTimestamp(value: string | null): string {
@@ -76,6 +109,13 @@ function metricTone(value: number): string {
 
 function riskTone(value: number): string {
   if (value > 0) return "text-amber-300";
+  return "text-zinc-200";
+}
+
+function deltaTone(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "text-zinc-200";
+  if (value < 0) return "text-red-300";
+  if (value > 0) return "text-emerald-300";
   return "text-zinc-200";
 }
 
@@ -122,6 +162,8 @@ export function ContextOptimizerPanel() {
   const [state, setState] = useState<LoadState>({
     summary: null,
     events: [],
+    qualitySummary: null,
+    qualityEvents: [],
     loading: true,
     error: null,
     gate: null,
@@ -134,19 +176,28 @@ export function ContextOptimizerPanel() {
       setState((prev) => ({ ...prev, loading: true, error: null, gate: null }));
 
       try {
-        const [summaryRes, eventsRes] = await Promise.all([
+        const [summaryRes, eventsRes, qualitySummaryRes, qualityEventsRes] = await Promise.all([
           gatewayFetchRaw("/v1/context/summary"),
           gatewayFetchRaw("/v1/context/events?limit=25"),
+          gatewayFetchRaw("/v1/context/quality/summary"),
+          gatewayFetchRaw("/v1/context/quality/events?limit=10"),
         ]);
 
-        if (summaryRes.status === 402 || eventsRes.status === 402) {
+        if (
+          summaryRes.status === 402 ||
+          eventsRes.status === 402 ||
+          qualitySummaryRes.status === 402 ||
+          qualityEventsRes.status === 402
+        ) {
           const body = await readJson<{ error?: { message?: string }; gate?: { upgradeUrl?: string } }>(
-            summaryRes.status === 402 ? summaryRes : eventsRes,
+            [summaryRes, eventsRes, qualitySummaryRes, qualityEventsRes].find((res) => res.status === 402) ?? summaryRes,
           );
           if (!cancelled) {
             setState({
               summary: null,
               events: [],
+              qualitySummary: null,
+              qualityEvents: [],
               loading: false,
               error: null,
               gate: {
@@ -158,17 +209,21 @@ export function ContextOptimizerPanel() {
           return;
         }
 
-        if (!summaryRes.ok || !eventsRes.ok) {
+        if (!summaryRes.ok || !eventsRes.ok || !qualitySummaryRes.ok || !qualityEventsRes.ok) {
           throw new Error("Failed to load Context Optimizer data");
         }
 
         const summaryBody = await summaryRes.json() as { summary: ContextOptimizationSummary };
         const eventsBody = await eventsRes.json() as { events: ContextOptimizationEvent[] };
+        const qualitySummaryBody = await qualitySummaryRes.json() as { summary: ContextQualitySummary };
+        const qualityEventsBody = await qualityEventsRes.json() as { events: ContextQualityEvent[] };
 
         if (!cancelled) {
           setState({
             summary: summaryBody.summary,
             events: eventsBody.events,
+            qualitySummary: qualitySummaryBody.summary,
+            qualityEvents: qualityEventsBody.events,
             loading: false,
             error: null,
             gate: null,
@@ -179,6 +234,8 @@ export function ContextOptimizerPanel() {
           setState({
             summary: null,
             events: [],
+            qualitySummary: null,
+            qualityEvents: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
             gate: null,
@@ -195,6 +252,8 @@ export function ContextOptimizerPanel() {
 
   const summary = state.summary;
   const eventRows = useMemo(() => state.events, [state.events]);
+  const qualitySummary = state.qualitySummary;
+  const qualityRows = useMemo(() => state.qualityEvents, [state.qualityEvents]);
 
   return (
     <div className="space-y-6">
@@ -257,6 +316,99 @@ export function ContextOptimizerPanel() {
           tone={metricTone(summary?.reductionPct ?? 0)}
         />
       </div>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Quality Loop</h2>
+          <p className="mt-1 text-sm text-zinc-500">Raw-context vs optimized-context answer scoring.</p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <StatTile
+            label="Quality Delta"
+            value={formatScore(qualitySummary?.avgDelta)}
+            detail={`${formatScore(qualitySummary?.avgOptimizedScore)} optimized vs ${formatScore(qualitySummary?.avgRawScore)} raw`}
+            tone={deltaTone(qualitySummary?.avgDelta)}
+          />
+          <StatTile
+            label="Quality Checks"
+            value={formatInteger(qualitySummary?.eventCount ?? 0)}
+            detail="Raw vs optimized comparisons"
+          />
+          <StatTile
+            label="Regressions"
+            value={formatInteger(qualitySummary?.regressedCount ?? 0)}
+            detail="Below configured delta threshold"
+            tone={riskTone(qualitySummary?.regressedCount ?? 0)}
+          />
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Quality Events</h2>
+          <p className="mt-1 text-sm text-zinc-500">Recent judge comparisons for optimized context.</p>
+        </div>
+
+        {state.loading ? (
+          <LoadingRows />
+        ) : qualityRows.length === 0 ? (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center text-sm text-zinc-400">
+            No context quality checks yet.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">Time</th>
+                    <th className="px-4 py-3 text-right font-medium">Raw</th>
+                    <th className="px-4 py-3 text-right font-medium">Optimized</th>
+                    <th className="px-4 py-3 text-right font-medium">Delta</th>
+                    <th className="px-4 py-3 text-left font-medium">Status</th>
+                    <th className="px-4 py-3 text-left font-medium">Sources</th>
+                    <th className="px-4 py-3 text-left font-medium">Judge</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {qualityRows.map((event) => (
+                    <tr key={event.id}>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{formatTimestamp(event.createdAt)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">{formatScore(event.rawScore)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">{formatScore(event.optimizedScore)}</td>
+                      <td className={`whitespace-nowrap px-4 py-3 text-right tabular-nums ${deltaTone(event.delta)}`}>
+                        {formatScore(event.delta)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        {event.regressed ? (
+                          <span className="rounded border border-red-900/70 bg-red-950/30 px-2 py-0.5 text-xs text-red-200">Regression</span>
+                        ) : (
+                          <span className="rounded border border-emerald-900/70 bg-emerald-950/20 px-2 py-0.5 text-xs text-emerald-200">Stable</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex max-w-xl flex-wrap gap-1">
+                          {[...new Set([...event.rawSourceIds, ...event.optimizedSourceIds])].slice(0, 6).map((id) => (
+                            <span key={id} className="rounded border border-zinc-700 bg-zinc-950 px-2 py-0.5 font-mono text-xs text-zinc-300">
+                              {id}
+                            </span>
+                          ))}
+                          {event.rawSourceIds.length + event.optimizedSourceIds.length === 0 && (
+                            <span className="text-zinc-600">None</span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-zinc-500">
+                        {event.judgeProvider}/{event.judgeModel}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
 
       <section>
         <div className="mb-3 flex items-center justify-between">

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -41,6 +41,40 @@ describe("ContextOptimizerPanel", () => {
           },
         }));
       }
+      if (path === "/v1/context/quality/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 3,
+            regressedCount: 1,
+            avgRawScore: 4.2,
+            avgOptimizedScore: 4,
+            avgDelta: -0.2,
+            latestAt: "2026-05-01T21:30:00.000Z",
+          },
+        }));
+      }
+      if (path === "/v1/context/quality/events?limit=10") {
+        return Promise.resolve(jsonResponse({
+          events: [
+            {
+              id: "quality-1",
+              tenantId: "tenant-pro",
+              rawScore: 4,
+              optimizedScore: 3,
+              delta: -1,
+              regressed: true,
+              regressionThreshold: -0.5,
+              judgeProvider: "openai",
+              judgeModel: "gpt-4o-mini",
+              promptHash: "abc123",
+              rawSourceIds: ["refunds#1", "policy#2"],
+              optimizedSourceIds: ["refunds#1"],
+              rationale: "Optimized answer omitted one detail.",
+              createdAt: "2026-05-01T21:30:00.000Z",
+            },
+          ],
+        }));
+      }
       return Promise.resolve(jsonResponse({
         events: [
           {
@@ -82,6 +116,9 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("chunk-c")).toBeInTheDocument();
     expect(screen.getByText("Risky Chunks")).toBeInTheDocument();
     expect(screen.getByText("chunk-risky")).toBeInTheDocument();
+    expect(screen.getByText("Quality Delta")).toBeInTheDocument();
+    expect(screen.getByText("Regression")).toBeInTheDocument();
+    expect(screen.getByText("refunds#1")).toBeInTheDocument();
   });
 
   it("shows the empty state", async () => {
@@ -103,12 +140,28 @@ describe("ContextOptimizerPanel", () => {
           },
         }));
       }
+      if (path === "/v1/context/quality/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            regressedCount: 0,
+            avgRawScore: null,
+            avgOptimizedScore: null,
+            avgDelta: null,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/quality/events?limit=10") {
+        return Promise.resolve(jsonResponse({ events: [] }));
+      }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
 
     render(<ContextOptimizerPanel />);
 
     expect(await screen.findByText("No context optimization events yet.")).toBeInTheDocument();
+    expect(screen.getByText("No context quality checks yet.")).toBeInTheDocument();
   });
 
   it("shows upgrade messaging for gated tenants", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -16,9 +16,11 @@ Implemented as of `0.2.0`:
 - Demo tenant seed data for screenshot-ready examples.
 - Optional retrieved-context risk scanning with active Guardrails rules.
 - Flagged and quarantined context reporting in API events and the dashboard.
+- Raw-context vs optimized-context judge scoring through `POST /v1/context/evaluate`.
+- `context_quality_events` with quality deltas, regression flags, source IDs, judge metadata, and dashboard visibility.
 
 Next planned layer:
-- Quality scoring for raw context vs optimized context.
+- Retrieval analytics for unused, duplicate, stale, and conflicting context.
 
 ## V1: Runtime Context Optimizer
 
@@ -53,10 +55,10 @@ Capabilities:
 Prove that smaller context still answers correctly.
 
 Capabilities:
-- Before/after judge scoring.
+- Before/after judge scoring. Shipped in V1.2 as raw-context vs optimized-context answer comparison.
 - Eval dataset support for raw context vs optimized context.
-- Quality delta reports.
-- Regression alerts when optimization reduces answer quality.
+- Quality delta reports. Shipped in V1.2 for recent events and aggregates.
+- Regression alerts when optimization reduces answer quality. V1.2 records regression flags; alert wiring remains future work.
 
 ## V2: Persistent Knowledge Distillation
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -11,6 +11,7 @@ The shipped V1 implementation is intentionally narrow:
 - Estimated token savings based on input and output context size.
 - Optional risk scanning with active Guardrails rules for retrieved context.
 - Flagged and quarantined context buckets with rule evidence and source IDs.
+- Raw-context vs optimized-context quality scoring with the configured judge model.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 
@@ -61,9 +62,32 @@ Visibility APIs:
 ```text
 GET /v1/context/summary
 GET /v1/context/events
+GET /v1/context/quality/summary
+GET /v1/context/quality/events
 ```
 
 These endpoints are tenant-scoped and require Intelligence access.
+
+Quality evaluation is available through:
+
+```text
+POST /v1/context/evaluate
+```
+
+The request accepts the same user prompt plus two already-produced answers:
+
+```json
+{
+  "prompt": "What is the refund window?",
+  "rawAnswer": "Refunds are available within 30 days and require a receipt.",
+  "optimizedAnswer": "Refunds are available within 30 days.",
+  "rawSourceIds": ["refunds.md#4", "policy.md#2"],
+  "optimizedSourceIds": ["refunds.md#4"],
+  "regressionThreshold": -0.5
+}
+```
+
+The response includes the judge scores, optimized-minus-raw delta, regression flag, judge target, and persisted event. Provara stores a prompt hash, scores, source IDs, judge metadata, and rationale. It does not persist the full prompt, answers, or context content.
 
 ## Dashboard
 
@@ -91,14 +115,21 @@ The Recent Events table shows:
 - Duplicate source IDs that were removed.
 - Risky source IDs that were flagged or quarantined.
 
+The Quality Loop section shows:
+
+- Average optimized-minus-raw quality delta.
+- Number of raw-vs-optimized quality checks.
+- Number of checks below the configured regression threshold.
+- Recent quality events with raw score, optimized score, delta, status, source IDs, and judge target.
+
 ## Demo Mode
 
 The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This keeps `/dashboard/context` useful for demos, screenshots, and product walkthroughs without requiring a live RAG integration.
 
 ## Next Roadmap Step
 
-The next behavior layer is the quality loop:
+The next behavior layer is retrieval analytics:
 
-- Compare optimized context against raw context with judge scoring.
-- Alert when optimization appears to reduce answer quality.
-- Feed risky-context evidence into future review workflows.
+- Measure unused, duplicate, stale, and conflicting context rates.
+- Recommend source cleanup and retrieval tuning.
+- Feed quality deltas into alerting and evaluation workflows.

--- a/packages/db/drizzle/0047_context_quality_events.sql
+++ b/packages/db/drizzle/0047_context_quality_events.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `context_quality_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`raw_score` real NOT NULL,
+	`optimized_score` real NOT NULL,
+	`delta` real NOT NULL,
+	`regressed` integer DEFAULT 0 NOT NULL,
+	`regression_threshold` real NOT NULL,
+	`judge_provider` text NOT NULL,
+	`judge_model` text NOT NULL,
+	`prompt_hash` text NOT NULL,
+	`raw_source_ids` text DEFAULT '[]' NOT NULL,
+	`optimized_source_ids` text DEFAULT '[]' NOT NULL,
+	`rationale` text,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `context_quality_events_tenant_created_idx` ON `context_quality_events` (`tenant_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `context_quality_events_tenant_regressed_idx` ON `context_quality_events` (`tenant_id`,`regressed`,`created_at`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1777653900000,
       "tag": "0046_context_optimization_risk",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1777656000000,
+      "tag": "0047_context_quality_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -346,6 +346,28 @@ export const contextOptimizationEvents = sqliteTable("context_optimization_event
   index("context_optimization_events_tenant_created_idx").on(table.tenantId, table.createdAt),
 ]);
 
+export const contextQualityEvents = sqliteTable("context_quality_events", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  rawScore: real("raw_score").notNull(),
+  optimizedScore: real("optimized_score").notNull(),
+  delta: real("delta").notNull(),
+  regressed: integer("regressed", { mode: "boolean" }).notNull().default(false),
+  regressionThreshold: real("regression_threshold").notNull(),
+  judgeProvider: text("judge_provider").notNull(),
+  judgeModel: text("judge_model").notNull(),
+  promptHash: text("prompt_hash").notNull(),
+  rawSourceIds: text("raw_source_ids").notNull().default("[]"),
+  optimizedSourceIds: text("optimized_source_ids").notNull().default("[]"),
+  rationale: text("rationale"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_quality_events_tenant_created_idx").on(table.tenantId, table.createdAt),
+  index("context_quality_events_tenant_regressed_idx").on(table.tenantId, table.regressed, table.createdAt),
+]);
+
 export const alertRules = sqliteTable("alert_rules", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -485,6 +485,93 @@ paths:
         "402":
           $ref: "#/components/responses/InsufficientTier"
 
+  /v1/context/evaluate:
+    post:
+      tags: [Context Optimizer]
+      summary: Evaluate raw-context vs optimized-context answer quality
+      description: |
+        Intelligence-tier endpoint that uses the configured judge model to compare
+        an answer produced with raw retrieved context against an answer produced
+        with optimized context. The event stores scores, source IDs, judge
+        metadata, a prompt hash, and rationale without persisting full content.
+      operationId: evaluateContextQuality
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContextQualityEvaluateRequest"
+      responses:
+        "200":
+          description: Quality evaluation result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [evaluation, event]
+                properties:
+                  evaluation:
+                    $ref: "#/components/schemas/ContextQualityEvaluation"
+                  event:
+                    $ref: "#/components/schemas/ContextQualityEvent"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "502":
+          description: Judge model failed or returned invalid scores.
+
+  /v1/context/quality/events:
+    get:
+      tags: [Context Optimizer]
+      summary: List recent context quality events
+      operationId: listContextQualityEvents
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - in: query
+          name: regressedOnly
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: Recent quality events
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [events]
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextQualityEvent"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
+  /v1/context/quality/summary:
+    get:
+      tags: [Context Optimizer]
+      summary: Summarize context quality events
+      operationId: summarizeContextQuality
+      responses:
+        "200":
+          description: Aggregate quality summary
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [summary]
+                properties:
+                  summary:
+                    $ref: "#/components/schemas/ContextQualitySummary"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
   /v1/api-keys/status:
     get:
       tags: [API Keys]
@@ -2142,6 +2229,133 @@ components:
           type: integer
         quarantinedChunks:
           type: integer
+        latestAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    ContextQualityEvaluateRequest:
+      type: object
+      required: [prompt, rawAnswer, optimizedAnswer]
+      properties:
+        prompt:
+          type: string
+          minLength: 1
+        rawAnswer:
+          type: string
+          minLength: 1
+        optimizedAnswer:
+          type: string
+          minLength: 1
+        rawSourceIds:
+          type: array
+          items:
+            type: string
+        optimizedSourceIds:
+          type: array
+          items:
+            type: string
+        regressionThreshold:
+          type: number
+          default: -0.5
+
+    ContextQualityEvaluation:
+      type: object
+      required: [rawScore, optimizedScore, delta, regressed, regressionThreshold, judge, rationale]
+      properties:
+        rawScore:
+          type: number
+        optimizedScore:
+          type: number
+        delta:
+          type: number
+        regressed:
+          type: boolean
+        regressionThreshold:
+          type: number
+        judge:
+          type: object
+          required: [provider, model]
+          properties:
+            provider:
+              type: string
+            model:
+              type: string
+        rationale:
+          type: string
+          nullable: true
+
+    ContextQualityEvent:
+      type: object
+      required:
+        - id
+        - tenantId
+        - rawScore
+        - optimizedScore
+        - delta
+        - regressed
+        - regressionThreshold
+        - judgeProvider
+        - judgeModel
+        - promptHash
+        - rawSourceIds
+        - optimizedSourceIds
+        - rationale
+        - createdAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        rawScore:
+          type: number
+        optimizedScore:
+          type: number
+        delta:
+          type: number
+        regressed:
+          type: boolean
+        regressionThreshold:
+          type: number
+        judgeProvider:
+          type: string
+        judgeModel:
+          type: string
+        promptHash:
+          type: string
+        rawSourceIds:
+          type: array
+          items:
+            type: string
+        optimizedSourceIds:
+          type: array
+          items:
+            type: string
+        rationale:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+
+    ContextQualitySummary:
+      type: object
+      required: [eventCount, regressedCount, avgRawScore, avgOptimizedScore, avgDelta, latestAt]
+      properties:
+        eventCount:
+          type: integer
+        regressedCount:
+          type: integer
+        avgRawScore:
+          type: number
+          nullable: true
+        avgOptimizedScore:
+          type: number
+          nullable: true
+        avgDelta:
+          type: number
+          nullable: true
         latestAt:
           type: string
           format: date-time

--- a/packages/gateway/src/context/quality.ts
+++ b/packages/gateway/src/context/quality.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import type { Db } from "@provara/db";
+import { contextQualityEvents } from "@provara/db";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { tenantFilter } from "../auth/tenant.js";
+import type { ProviderRegistry } from "../providers/index.js";
+import type { ChatMessage } from "../providers/types.js";
+import { resolveJudgeTarget } from "../routing/judge.js";
+
+const DEFAULT_REGRESSION_THRESHOLD = -0.5;
+
+const CONTEXT_QUALITY_JUDGE_PROMPT = `You are a strict, impartial evaluator for RAG context optimization.
+
+Compare two assistant answers to the same user prompt:
+- RAW answer: produced with unoptimized retrieved context.
+- OPTIMIZED answer: produced after context optimization.
+
+Score each answer from 1 to 5 for whether it correctly and completely answers the prompt. Penalize missing facts, unsupported claims, irrelevant content, and ambiguity. A 5 should be rare.
+
+Return ONLY valid JSON:
+{"rawScore": N, "optimizedScore": N, "rationale": "short reason"}`;
+
+export interface ContextQualityEvent {
+  id: string;
+  tenantId: string | null;
+  rawScore: number;
+  optimizedScore: number;
+  delta: number;
+  regressed: boolean;
+  regressionThreshold: number;
+  judgeProvider: string;
+  judgeModel: string;
+  promptHash: string;
+  rawSourceIds: string[];
+  optimizedSourceIds: string[];
+  rationale: string | null;
+  createdAt: Date;
+}
+
+export interface ContextQualityEvaluationInput {
+  prompt: string;
+  rawAnswer: string;
+  optimizedAnswer: string;
+  rawSourceIds?: string[];
+  optimizedSourceIds?: string[];
+  regressionThreshold?: number;
+}
+
+export interface ContextQualityEvaluation {
+  rawScore: number;
+  optimizedScore: number;
+  delta: number;
+  regressed: boolean;
+  regressionThreshold: number;
+  judge: { provider: string; model: string };
+  rationale: string | null;
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function eventFromRow(row: typeof contextQualityEvents.$inferSelect): ContextQualityEvent {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    rawScore: row.rawScore,
+    optimizedScore: row.optimizedScore,
+    delta: row.delta,
+    regressed: row.regressed,
+    regressionThreshold: row.regressionThreshold,
+    judgeProvider: row.judgeProvider,
+    judgeModel: row.judgeModel,
+    promptHash: row.promptHash,
+    rawSourceIds: parseStringArray(row.rawSourceIds),
+    optimizedSourceIds: parseStringArray(row.optimizedSourceIds),
+    rationale: row.rationale,
+    createdAt: row.createdAt,
+  };
+}
+
+function promptHash(prompt: string): string {
+  return createHash("sha256").update(prompt).digest("hex");
+}
+
+function clampScore(value: unknown): number | null {
+  const score = Number(value);
+  if (!Number.isFinite(score) || score < 1 || score > 5) return null;
+  return Number(score.toFixed(2));
+}
+
+function parseJudgeResponse(raw: string): { rawScore: number; optimizedScore: number; rationale: string | null } | null {
+  try {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    const parsed = JSON.parse(match[0]) as { rawScore?: unknown; optimizedScore?: unknown; rationale?: unknown };
+    const rawScore = clampScore(parsed.rawScore);
+    const optimizedScore = clampScore(parsed.optimizedScore);
+    if (rawScore === null || optimizedScore === null) return null;
+    return {
+      rawScore,
+      optimizedScore,
+      rationale: typeof parsed.rationale === "string" ? parsed.rationale.slice(0, 1000) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function judgeMessages(input: ContextQualityEvaluationInput): ChatMessage[] {
+  return [
+    { role: "system", content: CONTEXT_QUALITY_JUDGE_PROMPT },
+    {
+      role: "user",
+      content: [
+        `Prompt:\n${input.prompt}`,
+        `RAW answer:\n${input.rawAnswer}`,
+        `OPTIMIZED answer:\n${input.optimizedAnswer}`,
+      ].join("\n\n"),
+    },
+  ];
+}
+
+export async function evaluateContextQuality(
+  db: Db,
+  registry: ProviderRegistry,
+  tenantId: string | null,
+  input: ContextQualityEvaluationInput,
+): Promise<{ evaluation: ContextQualityEvaluation; event: ContextQualityEvent }> {
+  const target = resolveJudgeTarget(registry);
+  if (!target) {
+    throw new Error("No judge model is configured");
+  }
+
+  const provider = registry.get(target.provider);
+  if (!provider) {
+    throw new Error("Configured judge provider is unavailable");
+  }
+
+  const response = await provider.complete({
+    model: target.model,
+    messages: judgeMessages(input),
+    temperature: 0,
+    max_tokens: 200,
+  });
+  const judged = parseJudgeResponse(response.content);
+  if (!judged) {
+    throw new Error("Judge returned an invalid quality score");
+  }
+
+  const regressionThreshold = input.regressionThreshold ?? DEFAULT_REGRESSION_THRESHOLD;
+  const delta = Number((judged.optimizedScore - judged.rawScore).toFixed(2));
+  const evaluation: ContextQualityEvaluation = {
+    rawScore: judged.rawScore,
+    optimizedScore: judged.optimizedScore,
+    delta,
+    regressed: delta <= regressionThreshold,
+    regressionThreshold,
+    judge: target,
+    rationale: judged.rationale,
+  };
+  const id = nanoid();
+  await db.insert(contextQualityEvents).values({
+    id,
+    tenantId,
+    rawScore: evaluation.rawScore,
+    optimizedScore: evaluation.optimizedScore,
+    delta: evaluation.delta,
+    regressed: evaluation.regressed,
+    regressionThreshold: evaluation.regressionThreshold,
+    judgeProvider: target.provider,
+    judgeModel: target.model,
+    promptHash: promptHash(input.prompt),
+    rawSourceIds: JSON.stringify(input.rawSourceIds ?? []),
+    optimizedSourceIds: JSON.stringify(input.optimizedSourceIds ?? []),
+    rationale: evaluation.rationale,
+  }).run();
+
+  const row = await db.select().from(contextQualityEvents).where(eq(contextQualityEvents.id, id)).get();
+  if (!row) throw new Error("Failed to record context quality event");
+  return { evaluation, event: eventFromRow(row) };
+}
+
+export async function listContextQualityEvents(
+  db: Db,
+  tenantId: string | null,
+  options: { limit?: number; regressedOnly?: boolean } = {},
+): Promise<ContextQualityEvent[]> {
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 25)));
+  const rows = await db
+    .select()
+    .from(contextQualityEvents)
+    .where(
+      options.regressedOnly
+        ? and(tenantFilter(contextQualityEvents.tenantId, tenantId), eq(contextQualityEvents.regressed, true))
+        : tenantFilter(contextQualityEvents.tenantId, tenantId),
+    )
+    .orderBy(desc(contextQualityEvents.createdAt))
+    .limit(limit)
+    .all();
+
+  return rows.map(eventFromRow);
+}
+
+export async function summarizeContextQualityEvents(db: Db, tenantId: string | null) {
+  const whereClause = tenantFilter(contextQualityEvents.tenantId, tenantId);
+  const row = await db
+    .select({
+      eventCount: sql<number>`count(*)`,
+      regressedCount: sql<number>`coalesce(sum(case when ${contextQualityEvents.regressed} = 1 then 1 else 0 end), 0)`,
+      avgRawScore: sql<number>`avg(${contextQualityEvents.rawScore})`,
+      avgOptimizedScore: sql<number>`avg(${contextQualityEvents.optimizedScore})`,
+      avgDelta: sql<number>`avg(${contextQualityEvents.delta})`,
+    })
+    .from(contextQualityEvents)
+    .where(whereClause)
+    .get();
+
+  const latestRow = await db
+    .select({ createdAt: contextQualityEvents.createdAt })
+    .from(contextQualityEvents)
+    .where(whereClause)
+    .orderBy(desc(contextQualityEvents.createdAt))
+    .limit(1)
+    .get();
+
+  return {
+    eventCount: row?.eventCount ?? 0,
+    regressedCount: row?.regressedCount ?? 0,
+    avgRawScore: row?.avgRawScore === null || row?.avgRawScore === undefined ? null : Number(row.avgRawScore.toFixed(2)),
+    avgOptimizedScore: row?.avgOptimizedScore === null || row?.avgOptimizedScore === undefined ? null : Number(row.avgOptimizedScore.toFixed(2)),
+    avgDelta: row?.avgDelta === null || row?.avgDelta === undefined ? null : Number(row.avgDelta.toFixed(2)),
+    latestAt: latestRow?.createdAt ?? null,
+  };
+}

--- a/packages/gateway/src/demo/seed.ts
+++ b/packages/gateway/src/demo/seed.ts
@@ -10,6 +10,7 @@ import {
   costLogs,
   costMigrations,
   contextOptimizationEvents,
+  contextQualityEvents,
   customProviders,
   feedback,
   guardrailLogs,
@@ -721,6 +722,72 @@ export async function reseedDemoTenant(db: Db, now: Date = new Date()): Promise<
       createdAt: event.createdAt,
     }).run();
   }
+
+  const contextQualityRows = [
+    {
+      id: "cqe_demo_refunds_stable",
+      rawScore: 4.4,
+      optimizedScore: 4.3,
+      delta: -0.1,
+      regressed: false,
+      regressionThreshold: -0.5,
+      judgeProvider: "openai",
+      judgeModel: "gpt-4o-mini",
+      promptHash: "demo_refunds_hash",
+      rawSourceIds: ["refunds.md#4", "refunds-copy.md#1", "billing-faq#9"],
+      optimizedSourceIds: ["refunds.md#4", "billing-faq#9"],
+      rationale: "Optimized answer preserved the refund window and removed repeated policy text.",
+      createdAt: new Date(now.getTime() - 90 * 60 * 1000),
+    },
+    {
+      id: "cqe_demo_policy_regression",
+      rawScore: 4.1,
+      optimizedScore: 3.3,
+      delta: -0.8,
+      regressed: true,
+      regressionThreshold: -0.5,
+      judgeProvider: "openai",
+      judgeModel: "gpt-4o-mini",
+      promptHash: "demo_policy_hash",
+      rawSourceIds: ["security-policy#2", "sso-runbook#5", "partner-note#3"],
+      optimizedSourceIds: ["security-policy#2", "sso-runbook#5"],
+      rationale: "Optimized answer lost one exception from the raw context.",
+      createdAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    },
+    {
+      id: "cqe_demo_runbook_improved",
+      rawScore: 3.8,
+      optimizedScore: 4.2,
+      delta: 0.4,
+      regressed: false,
+      regressionThreshold: -0.5,
+      judgeProvider: "openai",
+      judgeModel: "gpt-4o-mini",
+      promptHash: "demo_runbook_hash",
+      rawSourceIds: ["agent-runbook#11", "tool-calls#4", "handoff#2"],
+      optimizedSourceIds: ["agent-runbook#11", "tool-calls#4"],
+      rationale: "Optimized answer was more concise while retaining the required handoff steps.",
+      createdAt: new Date(now.getTime() - 1 * DAY_MS),
+    },
+  ];
+  for (const event of contextQualityRows) {
+    await db.insert(contextQualityEvents).values({
+      id: event.id,
+      tenantId,
+      rawScore: event.rawScore,
+      optimizedScore: event.optimizedScore,
+      delta: event.delta,
+      regressed: event.regressed,
+      regressionThreshold: event.regressionThreshold,
+      judgeProvider: event.judgeProvider,
+      judgeModel: event.judgeModel,
+      promptHash: event.promptHash,
+      rawSourceIds: JSON.stringify(event.rawSourceIds),
+      optimizedSourceIds: JSON.stringify(event.optimizedSourceIds),
+      rationale: event.rationale,
+      createdAt: event.createdAt,
+    }).run();
+  }
 }
 
 /** Wipe every row scoped to the demo tenant. Order matters where FKs apply. */
@@ -744,6 +811,7 @@ async function wipe(db: Db, tenantId: string): Promise<void> {
   await db.delete(routingWeightSnapshots).where(eq(routingWeightSnapshots.tenantId, tenantId)).run();
   await db.delete(spendBudgets).where(eq(spendBudgets.tenantId, tenantId)).run();
   await db.delete(costMigrations).where(eq(costMigrations.tenantId, tenantId)).run();
+  await db.delete(contextQualityEvents).where(eq(contextQualityEvents.tenantId, tenantId)).run();
   await db.delete(contextOptimizationEvents).where(eq(contextOptimizationEvents.tenantId, tenantId)).run();
   await db.delete(customProviders).where(eq(customProviders.tenantId, tenantId)).run();
   await db.delete(teamInvites).where(eq(teamInvites.tenantId, tenantId)).run();

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -414,7 +414,7 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/context/*", tierGate);
   app.route("/v1/regression", createRegressionRoutes(ctx.db, routingEngine.regressionCellTable));
   app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
-  app.route("/v1/context", createContextRoutes(ctx.db));
+  app.route("/v1/context", createContextRoutes(ctx.db, ctx.registry));
 
   // Mount analytics routes
   app.route("/v1/analytics", createAnalyticsRoutes(ctx.db, ctx.registry));

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -12,8 +12,14 @@ import {
   recordContextOptimizationEvent,
   summarizeContextOptimizationEvents,
 } from "../context/events.js";
+import {
+  evaluateContextQuality,
+  listContextQualityEvents,
+  summarizeContextQualityEvents,
+} from "../context/quality.js";
 import { getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
+import type { ProviderRegistry } from "../providers/index.js";
 
 const MAX_CHUNKS = 200;
 const MAX_CHUNK_CHARS = 100_000;
@@ -61,6 +67,66 @@ function validateScanRisk(value: unknown): { scanRisk?: boolean; error?: string 
   if (value === undefined) return { scanRisk: false };
   if (typeof value !== "boolean") return { error: "scanRisk must be a boolean" };
   return { scanRisk: value };
+}
+
+function validateStringArray(value: unknown, field: string): { values?: string[]; error?: string } {
+  if (value === undefined) return { values: [] };
+  if (!Array.isArray(value)) return { error: `${field} must be an array` };
+  const values: string[] = [];
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      return { error: `${field}[${index}] must be a non-empty string` };
+    }
+    values.push(item);
+  }
+  return { values };
+}
+
+function validateQualityBody(value: unknown): {
+  input?: {
+    prompt: string;
+    rawAnswer: string;
+    optimizedAnswer: string;
+    rawSourceIds: string[];
+    optimizedSourceIds: string[];
+    regressionThreshold?: number;
+  };
+  error?: string;
+} {
+  if (!isRecord(value)) return { error: "body must be an object" };
+  const prompt = value.prompt;
+  const rawAnswer = value.rawAnswer;
+  const optimizedAnswer = value.optimizedAnswer;
+  if (typeof prompt !== "string" || prompt.trim().length === 0) {
+    return { error: "prompt is required" };
+  }
+  if (typeof rawAnswer !== "string" || rawAnswer.trim().length === 0) {
+    return { error: "rawAnswer is required" };
+  }
+  if (typeof optimizedAnswer !== "string" || optimizedAnswer.trim().length === 0) {
+    return { error: "optimizedAnswer is required" };
+  }
+  const rawSourceIds = validateStringArray(value.rawSourceIds, "rawSourceIds");
+  if (!rawSourceIds.values) return { error: rawSourceIds.error };
+  const optimizedSourceIds = validateStringArray(value.optimizedSourceIds, "optimizedSourceIds");
+  if (!optimizedSourceIds.values) return { error: optimizedSourceIds.error };
+  if (
+    value.regressionThreshold !== undefined &&
+    (typeof value.regressionThreshold !== "number" || !Number.isFinite(value.regressionThreshold))
+  ) {
+    return { error: "regressionThreshold must be a number" };
+  }
+
+  return {
+    input: {
+      prompt,
+      rawAnswer,
+      optimizedAnswer,
+      rawSourceIds: rawSourceIds.values,
+      optimizedSourceIds: optimizedSourceIds.values,
+      regressionThreshold: typeof value.regressionThreshold === "number" ? value.regressionThreshold : undefined,
+    },
+  };
 }
 
 function recalculateMetrics(result: ContextOptimizationResult): ContextOptimizationResult {
@@ -124,7 +190,7 @@ async function applyRiskScan(
   });
 }
 
-export function createContextRoutes(db: Db) {
+export function createContextRoutes(db: Db, registry?: ProviderRegistry) {
   const app = new Hono();
 
   app.post("/optimize", async (c) => {
@@ -176,6 +242,56 @@ export function createContextRoutes(db: Db) {
   app.get("/summary", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const summary = await summarizeContextOptimizationEvents(db, tenantId);
+
+    return c.json({ summary });
+  });
+
+  app.post("/evaluate", async (c) => {
+    if (!registry) {
+      return c.json(
+        { error: { message: "Judge registry is not configured", type: "configuration_error" } },
+        503,
+      );
+    }
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateQualityBody(body);
+    if (!parsed.input) {
+      return c.json(
+        { error: { message: parsed.error || "invalid evaluation body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const result = await evaluateContextQuality(db, registry, tenantId, parsed.input);
+      return c.json(result);
+    } catch (err) {
+      return c.json(
+        {
+          error: {
+            message: err instanceof Error ? err.message : "Context quality evaluation failed",
+            type: "judge_error",
+          },
+        },
+        502,
+      );
+    }
+  });
+
+  app.get("/quality/events", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const rawLimit = Number(c.req.query("limit") ?? 25);
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 25;
+    const regressedOnly = c.req.query("regressedOnly") === "true";
+    const events = await listContextQualityEvents(db, tenantId, { limit, regressedOnly });
+
+    return c.json({ events });
+  });
+
+  app.get("/quality/summary", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const summary = await summarizeContextQualityEvents(db, tenantId);
 
     return c.json({ summary });
   });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { contextOptimizationEvents, guardrailRules } from "@provara/db";
+import { contextOptimizationEvents, contextQualityEvents, guardrailRules } from "@provara/db";
+import type { ProviderRegistry } from "../src/providers/index.js";
+import type { CompletionRequest, CompletionResponse, Provider, StreamChunk } from "../src/providers/types.js";
 import { optimizeContextChunks } from "../src/context/optimizer.js";
 import { createContextRoutes } from "../src/routes/context.js";
 import { makeTestDb } from "./_setup/db.js";
@@ -14,10 +16,40 @@ vi.mock("../src/auth/tenant.js", async (importOriginal) => ({
 
 import { requireIntelligenceTier } from "../src/auth/tier.js";
 
-function buildApp(db: Db) {
+function fakeRegistry(content = '{"rawScore": 4, "optimizedScore": 3, "rationale": "Optimized answer omitted one detail."}'): ProviderRegistry {
+  const provider: Provider = {
+    name: "test-judge",
+    models: ["gpt-4o-mini"],
+    async complete(request: CompletionRequest): Promise<CompletionResponse> {
+      return {
+        id: "judge-response",
+        provider: "test-judge",
+      model: request.model,
+        content,
+        finish_reason: "stop",
+        usage: { inputTokens: 10, outputTokens: 8 },
+        latencyMs: 1,
+      };
+    },
+    async *stream(): AsyncIterable<StreamChunk> {
+      yield { content: "", done: true };
+    },
+  };
+  return {
+    get: (name) => (name === provider.name ? provider : undefined),
+    getForModel: (model) => (provider.models.includes(model) ? provider : undefined),
+    list: () => [provider],
+    reload: () => undefined,
+    refreshModels: async () => [{ provider: provider.name, models: provider.models, discovered: false }],
+    addCustom: () => undefined,
+    removeCustom: () => undefined,
+  };
+}
+
+function buildApp(db: Db, registry?: ProviderRegistry) {
   const app = new Hono();
   app.use("/v1/context/*", requireIntelligenceTier(db));
-  app.route("/v1/context", createContextRoutes(db));
+  app.route("/v1/context", createContextRoutes(db, registry));
   return app;
 }
 
@@ -368,5 +400,142 @@ describe("POST /v1/context/optimize", () => {
       type: "validation_error",
       message: "Invalid JSON body",
     });
+  });
+
+  it("evaluates raw-vs-optimized answer quality and records regressions", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db, fakeRegistry());
+
+    const res = await app.request("/v1/context/evaluate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        prompt: "What is the refund window?",
+        rawAnswer: "Refunds are available within 30 days and require a receipt.",
+        optimizedAnswer: "Refunds are available within 30 days.",
+        rawSourceIds: ["refunds#1", "policy#2"],
+        optimizedSourceIds: ["refunds#1"],
+        regressionThreshold: -0.5,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      evaluation: {
+        rawScore: number;
+        optimizedScore: number;
+        delta: number;
+        regressed: boolean;
+        judge: { provider: string; model: string };
+      };
+      event: {
+        tenantId: string;
+        rawScore: number;
+        optimizedScore: number;
+        delta: number;
+        regressed: boolean;
+        promptHash: string;
+        rawSourceIds: string[];
+        optimizedSourceIds: string[];
+      };
+    };
+
+    expect(body.evaluation).toMatchObject({
+      rawScore: 4,
+      optimizedScore: 3,
+      delta: -1,
+      regressed: true,
+      judge: { provider: "test-judge", model: "gpt-4o-mini" },
+    });
+    expect(body.event).toMatchObject({
+      tenantId: "tenant-pro",
+      rawScore: 4,
+      optimizedScore: 3,
+      delta: -1,
+      regressed: true,
+      rawSourceIds: ["refunds#1", "policy#2"],
+      optimizedSourceIds: ["refunds#1"],
+    });
+    expect(body.event.promptHash).toHaveLength(64);
+
+    const rows = await db.select().from(contextQualityEvents).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      tenantId: "tenant-pro",
+      rawScore: 4,
+      optimizedScore: 3,
+      delta: -1,
+      regressed: true,
+      judgeProvider: "test-judge",
+      judgeModel: "gpt-4o-mini",
+    });
+  });
+
+  it("lists and summarizes context quality events by tenant", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db, fakeRegistry('{"rawScore": 4, "optimizedScore": 4.5, "rationale": "No loss."}'));
+
+    await app.request("/v1/context/evaluate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        prompt: "Summarize support hours",
+        rawAnswer: "Support is open 9 to 5.",
+        optimizedAnswer: "Support is open 9 to 5.",
+      }),
+    });
+    await app.request("/v1/context/evaluate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({
+        prompt: "Other tenant",
+        rawAnswer: "Raw",
+        optimizedAnswer: "Optimized",
+      }),
+    });
+
+    const eventsRes = await app.request("/v1/context/quality/events", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(eventsRes.status).toBe(200);
+    const eventsBody = await eventsRes.json() as {
+      events: Array<{ tenantId: string; rawScore: number; optimizedScore: number; delta: number }>;
+    };
+    expect(eventsBody.events).toHaveLength(1);
+    expect(eventsBody.events[0]).toMatchObject({
+      tenantId: "tenant-pro",
+      rawScore: 4,
+      optimizedScore: 4.5,
+      delta: 0.5,
+    });
+
+    const summaryRes = await app.request("/v1/context/quality/summary", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(summaryRes.status).toBe(200);
+    const summaryBody = await summaryRes.json() as {
+      summary: {
+        eventCount: number;
+        regressedCount: number;
+        avgRawScore: number;
+        avgOptimizedScore: number;
+        avgDelta: number;
+        latestAt: string | null;
+      };
+    };
+    expect(summaryBody.summary).toMatchObject({
+      eventCount: 1,
+      regressedCount: 0,
+      avgRawScore: 4,
+      avgOptimizedScore: 4.5,
+      avgDelta: 0.5,
+    });
+    expect(summaryBody.summary.latestAt).toEqual(expect.any(String));
   });
 });

--- a/packages/gateway/tests/demo.test.ts
+++ b/packages/gateway/tests/demo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { auditLogs, contextOptimizationEvents, costLogs, requests, sessions, subscriptions, users } from "@provara/db";
+import { auditLogs, contextOptimizationEvents, contextQualityEvents, costLogs, requests, sessions, subscriptions, users } from "@provara/db";
 import { eq } from "drizzle-orm";
 import { makeTestDb } from "./_setup/db.js";
 import { reseedDemoTenant, DEMO_TENANT_ID } from "../src/demo/seed.js";
@@ -62,6 +62,14 @@ describe("#229 — demo tenant seed", () => {
     expect(contextEvents.reduce((sum, row) => sum + row.quarantinedChunks, 0)).toBe(1);
     expect(JSON.parse(contextEvents[0].duplicateSourceIds)).toEqual(expect.any(Array));
     expect(JSON.parse(contextEvents[0].riskySourceIds)).toEqual(expect.any(Array));
+
+    const qualityEvents = await db
+      .select()
+      .from(contextQualityEvents)
+      .where(eq(contextQualityEvents.tenantId, DEMO_TENANT_ID))
+      .all();
+    expect(qualityEvents).toHaveLength(3);
+    expect(qualityEvents.some((row) => row.regressed)).toBe(true);
   });
 
   it("populates attribution fields on every seeded request", async () => {


### PR DESCRIPTION
## Summary
- add `context_quality_events` persistence and `POST /v1/context/evaluate` for raw-vs-optimized answer scoring
- add quality summary/event APIs and dashboard Quality Loop/Quality Events visibility
- seed demo quality rows and update OpenAPI, docs, roadmap, changelog, and tests

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts tests/demo.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/db/tsconfig.json`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- OpenAPI YAML parse
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `npm test --workspace @provara/web` (19 tests)
- `npm test --workspace @provara/gateway` (633 tests, passed on rerun)
- `git diff --check`

Closes #343

Last-code-by: Codex/GPT-5 (codex)
