### PR TITLE
feat(#345): add context retrieval analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable Provara changes are tracked here.
   - Demo tenant seed data for screenshot-ready Context Optimizer examples.
   - Optional retrieved-context risk scanning with active Guardrails rules, flagged/quarantined result buckets, persisted source IDs, and dashboard risk metrics.
   - Context Optimizer quality loop with `POST /v1/context/evaluate`, persisted `context_quality_events`, demo quality rows, and dashboard quality delta/regression visibility.
+  - Context retrieval analytics with persisted `context_retrieval_events`, retrieval efficiency, unused context, duplicate rate, risky context rate, demo rows, APIs, and dashboard visibility.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
 - Optional semantic and hybrid prompt-injection scan modes using the configured judge model.
@@ -29,7 +30,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, and V1.2 quality scoring as shipped checkpoints, with retrieval analytics as the next planned layer.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, and retrieval analytics as shipped checkpoints, with semantic optimization as the next planned layer.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -44,12 +45,13 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, and quality scoring, run database migrations through `0047_context_quality_events`.
+- For Context Optimizer visibility, risk reporting, quality scoring, and retrieval analytics, run database migrations through `0048_context_retrieval_events`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
   - `context_optimization_events`
   - `context_quality_events`
+  - `context_retrieval_events`
 - Existing tenants keep the safe default firewall settings:
   - `defaultScanMode: "signature"`
   - `toolCallAlignment: "block"`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -67,6 +67,43 @@ export interface ContextQualityEvent {
   createdAt: string;
 }
 
+export interface ContextRetrievalSummary {
+  eventCount: number;
+  retrievedChunks: number;
+  usedChunks: number;
+  unusedChunks: number;
+  duplicateChunks: number;
+  riskyChunks: number;
+  retrievedTokens: number;
+  usedTokens: number;
+  unusedTokens: number;
+  efficiencyPct: number;
+  duplicateRatePct: number;
+  riskyRatePct: number;
+  latestAt: string | null;
+}
+
+export interface ContextRetrievalEvent {
+  id: string;
+  tenantId: string | null;
+  optimizationEventId: string | null;
+  retrievedChunks: number;
+  usedChunks: number;
+  unusedChunks: number;
+  duplicateChunks: number;
+  riskyChunks: number;
+  retrievedTokens: number;
+  usedTokens: number;
+  unusedTokens: number;
+  efficiencyPct: number;
+  duplicateRatePct: number;
+  riskyRatePct: number;
+  usedSourceIds: string[];
+  unusedSourceIds: string[];
+  riskySourceIds: string[];
+  createdAt: string;
+}
+
 interface GateState {
   message: string;
   upgradeUrl?: string;
@@ -77,6 +114,8 @@ interface LoadState {
   events: ContextOptimizationEvent[];
   qualitySummary: ContextQualitySummary | null;
   qualityEvents: ContextQualityEvent[];
+  retrievalSummary: ContextRetrievalSummary | null;
+  retrievalEvents: ContextRetrievalEvent[];
   loading: boolean;
   error: string | null;
   gate: GateState | null;
@@ -164,6 +203,8 @@ export function ContextOptimizerPanel() {
     events: [],
     qualitySummary: null,
     qualityEvents: [],
+    retrievalSummary: null,
+    retrievalEvents: [],
     loading: true,
     error: null,
     gate: null,
@@ -176,21 +217,35 @@ export function ContextOptimizerPanel() {
       setState((prev) => ({ ...prev, loading: true, error: null, gate: null }));
 
       try {
-        const [summaryRes, eventsRes, qualitySummaryRes, qualityEventsRes] = await Promise.all([
+        const [
+          summaryRes,
+          eventsRes,
+          qualitySummaryRes,
+          qualityEventsRes,
+          retrievalSummaryRes,
+          retrievalEventsRes,
+        ] = await Promise.all([
           gatewayFetchRaw("/v1/context/summary"),
           gatewayFetchRaw("/v1/context/events?limit=25"),
           gatewayFetchRaw("/v1/context/quality/summary"),
           gatewayFetchRaw("/v1/context/quality/events?limit=10"),
+          gatewayFetchRaw("/v1/context/retrieval/summary"),
+          gatewayFetchRaw("/v1/context/retrieval/events?limit=10"),
         ]);
 
+        const responses = [
+          summaryRes,
+          eventsRes,
+          qualitySummaryRes,
+          qualityEventsRes,
+          retrievalSummaryRes,
+          retrievalEventsRes,
+        ];
         if (
-          summaryRes.status === 402 ||
-          eventsRes.status === 402 ||
-          qualitySummaryRes.status === 402 ||
-          qualityEventsRes.status === 402
+          responses.some((res) => res.status === 402)
         ) {
           const body = await readJson<{ error?: { message?: string }; gate?: { upgradeUrl?: string } }>(
-            [summaryRes, eventsRes, qualitySummaryRes, qualityEventsRes].find((res) => res.status === 402) ?? summaryRes,
+            responses.find((res) => res.status === 402) ?? summaryRes,
           );
           if (!cancelled) {
             setState({
@@ -198,6 +253,8 @@ export function ContextOptimizerPanel() {
               events: [],
               qualitySummary: null,
               qualityEvents: [],
+              retrievalSummary: null,
+              retrievalEvents: [],
               loading: false,
               error: null,
               gate: {
@@ -209,7 +266,7 @@ export function ContextOptimizerPanel() {
           return;
         }
 
-        if (!summaryRes.ok || !eventsRes.ok || !qualitySummaryRes.ok || !qualityEventsRes.ok) {
+        if (responses.some((res) => !res.ok)) {
           throw new Error("Failed to load Context Optimizer data");
         }
 
@@ -217,6 +274,8 @@ export function ContextOptimizerPanel() {
         const eventsBody = await eventsRes.json() as { events: ContextOptimizationEvent[] };
         const qualitySummaryBody = await qualitySummaryRes.json() as { summary: ContextQualitySummary };
         const qualityEventsBody = await qualityEventsRes.json() as { events: ContextQualityEvent[] };
+        const retrievalSummaryBody = await retrievalSummaryRes.json() as { summary: ContextRetrievalSummary };
+        const retrievalEventsBody = await retrievalEventsRes.json() as { events: ContextRetrievalEvent[] };
 
         if (!cancelled) {
           setState({
@@ -224,6 +283,8 @@ export function ContextOptimizerPanel() {
             events: eventsBody.events,
             qualitySummary: qualitySummaryBody.summary,
             qualityEvents: qualityEventsBody.events,
+            retrievalSummary: retrievalSummaryBody.summary,
+            retrievalEvents: retrievalEventsBody.events,
             loading: false,
             error: null,
             gate: null,
@@ -236,6 +297,8 @@ export function ContextOptimizerPanel() {
             events: [],
             qualitySummary: null,
             qualityEvents: [],
+            retrievalSummary: null,
+            retrievalEvents: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
             gate: null,
@@ -254,6 +317,8 @@ export function ContextOptimizerPanel() {
   const eventRows = useMemo(() => state.events, [state.events]);
   const qualitySummary = state.qualitySummary;
   const qualityRows = useMemo(() => state.qualityEvents, [state.qualityEvents]);
+  const retrievalSummary = state.retrievalSummary;
+  const retrievalRows = useMemo(() => state.retrievalEvents, [state.retrievalEvents]);
 
   return (
     <div className="space-y-6">
@@ -316,6 +381,110 @@ export function ContextOptimizerPanel() {
           tone={metricTone(summary?.reductionPct ?? 0)}
         />
       </div>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Retrieval Analytics</h2>
+          <p className="mt-1 text-sm text-zinc-500">Context usage and retrieval health.</p>
+        </div>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <StatTile
+            label="Retrieval Efficiency"
+            value={formatPercent(retrievalSummary?.efficiencyPct ?? 0)}
+            detail={`${formatInteger(retrievalSummary?.usedChunks ?? 0)} used of ${formatInteger(retrievalSummary?.retrievedChunks ?? 0)} chunks`}
+            tone={metricTone(retrievalSummary?.efficiencyPct ?? 0)}
+          />
+          <StatTile
+            label="Unused Context"
+            value={formatInteger(retrievalSummary?.unusedChunks ?? 0)}
+            detail={`${formatInteger(retrievalSummary?.unusedTokens ?? 0)} unused token estimate`}
+            tone={riskTone(retrievalSummary?.unusedChunks ?? 0)}
+          />
+          <StatTile
+            label="Duplicate Rate"
+            value={formatPercent(retrievalSummary?.duplicateRatePct ?? 0)}
+            detail={`${formatInteger(retrievalSummary?.duplicateChunks ?? 0)} duplicate chunks`}
+            tone={riskTone(retrievalSummary?.duplicateChunks ?? 0)}
+          />
+          <StatTile
+            label="Risky Context Rate"
+            value={formatPercent(retrievalSummary?.riskyRatePct ?? 0)}
+            detail={`${formatInteger(retrievalSummary?.riskyChunks ?? 0)} risky chunks`}
+            tone={riskTone(retrievalSummary?.riskyChunks ?? 0)}
+          />
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Retrieval Events</h2>
+          <p className="mt-1 text-sm text-zinc-500">Recent retrieved-context efficiency records.</p>
+        </div>
+
+        {state.loading ? (
+          <LoadingRows />
+        ) : retrievalRows.length === 0 ? (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center text-sm text-zinc-400">
+            No context retrieval events yet.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">Time</th>
+                    <th className="px-4 py-3 text-right font-medium">Chunks</th>
+                    <th className="px-4 py-3 text-right font-medium">Efficiency</th>
+                    <th className="px-4 py-3 text-right font-medium">Duplicates</th>
+                    <th className="px-4 py-3 text-right font-medium">Risky</th>
+                    <th className="px-4 py-3 text-left font-medium">Unused IDs</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {retrievalRows.map((event) => (
+                    <tr key={event.id}>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{formatTimestamp(event.createdAt)}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(event.usedChunks)} / {formatInteger(event.retrievedChunks)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-emerald-300">
+                        {formatPercent(event.efficiencyPct)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(event.duplicateChunks)}
+                        <span className="ml-2 text-xs text-zinc-500">{formatPercent(event.duplicateRatePct)}</span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-amber-300">
+                        {formatInteger(event.riskyChunks)}
+                        <span className="ml-2 text-xs text-zinc-500">{formatPercent(event.riskyRatePct)}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        {event.unusedSourceIds.length === 0 ? (
+                          <span className="text-zinc-600">None</span>
+                        ) : (
+                          <div className="flex max-w-xl flex-wrap gap-1">
+                            {event.unusedSourceIds.slice(0, 6).map((id) => (
+                              <span key={id} className="rounded border border-zinc-700 bg-zinc-950 px-2 py-0.5 font-mono text-xs text-zinc-300">
+                                {id}
+                              </span>
+                            ))}
+                            {event.unusedSourceIds.length > 6 && (
+                              <span className="rounded border border-zinc-700 bg-zinc-950 px-2 py-0.5 text-xs text-zinc-500">
+                                +{event.unusedSourceIds.length - 6}
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
 
       <section>
         <div className="mb-3">

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -75,6 +75,51 @@ describe("ContextOptimizerPanel", () => {
           ],
         }));
       }
+      if (path === "/v1/context/retrieval/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 2,
+            retrievedChunks: 10,
+            usedChunks: 6,
+            unusedChunks: 4,
+            duplicateChunks: 2,
+            riskyChunks: 1,
+            retrievedTokens: 1000,
+            usedTokens: 620,
+            unusedTokens: 380,
+            efficiencyPct: 62,
+            duplicateRatePct: 20,
+            riskyRatePct: 10,
+            latestAt: "2026-05-01T21:45:00.000Z",
+          },
+        }));
+      }
+      if (path === "/v1/context/retrieval/events?limit=10") {
+        return Promise.resolve(jsonResponse({
+          events: [
+            {
+              id: "retrieval-1",
+              tenantId: "tenant-pro",
+              optimizationEventId: "evt-1",
+              retrievedChunks: 5,
+              usedChunks: 3,
+              unusedChunks: 2,
+              duplicateChunks: 1,
+              riskyChunks: 1,
+              retrievedTokens: 500,
+              usedTokens: 300,
+              unusedTokens: 200,
+              efficiencyPct: 60,
+              duplicateRatePct: 20,
+              riskyRatePct: 20,
+              usedSourceIds: ["chunk-a", "chunk-b", "chunk-c"],
+              unusedSourceIds: ["chunk-c", "chunk-risky"],
+              riskySourceIds: ["chunk-risky"],
+              createdAt: "2026-05-01T21:45:00.000Z",
+            },
+          ],
+        }));
+      }
       return Promise.resolve(jsonResponse({
         events: [
           {
@@ -113,12 +158,15 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("10 input chunks scanned")).toBeInTheDocument();
     expect(screen.getByText("27%")).toBeInTheDocument();
     expect(screen.getByText("chunk-b")).toBeInTheDocument();
-    expect(screen.getByText("chunk-c")).toBeInTheDocument();
+    expect(screen.getAllByText("chunk-c").length).toBeGreaterThan(0);
     expect(screen.getByText("Risky Chunks")).toBeInTheDocument();
-    expect(screen.getByText("chunk-risky")).toBeInTheDocument();
+    expect(screen.getAllByText("chunk-risky").length).toBeGreaterThan(0);
     expect(screen.getByText("Quality Delta")).toBeInTheDocument();
     expect(screen.getByText("Regression")).toBeInTheDocument();
     expect(screen.getByText("refunds#1")).toBeInTheDocument();
+    expect(screen.getByText("Retrieval Efficiency")).toBeInTheDocument();
+    expect(screen.getByText("Unused Context")).toBeInTheDocument();
+    expect(screen.getAllByText("chunk-risky").length).toBeGreaterThan(0);
   });
 
   it("shows the empty state", async () => {
@@ -155,6 +203,28 @@ describe("ContextOptimizerPanel", () => {
       if (path === "/v1/context/quality/events?limit=10") {
         return Promise.resolve(jsonResponse({ events: [] }));
       }
+      if (path === "/v1/context/retrieval/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            retrievedChunks: 0,
+            usedChunks: 0,
+            unusedChunks: 0,
+            duplicateChunks: 0,
+            riskyChunks: 0,
+            retrievedTokens: 0,
+            usedTokens: 0,
+            unusedTokens: 0,
+            efficiencyPct: 0,
+            duplicateRatePct: 0,
+            riskyRatePct: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/retrieval/events?limit=10") {
+        return Promise.resolve(jsonResponse({ events: [] }));
+      }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
 
@@ -162,6 +232,7 @@ describe("ContextOptimizerPanel", () => {
 
     expect(await screen.findByText("No context optimization events yet.")).toBeInTheDocument();
     expect(screen.getByText("No context quality checks yet.")).toBeInTheDocument();
+    expect(screen.getByText("No context retrieval events yet.")).toBeInTheDocument();
   });
 
   it("shows upgrade messaging for gated tenants", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -18,9 +18,10 @@ Implemented as of `0.2.0`:
 - Flagged and quarantined context reporting in API events and the dashboard.
 - Raw-context vs optimized-context judge scoring through `POST /v1/context/evaluate`.
 - `context_quality_events` with quality deltas, regression flags, source IDs, judge metadata, and dashboard visibility.
+- `context_retrieval_events` with retrieval efficiency, unused context, duplicate rate, risky context rate, source IDs, and dashboard visibility.
 
 Next planned layer:
-- Retrieval analytics for unused, duplicate, stale, and conflicting context.
+- Semantic optimization for near duplicates, relevance scoring, reranking, stale context, and conflicting context.
 
 ## V1: Runtime Context Optimizer
 
@@ -47,6 +48,7 @@ Capabilities:
 - Context savings analytics.
 - Duplicate-rate reporting.
 - Quarantined context reporting.
+- Retrieval efficiency and unused-context reporting. Shipped in V1.2.
 - Request-detail integration.
 - Dashboard cards for saved tokens, dropped chunks, reduction, and risk flags.
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -12,6 +12,7 @@ The shipped V1 implementation is intentionally narrow:
 - Optional risk scanning with active Guardrails rules for retrieved context.
 - Flagged and quarantined context buckets with rule evidence and source IDs.
 - Raw-context vs optimized-context quality scoring with the configured judge model.
+- Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 
@@ -54,6 +55,7 @@ The response includes:
 - `optimization.quarantined`: risky chunks removed from model context before provider routing.
 - `optimization.metrics`: input/output chunk counts, estimated tokens, saved tokens, and reduction percentage.
 - `event`: the persisted visibility record for the optimization call.
+- `retrieval`: the persisted retrieval analytics record with efficiency, unused context, duplicate rate, and risky context rate.
 
 `scanRisk` defaults to `false` for backwards compatibility. When enabled, Provara uses active Guardrails rules against the `retrieved_context` surface after duplicate removal. `flag` and `redact` actions become flagged context; `block` actions become quarantined context.
 
@@ -64,6 +66,8 @@ GET /v1/context/summary
 GET /v1/context/events
 GET /v1/context/quality/summary
 GET /v1/context/quality/events
+GET /v1/context/retrieval/summary
+GET /v1/context/retrieval/events
 ```
 
 These endpoints are tenant-scoped and require Intelligence access.
@@ -122,14 +126,22 @@ The Quality Loop section shows:
 - Number of checks below the configured regression threshold.
 - Recent quality events with raw score, optimized score, delta, status, source IDs, and judge target.
 
+The Retrieval Analytics section shows:
+
+- Retrieval efficiency: used context divided by retrieved context.
+- Unused context count and token estimate.
+- Duplicate rate.
+- Risky context rate.
+- Recent retrieval events with used/retrieved chunks, duplicate/risky counts, and unused source IDs.
+
 ## Demo Mode
 
 The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This keeps `/dashboard/context` useful for demos, screenshots, and product walkthroughs without requiring a live RAG integration.
 
 ## Next Roadmap Step
 
-The next behavior layer is retrieval analytics:
+The next behavior layer is semantic optimization:
 
-- Measure unused, duplicate, stale, and conflicting context rates.
-- Recommend source cleanup and retrieval tuning.
-- Feed quality deltas into alerting and evaluation workflows.
+- Near-duplicate and semantic duplicate detection.
+- Relevance scoring and reranking.
+- Stale and conflicting context detection.

--- a/packages/db/drizzle/0048_context_retrieval_events.sql
+++ b/packages/db/drizzle/0048_context_retrieval_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `context_retrieval_events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`tenant_id` text,
+	`optimization_event_id` text,
+	`retrieved_chunks` integer NOT NULL,
+	`used_chunks` integer NOT NULL,
+	`unused_chunks` integer NOT NULL,
+	`duplicate_chunks` integer NOT NULL,
+	`risky_chunks` integer NOT NULL,
+	`retrieved_tokens` integer NOT NULL,
+	`used_tokens` integer NOT NULL,
+	`unused_tokens` integer NOT NULL,
+	`efficiency_pct` real NOT NULL,
+	`duplicate_rate_pct` real NOT NULL,
+	`risky_rate_pct` real NOT NULL,
+	`used_source_ids` text DEFAULT '[]' NOT NULL,
+	`unused_source_ids` text DEFAULT '[]' NOT NULL,
+	`risky_source_ids` text DEFAULT '[]' NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `context_retrieval_events_tenant_created_idx` ON `context_retrieval_events` (`tenant_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `context_retrieval_events_optimization_idx` ON `context_retrieval_events` (`optimization_event_id`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1777656000000,
       "tag": "0047_context_quality_events",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1777658100000,
+      "tag": "0048_context_retrieval_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -368,6 +368,32 @@ export const contextQualityEvents = sqliteTable("context_quality_events", {
   index("context_quality_events_tenant_regressed_idx").on(table.tenantId, table.regressed, table.createdAt),
 ]);
 
+export const contextRetrievalEvents = sqliteTable("context_retrieval_events", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  optimizationEventId: text("optimization_event_id"),
+  retrievedChunks: integer("retrieved_chunks").notNull(),
+  usedChunks: integer("used_chunks").notNull(),
+  unusedChunks: integer("unused_chunks").notNull(),
+  duplicateChunks: integer("duplicate_chunks").notNull(),
+  riskyChunks: integer("risky_chunks").notNull(),
+  retrievedTokens: integer("retrieved_tokens").notNull(),
+  usedTokens: integer("used_tokens").notNull(),
+  unusedTokens: integer("unused_tokens").notNull(),
+  efficiencyPct: real("efficiency_pct").notNull(),
+  duplicateRatePct: real("duplicate_rate_pct").notNull(),
+  riskyRatePct: real("risky_rate_pct").notNull(),
+  usedSourceIds: text("used_source_ids").notNull().default("[]"),
+  unusedSourceIds: text("unused_source_ids").notNull().default("[]"),
+  riskySourceIds: text("risky_source_ids").notNull().default("[]"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_retrieval_events_tenant_created_idx").on(table.tenantId, table.createdAt),
+  index("context_retrieval_events_optimization_idx").on(table.optimizationEventId),
+]);
+
 export const alertRules = sqliteTable("alert_rules", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -426,12 +426,14 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [optimization, event]
+                required: [optimization, event, retrieval]
                 properties:
                   optimization:
                     $ref: "#/components/schemas/ContextOptimizationResult"
                   event:
                     $ref: "#/components/schemas/ContextOptimizationEvent"
+                  retrieval:
+                    $ref: "#/components/schemas/ContextRetrievalEvent"
         "400":
           $ref: "#/components/responses/ValidationError"
         "402":
@@ -569,6 +571,53 @@ paths:
                 properties:
                   summary:
                     $ref: "#/components/schemas/ContextQualitySummary"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
+  /v1/context/retrieval/events:
+    get:
+      tags: [Context Optimizer]
+      summary: List recent context retrieval analytics events
+      operationId: listContextRetrievalEvents
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Recent retrieval events
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [events]
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextRetrievalEvent"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
+  /v1/context/retrieval/summary:
+    get:
+      tags: [Context Optimizer]
+      summary: Summarize context retrieval analytics
+      operationId: summarizeContextRetrieval
+      responses:
+        "200":
+          description: Aggregate retrieval summary
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [summary]
+                properties:
+                  summary:
+                    $ref: "#/components/schemas/ContextRetrievalSummary"
         "402":
           $ref: "#/components/responses/InsufficientTier"
 
@@ -2356,6 +2405,120 @@ components:
         avgDelta:
           type: number
           nullable: true
+        latestAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    ContextRetrievalEvent:
+      type: object
+      required:
+        - id
+        - tenantId
+        - optimizationEventId
+        - retrievedChunks
+        - usedChunks
+        - unusedChunks
+        - duplicateChunks
+        - riskyChunks
+        - retrievedTokens
+        - usedTokens
+        - unusedTokens
+        - efficiencyPct
+        - duplicateRatePct
+        - riskyRatePct
+        - usedSourceIds
+        - unusedSourceIds
+        - riskySourceIds
+        - createdAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        optimizationEventId:
+          type: string
+          nullable: true
+        retrievedChunks:
+          type: integer
+        usedChunks:
+          type: integer
+        unusedChunks:
+          type: integer
+        duplicateChunks:
+          type: integer
+        riskyChunks:
+          type: integer
+        retrievedTokens:
+          type: integer
+        usedTokens:
+          type: integer
+        unusedTokens:
+          type: integer
+        efficiencyPct:
+          type: number
+        duplicateRatePct:
+          type: number
+        riskyRatePct:
+          type: number
+        usedSourceIds:
+          type: array
+          items:
+            type: string
+        unusedSourceIds:
+          type: array
+          items:
+            type: string
+        riskySourceIds:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    ContextRetrievalSummary:
+      type: object
+      required:
+        - eventCount
+        - retrievedChunks
+        - usedChunks
+        - unusedChunks
+        - duplicateChunks
+        - riskyChunks
+        - retrievedTokens
+        - usedTokens
+        - unusedTokens
+        - efficiencyPct
+        - duplicateRatePct
+        - riskyRatePct
+        - latestAt
+      properties:
+        eventCount:
+          type: integer
+        retrievedChunks:
+          type: integer
+        usedChunks:
+          type: integer
+        unusedChunks:
+          type: integer
+        duplicateChunks:
+          type: integer
+        riskyChunks:
+          type: integer
+        retrievedTokens:
+          type: integer
+        usedTokens:
+          type: integer
+        unusedTokens:
+          type: integer
+        efficiencyPct:
+          type: number
+        duplicateRatePct:
+          type: number
+        riskyRatePct:
+          type: number
         latestAt:
           type: string
           format: date-time

--- a/packages/gateway/src/context/retrieval.ts
+++ b/packages/gateway/src/context/retrieval.ts
@@ -1,0 +1,180 @@
+import type { Db } from "@provara/db";
+import { contextRetrievalEvents } from "@provara/db";
+import { desc, eq, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { tenantFilter } from "../auth/tenant.js";
+import type { ContextOptimizationResult } from "./optimizer.js";
+
+export interface ContextRetrievalEvent {
+  id: string;
+  tenantId: string | null;
+  optimizationEventId: string | null;
+  retrievedChunks: number;
+  usedChunks: number;
+  unusedChunks: number;
+  duplicateChunks: number;
+  riskyChunks: number;
+  retrievedTokens: number;
+  usedTokens: number;
+  unusedTokens: number;
+  efficiencyPct: number;
+  duplicateRatePct: number;
+  riskyRatePct: number;
+  usedSourceIds: string[];
+  unusedSourceIds: string[];
+  riskySourceIds: string[];
+  createdAt: Date;
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function pct(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0;
+  return Number(((numerator / denominator) * 100).toFixed(2));
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function eventFromRow(row: typeof contextRetrievalEvents.$inferSelect): ContextRetrievalEvent {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    optimizationEventId: row.optimizationEventId,
+    retrievedChunks: row.retrievedChunks,
+    usedChunks: row.usedChunks,
+    unusedChunks: row.unusedChunks,
+    duplicateChunks: row.duplicateChunks,
+    riskyChunks: row.riskyChunks,
+    retrievedTokens: row.retrievedTokens,
+    usedTokens: row.usedTokens,
+    unusedTokens: row.unusedTokens,
+    efficiencyPct: row.efficiencyPct,
+    duplicateRatePct: row.duplicateRatePct,
+    riskyRatePct: row.riskyRatePct,
+    usedSourceIds: parseStringArray(row.usedSourceIds),
+    unusedSourceIds: parseStringArray(row.unusedSourceIds),
+    riskySourceIds: parseStringArray(row.riskySourceIds),
+    createdAt: row.createdAt,
+  };
+}
+
+export async function recordContextRetrievalEvent(
+  db: Db,
+  tenantId: string | null,
+  result: ContextOptimizationResult,
+  options: { optimizationEventId?: string | null } = {},
+): Promise<ContextRetrievalEvent> {
+  const riskyChunks = [...result.flagged, ...result.quarantined];
+  const usedSourceIds = unique(result.optimized.map((chunk) => chunk.id));
+  const riskySourceIds = unique(riskyChunks.flatMap((chunk) => chunk.sourceIds));
+  const unusedSourceIds = unique([
+    ...result.dropped.map((chunk) => chunk.id),
+    ...riskySourceIds,
+  ]);
+  const retrievedChunks = result.metrics.inputChunks;
+  const usedChunks = result.metrics.outputChunks;
+  const unusedChunks = Math.max(0, retrievedChunks - usedChunks);
+  const duplicateChunks = result.metrics.droppedChunks;
+  const riskyChunkCount = result.metrics.flaggedChunks + result.metrics.quarantinedChunks;
+  const retrievedTokens = result.metrics.inputTokens;
+  const usedTokens = result.metrics.outputTokens;
+  const unusedTokens = Math.max(0, retrievedTokens - usedTokens);
+  const id = nanoid();
+
+  await db.insert(contextRetrievalEvents).values({
+    id,
+    tenantId,
+    optimizationEventId: options.optimizationEventId ?? null,
+    retrievedChunks,
+    usedChunks,
+    unusedChunks,
+    duplicateChunks,
+    riskyChunks: riskyChunkCount,
+    retrievedTokens,
+    usedTokens,
+    unusedTokens,
+    efficiencyPct: pct(usedTokens, retrievedTokens),
+    duplicateRatePct: pct(duplicateChunks, retrievedChunks),
+    riskyRatePct: pct(riskyChunkCount, retrievedChunks),
+    usedSourceIds: JSON.stringify(usedSourceIds),
+    unusedSourceIds: JSON.stringify(unusedSourceIds),
+    riskySourceIds: JSON.stringify(riskySourceIds),
+  }).run();
+
+  const row = await db.select().from(contextRetrievalEvents).where(eq(contextRetrievalEvents.id, id)).get();
+  if (!row) throw new Error("Failed to record context retrieval event");
+  return eventFromRow(row);
+}
+
+export async function listContextRetrievalEvents(
+  db: Db,
+  tenantId: string | null,
+  options: { limit?: number } = {},
+): Promise<ContextRetrievalEvent[]> {
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 25)));
+  const rows = await db
+    .select()
+    .from(contextRetrievalEvents)
+    .where(tenantFilter(contextRetrievalEvents.tenantId, tenantId))
+    .orderBy(desc(contextRetrievalEvents.createdAt))
+    .limit(limit)
+    .all();
+
+  return rows.map(eventFromRow);
+}
+
+export async function summarizeContextRetrievalEvents(db: Db, tenantId: string | null) {
+  const whereClause = tenantFilter(contextRetrievalEvents.tenantId, tenantId);
+  const row = await db
+    .select({
+      eventCount: sql<number>`count(*)`,
+      retrievedChunks: sql<number>`coalesce(sum(${contextRetrievalEvents.retrievedChunks}), 0)`,
+      usedChunks: sql<number>`coalesce(sum(${contextRetrievalEvents.usedChunks}), 0)`,
+      unusedChunks: sql<number>`coalesce(sum(${contextRetrievalEvents.unusedChunks}), 0)`,
+      duplicateChunks: sql<number>`coalesce(sum(${contextRetrievalEvents.duplicateChunks}), 0)`,
+      riskyChunks: sql<number>`coalesce(sum(${contextRetrievalEvents.riskyChunks}), 0)`,
+      retrievedTokens: sql<number>`coalesce(sum(${contextRetrievalEvents.retrievedTokens}), 0)`,
+      usedTokens: sql<number>`coalesce(sum(${contextRetrievalEvents.usedTokens}), 0)`,
+      unusedTokens: sql<number>`coalesce(sum(${contextRetrievalEvents.unusedTokens}), 0)`,
+    })
+    .from(contextRetrievalEvents)
+    .where(whereClause)
+    .get();
+
+  const retrievedChunks = row?.retrievedChunks ?? 0;
+  const retrievedTokens = row?.retrievedTokens ?? 0;
+  const usedTokens = row?.usedTokens ?? 0;
+  const latestRow = await db
+    .select({ createdAt: contextRetrievalEvents.createdAt })
+    .from(contextRetrievalEvents)
+    .where(whereClause)
+    .orderBy(desc(contextRetrievalEvents.createdAt))
+    .limit(1)
+    .get();
+
+  return {
+    eventCount: row?.eventCount ?? 0,
+    retrievedChunks,
+    usedChunks: row?.usedChunks ?? 0,
+    unusedChunks: row?.unusedChunks ?? 0,
+    duplicateChunks: row?.duplicateChunks ?? 0,
+    riskyChunks: row?.riskyChunks ?? 0,
+    retrievedTokens,
+    usedTokens,
+    unusedTokens: row?.unusedTokens ?? 0,
+    efficiencyPct: pct(usedTokens, retrievedTokens),
+    duplicateRatePct: pct(row?.duplicateChunks ?? 0, retrievedChunks),
+    riskyRatePct: pct(row?.riskyChunks ?? 0, retrievedChunks),
+    latestAt: latestRow?.createdAt ?? null,
+  };
+}

--- a/packages/gateway/src/demo/seed.ts
+++ b/packages/gateway/src/demo/seed.ts
@@ -11,6 +11,7 @@ import {
   costMigrations,
   contextOptimizationEvents,
   contextQualityEvents,
+  contextRetrievalEvents,
   customProviders,
   feedback,
   guardrailLogs,
@@ -723,6 +724,34 @@ export async function reseedDemoTenant(db: Db, now: Date = new Date()): Promise<
     }).run();
   }
 
+  for (const event of contextEvents) {
+    const riskyChunks = event.flaggedChunks + event.quarantinedChunks;
+    const usedSourceIds = event.duplicateSourceIds.length === 0
+      ? [`${event.id}#used`]
+      : event.duplicateSourceIds.slice(0, Math.max(1, Math.min(4, event.outputChunks)));
+    const unusedSourceIds = [...event.duplicateSourceIds, ...event.riskySourceIds];
+    await db.insert(contextRetrievalEvents).values({
+      id: `cre_${event.id.replace(/^coe_/, "")}`,
+      tenantId,
+      optimizationEventId: event.id,
+      retrievedChunks: event.inputChunks,
+      usedChunks: event.outputChunks,
+      unusedChunks: event.inputChunks - event.outputChunks,
+      duplicateChunks: event.droppedChunks,
+      riskyChunks,
+      retrievedTokens: event.inputTokens,
+      usedTokens: event.outputTokens,
+      unusedTokens: event.savedTokens,
+      efficiencyPct: Number(((event.outputTokens / event.inputTokens) * 100).toFixed(2)),
+      duplicateRatePct: Number(((event.droppedChunks / event.inputChunks) * 100).toFixed(2)),
+      riskyRatePct: Number(((riskyChunks / event.inputChunks) * 100).toFixed(2)),
+      usedSourceIds: JSON.stringify(usedSourceIds),
+      unusedSourceIds: JSON.stringify(unusedSourceIds),
+      riskySourceIds: JSON.stringify(event.riskySourceIds),
+      createdAt: event.createdAt,
+    }).run();
+  }
+
   const contextQualityRows = [
     {
       id: "cqe_demo_refunds_stable",
@@ -811,6 +840,7 @@ async function wipe(db: Db, tenantId: string): Promise<void> {
   await db.delete(routingWeightSnapshots).where(eq(routingWeightSnapshots.tenantId, tenantId)).run();
   await db.delete(spendBudgets).where(eq(spendBudgets.tenantId, tenantId)).run();
   await db.delete(costMigrations).where(eq(costMigrations.tenantId, tenantId)).run();
+  await db.delete(contextRetrievalEvents).where(eq(contextRetrievalEvents.tenantId, tenantId)).run();
   await db.delete(contextQualityEvents).where(eq(contextQualityEvents.tenantId, tenantId)).run();
   await db.delete(contextOptimizationEvents).where(eq(contextOptimizationEvents.tenantId, tenantId)).run();
   await db.delete(customProviders).where(eq(customProviders.tenantId, tenantId)).run();

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -17,6 +17,11 @@ import {
   listContextQualityEvents,
   summarizeContextQualityEvents,
 } from "../context/quality.js";
+import {
+  listContextRetrievalEvents,
+  recordContextRetrievalEvent,
+  summarizeContextRetrievalEvents,
+} from "../context/retrieval.js";
 import { getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
@@ -226,8 +231,11 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry) {
     const event = await recordContextOptimizationEvent(db, tenantId, optimization, {
       riskScanned: scanRisk.scanRisk ?? false,
     });
+    const retrieval = await recordContextRetrievalEvent(db, tenantId, optimization, {
+      optimizationEventId: event.id,
+    });
 
-    return c.json({ optimization, event });
+    return c.json({ optimization, event, retrieval });
   });
 
   app.get("/events", async (c) => {
@@ -292,6 +300,22 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry) {
   app.get("/quality/summary", async (c) => {
     const tenantId = getTenantId(c.req.raw);
     const summary = await summarizeContextQualityEvents(db, tenantId);
+
+    return c.json({ summary });
+  });
+
+  app.get("/retrieval/events", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const rawLimit = Number(c.req.query("limit") ?? 25);
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 25;
+    const events = await listContextRetrievalEvents(db, tenantId, { limit });
+
+    return c.json({ events });
+  });
+
+  app.get("/retrieval/summary", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const summary = await summarizeContextRetrievalEvents(db, tenantId);
 
     return c.json({ summary });
   });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { contextOptimizationEvents, contextQualityEvents, guardrailRules } from "@provara/db";
+import { contextOptimizationEvents, contextQualityEvents, contextRetrievalEvents, guardrailRules } from "@provara/db";
 import type { ProviderRegistry } from "../src/providers/index.js";
 import type { CompletionRequest, CompletionResponse, Provider, StreamChunk } from "../src/providers/types.js";
 import { optimizeContextChunks } from "../src/context/optimizer.js";
@@ -24,7 +24,7 @@ function fakeRegistry(content = '{"rawScore": 4, "optimizedScore": 3, "rationale
       return {
         id: "judge-response",
         provider: "test-judge",
-      model: request.model,
+        model: request.model,
         content,
         finish_reason: "stop",
         usage: { inputTokens: 10, outputTokens: 8 },
@@ -160,6 +160,15 @@ describe("POST /v1/context/optimize", () => {
         savedTokens: number;
         duplicateSourceIds: string[];
       };
+      retrieval: {
+        retrievedChunks: number;
+        usedChunks: number;
+        unusedChunks: number;
+        duplicateChunks: number;
+        riskyChunks: number;
+        usedSourceIds: string[];
+        unusedSourceIds: string[];
+      };
     };
     expect(body.optimization.optimized).toHaveLength(2);
     expect(body.optimization.optimized[0]).toMatchObject({
@@ -178,6 +187,15 @@ describe("POST /v1/context/optimize", () => {
       droppedChunks: 1,
       duplicateSourceIds: ["b"],
     });
+    expect(body.retrieval).toMatchObject({
+      retrievedChunks: 3,
+      usedChunks: 2,
+      unusedChunks: 1,
+      duplicateChunks: 1,
+      riskyChunks: 0,
+      usedSourceIds: ["a", "c"],
+      unusedSourceIds: ["b"],
+    });
 
     const rows = await db.select().from(contextOptimizationEvents).all();
     expect(rows).toHaveLength(1);
@@ -186,6 +204,16 @@ describe("POST /v1/context/optimize", () => {
       inputChunks: 3,
       outputChunks: 2,
       droppedChunks: 1,
+    });
+    const retrievalRows = await db.select().from(contextRetrievalEvents).all();
+    expect(retrievalRows).toHaveLength(1);
+    expect(retrievalRows[0]).toMatchObject({
+      tenantId: "tenant-pro",
+      retrievedChunks: 3,
+      usedChunks: 2,
+      unusedChunks: 1,
+      duplicateChunks: 1,
+      riskyChunks: 0,
     });
   });
 
@@ -243,6 +271,14 @@ describe("POST /v1/context/optimize", () => {
         riskySourceIds: string[];
         riskDetails: Array<{ id: string; decision: string; ruleName: string }>;
       };
+      retrieval: {
+        retrievedChunks: number;
+        usedChunks: number;
+        unusedChunks: number;
+        duplicateChunks: number;
+        riskyChunks: number;
+        riskySourceIds: string[];
+      };
     };
 
     expect(body.optimization.optimized).toEqual([expect.objectContaining({ id: "safe" })]);
@@ -277,6 +313,14 @@ describe("POST /v1/context/optimize", () => {
         ruleName: "Context injection",
       }),
     ]);
+    expect(body.retrieval).toMatchObject({
+      retrievedChunks: 3,
+      usedChunks: 1,
+      unusedChunks: 2,
+      duplicateChunks: 1,
+      riskyChunks: 1,
+      riskySourceIds: ["risky"],
+    });
 
     const rows = await db.select().from(contextOptimizationEvents).all();
     expect(rows[0]).toMatchObject({
@@ -358,6 +402,50 @@ describe("POST /v1/context/optimize", () => {
     expect(summaryBody.summary.savedTokens).toBeGreaterThan(0);
     expect(summaryBody.summary.reductionPct).toBeGreaterThan(0);
     expect(summaryBody.summary.latestAt).toEqual(expect.any(String));
+
+    const retrievalEventsRes = await app.request("/v1/context/retrieval/events", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(retrievalEventsRes.status).toBe(200);
+    const retrievalEventsBody = await retrievalEventsRes.json() as {
+      events: Array<{ tenantId: string; retrievedChunks: number; usedChunks: number; duplicateChunks: number }>;
+    };
+    expect(retrievalEventsBody.events).toHaveLength(1);
+    expect(retrievalEventsBody.events[0]).toMatchObject({
+      tenantId: "tenant-pro",
+      retrievedChunks: 3,
+      usedChunks: 2,
+      duplicateChunks: 1,
+    });
+
+    const retrievalSummaryRes = await app.request("/v1/context/retrieval/summary", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(retrievalSummaryRes.status).toBe(200);
+    const retrievalSummaryBody = await retrievalSummaryRes.json() as {
+      summary: {
+        eventCount: number;
+        retrievedChunks: number;
+        usedChunks: number;
+        unusedChunks: number;
+        duplicateChunks: number;
+        riskyChunks: number;
+        efficiencyPct: number;
+        duplicateRatePct: number;
+        riskyRatePct: number;
+      };
+    };
+    expect(retrievalSummaryBody.summary).toMatchObject({
+      eventCount: 1,
+      retrievedChunks: 3,
+      usedChunks: 2,
+      unusedChunks: 1,
+      duplicateChunks: 1,
+      riskyChunks: 0,
+    });
+    expect(retrievalSummaryBody.summary.efficiencyPct).toBeGreaterThan(0);
+    expect(retrievalSummaryBody.summary.duplicateRatePct).toBeGreaterThan(0);
+    expect(retrievalSummaryBody.summary.riskyRatePct).toBe(0);
   });
 
   it("validates chunks", async () => {

--- a/packages/gateway/tests/demo.test.ts
+++ b/packages/gateway/tests/demo.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { auditLogs, contextOptimizationEvents, contextQualityEvents, costLogs, requests, sessions, subscriptions, users } from "@provara/db";
+import { auditLogs, contextOptimizationEvents, contextQualityEvents, contextRetrievalEvents, costLogs, requests, sessions, subscriptions, users } from "@provara/db";
 import { eq } from "drizzle-orm";
 import { makeTestDb } from "./_setup/db.js";
 import { reseedDemoTenant, DEMO_TENANT_ID } from "../src/demo/seed.js";
@@ -70,6 +70,15 @@ describe("#229 — demo tenant seed", () => {
       .all();
     expect(qualityEvents).toHaveLength(3);
     expect(qualityEvents.some((row) => row.regressed)).toBe(true);
+
+    const retrievalEvents = await db
+      .select()
+      .from(contextRetrievalEvents)
+      .where(eq(contextRetrievalEvents.tenantId, DEMO_TENANT_ID))
+      .all();
+    expect(retrievalEvents).toHaveLength(4);
+    expect(retrievalEvents.reduce((sum, row) => sum + row.unusedChunks, 0)).toBeGreaterThan(0);
+    expect(JSON.parse(retrievalEvents[0].unusedSourceIds)).toEqual(expect.any(Array));
   });
 
   it("populates attribution fields on every seeded request", async () => {


### PR DESCRIPTION
## Summary
- add `context_retrieval_events` persistence plus tenant-scoped retrieval summary and event APIs
- record retrieval analytics from `POST /v1/context/optimize` without storing full context content
- surface retrieval efficiency, unused context, duplicate rate, risky context rate, and recent retrieval events in the Context Optimizer dashboard
- update demo seed data, OpenAPI, docs, roadmap, changelog, and focused tests

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts tests/demo.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npm test --workspace @provara/web`
- `npm test --workspace @provara/gateway`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- OpenAPI YAML parse
- `git diff --check`

Closes #345

Last-code-by: Codex/GPT-5 (codex)
