### PR TITLE
feat(#357): add embedding context relevance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable Provara changes are tracked here.
   - Context retrieval analytics with persisted `context_retrieval_events`, retrieval efficiency, unused context, duplicate rate, risky context rate, demo rows, APIs, and dashboard visibility.
   - Context Optimizer semantic near-duplicate mode with `dedupeMode: "semantic"`, configurable similarity threshold, separate near-duplicate source IDs/rates, demo rows, APIs, and dashboard visibility.
   - Context Optimizer lexical relevance mode with `rankMode: "lexical"`, query-scored stable reranking, low-relevance/reranked metrics, demo rows, APIs, and dashboard visibility.
+  - Context Optimizer embedding relevance mode with `rankMode: "embedding"`, cosine-similarity reranking through the configured embedding provider, and lexical fallback when embeddings are unavailable.
   - Context Optimizer stale-context detection with `freshnessMode: "metadata"`, freshness/stale metrics from bounded metadata parsing, demo rows, APIs, and dashboard visibility.
   - Context Optimizer conflicting-context detection with `conflictMode: "heuristic"`, bounded status/numeric/metadata checks, conflict metrics, demo rows, APIs, and dashboard visibility.
   - Context Optimizer extractive compression with `compressionMode: "extractive"`, bounded sentence selection, compression savings metrics, demo rows, APIs, and dashboard visibility.
@@ -35,7 +36,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, stale-context detection, conflicting-context detection, and extractive compression as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, and extractive compression as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -21,12 +21,13 @@ Implemented as of `0.2.0`:
 - `context_retrieval_events` with retrieval efficiency, unused context, duplicate rate, risky context rate, source IDs, and dashboard visibility.
 - Optional semantic near-duplicate detection with separate near-duplicate event, summary, retrieval, and dashboard metrics.
 - Optional lexical relevance scoring and stable reranking with aggregate relevance metrics and dashboard visibility.
+- Optional embedding-backed relevance scoring and reranking with lexical fallback.
 - Optional stale-context detection from freshness metadata with aggregate freshness metrics and dashboard visibility.
 - Optional conflicting-context detection with bounded heuristic status/numeric/metadata checks and dashboard visibility.
 - Optional extractive compression with bounded sentence selection, compression savings metrics, and dashboard visibility.
 
 Next planned layer:
-- Embedding-backed relevance, contradiction scoring, and abstractive compression.
+- Contradiction scoring and abstractive compression.
 
 ## V1: Runtime Context Optimizer
 
@@ -36,6 +37,7 @@ Core capabilities:
 - Exact duplicate removal.
 - Optional semantic near-duplicate removal through deterministic token similarity.
 - Optional lexical relevance scoring and reranking.
+- Optional embedding-backed relevance scoring and reranking.
 - Optional freshness scoring from chunk metadata.
 - Optional conflict detection across retained chunks.
 - Optional extractive compression for retained chunks.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -9,6 +9,7 @@ The shipped V1 implementation is intentionally narrow:
 - Exact duplicate detection after whitespace normalization and case folding.
 - Optional semantic near-duplicate detection with deterministic token similarity.
 - Optional lexical relevance scoring and reranking for retained chunks.
+- Optional embedding-backed relevance scoring and reranking with lexical fallback.
 - Optional stale-context detection from bounded freshness metadata.
 - Optional conflicting-context detection with bounded heuristic claim checks.
 - Optional extractive compression with bounded sentence selection.
@@ -37,7 +38,7 @@ The request accepts already-retrieved context chunks:
 {
   "dedupeMode": "semantic",
   "semanticThreshold": 0.72,
-  "rankMode": "lexical",
+  "rankMode": "embedding",
   "query": "What is the refund window?",
   "minRelevanceScore": 0.2,
   "freshnessMode": "metadata",
@@ -78,7 +79,7 @@ The response includes:
 
 `dedupeMode` defaults to `exact` for backwards compatibility. Set `dedupeMode` to `semantic` to also remove near duplicates using deterministic token overlap scoring. `semanticThreshold` defaults to `0.72` and accepts values from `0.5` to `1`.
 
-`rankMode` defaults to `none`. Set `rankMode` to `lexical` and provide `query` to score retained chunks with deterministic token matching and stable reranking. Provara caps query tokens internally, stores aggregate relevance metrics only, and does not persist the query text. `minRelevanceScore` defaults to `0.2` and controls the low-relevance chunk count.
+`rankMode` defaults to `none`. Set `rankMode` to `lexical` and provide `query` to score retained chunks with deterministic token matching and stable reranking. Set `rankMode` to `embedding` to score retained chunks by cosine similarity against the configured embedding provider. Embedding scoring bounds input text, batches chunk embeddings, stores aggregate relevance metrics only, and falls back to lexical scoring if embeddings are unavailable or fail. Provara does not persist the query text. `minRelevanceScore` defaults to `0.2` and controls the low-relevance chunk count.
 
 `freshnessMode` defaults to `off`. Set `freshnessMode` to `metadata` to score retained chunks from bounded freshness metadata. Provara checks common fields such as `updatedAt`, `lastModified`, `publishedAt`, and `expiresAt`, stores aggregate freshness metrics only, and does not persist the full metadata payload. `maxContextAgeDays` defaults to `180`.
 
@@ -177,5 +178,5 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 The next behavior layer is retrieval quality:
 
-- Stale and conflicting context detection.
-- Embedding-backed relevance scoring.
+- Stronger contradiction scoring beyond bounded heuristic checks.
+- Abstractive compression with strict provenance and fallback behavior.

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -2103,19 +2103,19 @@ components:
           description: Similarity threshold used when dedupeMode is semantic.
         rankMode:
           type: string
-          enum: [none, lexical]
+          enum: [none, lexical, embedding]
           default: none
-          description: Lexical mode scores and reranks retained chunks against query with deterministic local token matching.
+          description: Lexical mode scores retained chunks with deterministic local token matching. Embedding mode scores retained chunks with the configured embedding provider and falls back to lexical scoring when embeddings are unavailable.
         query:
           type: string
           maxLength: 2000
-          description: User query used for lexical relevance scoring. Not persisted.
+          description: User query used for relevance scoring. Not persisted.
         minRelevanceScore:
           type: number
           minimum: 0
           maximum: 1
           default: 0.2
-          description: Chunks below this score are counted as low relevance when rankMode is lexical.
+          description: Chunks below this score are counted as low relevance when rankMode is lexical or embedding.
         freshnessMode:
           type: string
           enum: [off, metadata]
@@ -2164,7 +2164,7 @@ components:
               type: integer
             relevanceScore:
               type: number
-              description: Lexical relevance score when rankMode is lexical.
+              description: Relevance score when rankMode is lexical or embedding.
             freshnessScore:
               type: number
               description: Metadata freshness score when freshnessMode is metadata.

--- a/packages/gateway/src/context/optimizer.ts
+++ b/packages/gateway/src/context/optimizer.ts
@@ -1,3 +1,6 @@
+import type { EmbeddingProvider } from "../embeddings/index.js";
+import { cosineSimilarity } from "../embeddings/index.js";
+
 export interface ContextChunk {
   id: string;
   content: string;
@@ -77,7 +80,7 @@ export interface ContextOptimizationResult {
 export interface ContextOptimizationOptions {
   dedupeMode?: "exact" | "semantic";
   semanticThreshold?: number;
-  rankMode?: "none" | "lexical";
+  rankMode?: "none" | "lexical" | "embedding";
   query?: string;
   minRelevanceScore?: number;
   freshnessMode?: "off" | "metadata";
@@ -206,6 +209,107 @@ function applyLexicalRanking(
     lowRelevanceChunks,
     rerankedChunks,
   };
+}
+
+function applyScoredRanking(
+  chunks: OptimizedContextChunk[],
+  scores: number[],
+  minRelevanceScore: number,
+): { chunks: OptimizedContextChunk[]; avgRelevanceScore: number | null; lowRelevanceChunks: number; rerankedChunks: number } {
+  if (chunks.length === 0 || scores.length !== chunks.length) {
+    return { chunks, avgRelevanceScore: null, lowRelevanceChunks: 0, rerankedChunks: 0 };
+  }
+
+  let total = 0;
+  let lowRelevanceChunks = 0;
+  const scored = chunks.map((chunk, index) => {
+    const relevanceScore = Number(Math.max(0, Math.min(1, scores[index] ?? 0)).toFixed(4));
+    total += relevanceScore;
+    if (relevanceScore < minRelevanceScore) lowRelevanceChunks += 1;
+    return { chunk: { ...chunk, relevanceScore }, index };
+  });
+
+  scored.sort((left, right) => {
+    if (right.chunk.relevanceScore !== left.chunk.relevanceScore) {
+      return (right.chunk.relevanceScore ?? 0) - (left.chunk.relevanceScore ?? 0);
+    }
+    return left.index - right.index;
+  });
+
+  let rerankedChunks = 0;
+  const ranked = scored.map((item, newIndex) => {
+    if (item.index !== newIndex) rerankedChunks += 1;
+    return item.chunk;
+  });
+
+  return {
+    chunks: ranked,
+    avgRelevanceScore: Number((total / chunks.length).toFixed(4)),
+    lowRelevanceChunks,
+    rerankedChunks,
+  };
+}
+
+function withRanking(
+  result: ContextOptimizationResult,
+  ranking: { chunks: OptimizedContextChunk[]; avgRelevanceScore: number | null; lowRelevanceChunks: number; rerankedChunks: number },
+): ContextOptimizationResult {
+  return {
+    ...result,
+    optimized: ranking.chunks,
+    metrics: {
+      ...result.metrics,
+      avgRelevanceScore: ranking.avgRelevanceScore,
+      lowRelevanceChunks: ranking.lowRelevanceChunks,
+      rerankedChunks: ranking.rerankedChunks,
+    },
+  };
+}
+
+export function rankContextOptimizationResultLexically(
+  result: ContextOptimizationResult,
+  options: { query?: string; minRelevanceScore?: number },
+): ContextOptimizationResult {
+  const minRelevanceScore = Math.max(0, Math.min(1, options.minRelevanceScore ?? 0.2));
+  return withRanking(result, applyLexicalRanking(result.optimized, options.query, minRelevanceScore));
+}
+
+const MAX_EMBEDDING_INPUT_CHARS = 6_000;
+const EMBEDDING_BATCH_SIZE = 8;
+
+function boundedEmbeddingInput(content: string): string {
+  return content.replace(/\s+/g, " ").trim().slice(0, MAX_EMBEDDING_INPUT_CHARS);
+}
+
+export async function rankContextOptimizationResultWithEmbeddings(
+  result: ContextOptimizationResult,
+  embeddings: EmbeddingProvider,
+  options: { query?: string; minRelevanceScore?: number },
+): Promise<ContextOptimizationResult> {
+  const query = boundedEmbeddingInput(options.query ?? "");
+  if (!query || result.optimized.length === 0) {
+    return withRanking(result, {
+      chunks: result.optimized,
+      avgRelevanceScore: null,
+      lowRelevanceChunks: 0,
+      rerankedChunks: 0,
+    });
+  }
+
+  const queryVector = await embeddings.embed(query);
+  const scores: number[] = [];
+  for (let index = 0; index < result.optimized.length; index += EMBEDDING_BATCH_SIZE) {
+    const batch = result.optimized.slice(index, index + EMBEDDING_BATCH_SIZE);
+    const vectors = await Promise.all(
+      batch.map((chunk) => embeddings.embed(boundedEmbeddingInput(chunk.content))),
+    );
+    for (const vector of vectors) {
+      scores.push(cosineSimilarity(queryVector, vector));
+    }
+  }
+
+  const minRelevanceScore = Math.max(0, Math.min(1, options.minRelevanceScore ?? 0.2));
+  return withRanking(result, applyScoredRanking(result.optimized, scores, minRelevanceScore));
 }
 
 const DAY_MS = 86_400_000;

--- a/packages/gateway/src/router.ts
+++ b/packages/gateway/src/router.ts
@@ -414,7 +414,7 @@ export async function createRouter(ctx: RouterContext) {
   app.use("/v1/context/*", tierGate);
   app.route("/v1/regression", createRegressionRoutes(ctx.db, routingEngine.regressionCellTable));
   app.route("/v1/cost-migrations", createMigrationRoutes(ctx.db, routingEngine.boostTable));
-  app.route("/v1/context", createContextRoutes(ctx.db, ctx.registry));
+  app.route("/v1/context", createContextRoutes(ctx.db, ctx.registry, { dbKeys: ctx.dbKeys }));
 
   // Mount analytics routes
   app.route("/v1/analytics", createAnalyticsRoutes(ctx.db, ctx.registry));

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -3,12 +3,15 @@ import type { Db } from "@provara/db";
 import {
   compressContextOptimizationResult,
   optimizeContextChunks,
+  rankContextOptimizationResultLexically,
+  rankContextOptimizationResultWithEmbeddings,
   type ContextChunk,
   type ContextOptimizationOptions,
   type ContextOptimizationResult,
   type OptimizedContextChunk,
   type RiskyContextChunk,
 } from "../context/optimizer.js";
+import { createEmbeddingProvider, type EmbeddingProvider } from "../embeddings/index.js";
 import {
   listContextOptimizationEvents,
   recordContextOptimizationEvent,
@@ -90,8 +93,8 @@ function validateDedupeOptions(value: Record<string, unknown>): { options?: Cont
   }
 
   const rankMode = value.rankMode;
-  if (rankMode !== undefined && rankMode !== "none" && rankMode !== "lexical") {
-    return { error: "rankMode must be either none or lexical" };
+  if (rankMode !== undefined && rankMode !== "none" && rankMode !== "lexical" && rankMode !== "embedding") {
+    return { error: "rankMode must be either none, lexical, or embedding" };
   }
   const query = value.query;
   if (query !== undefined && (typeof query !== "string" || query.length > 2000)) {
@@ -157,7 +160,7 @@ function validateDedupeOptions(value: Record<string, unknown>): { options?: Cont
     options: {
       dedupeMode: mode === "semantic" ? "semantic" : "exact",
       semanticThreshold: typeof threshold === "number" ? threshold : undefined,
-      rankMode: rankMode === "lexical" ? "lexical" : "none",
+      rankMode: rankMode === "lexical" || rankMode === "embedding" ? rankMode : "none",
       query: typeof query === "string" ? query : undefined,
       minRelevanceScore: typeof minRelevanceScore === "number" ? minRelevanceScore : undefined,
       freshnessMode: freshnessMode === "metadata" ? "metadata" : "off",
@@ -327,7 +330,47 @@ async function applyRiskScan(
   });
 }
 
-export function createContextRoutes(db: Db, registry?: ProviderRegistry) {
+export interface ContextRouteOptions {
+  embeddings?: EmbeddingProvider | null;
+  dbKeys?: Record<string, string>;
+}
+
+async function applyRequestedRanking(
+  result: ContextOptimizationResult,
+  options: ContextOptimizationOptions,
+  routeOptions: ContextRouteOptions,
+): Promise<ContextOptimizationResult> {
+  if (options.rankMode === "lexical") {
+    return result;
+  }
+  if (options.rankMode !== "embedding") {
+    return result;
+  }
+
+  const embeddings = routeOptions.embeddings !== undefined
+    ? routeOptions.embeddings
+    : createEmbeddingProvider({ dbKeys: routeOptions.dbKeys });
+  if (!embeddings) {
+    return rankContextOptimizationResultLexically(result, {
+      query: options.query,
+      minRelevanceScore: options.minRelevanceScore,
+    });
+  }
+
+  try {
+    return await rankContextOptimizationResultWithEmbeddings(result, embeddings, {
+      query: options.query,
+      minRelevanceScore: options.minRelevanceScore,
+    });
+  } catch {
+    return rankContextOptimizationResultLexically(result, {
+      query: options.query,
+      minRelevanceScore: options.minRelevanceScore,
+    });
+  }
+}
+
+export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOptions: ContextRouteOptions = {}) {
   const app = new Hono();
 
   app.post("/optimize", async (c) => {
@@ -364,20 +407,24 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry) {
       );
     }
 
-    const deferCompression = scanRisk.scanRisk && dedupe.options.compressionMode === "extractive";
+    const deferAsyncRanking = dedupe.options.rankMode === "embedding";
+    const deferCompression = (scanRisk.scanRisk || deferAsyncRanking) && dedupe.options.compressionMode === "extractive";
     const baseOptions = deferCompression
-      ? { ...dedupe.options, compressionMode: "off" as const }
+      ? { ...dedupe.options, rankMode: deferAsyncRanking ? "none" as const : dedupe.options.rankMode, compressionMode: "off" as const }
+      : deferAsyncRanking
+        ? { ...dedupe.options, rankMode: "none" as const }
       : dedupe.options;
     const baseOptimization = optimizeContextChunks(parsed.chunks, baseOptions);
     const scannedOptimization = scanRisk.scanRisk
       ? await applyRiskScan(db, tenantId, baseOptimization)
       : baseOptimization;
+    const rankedOptimization = await applyRequestedRanking(scannedOptimization, dedupe.options, routeOptions);
     const optimization = deferCompression
-      ? compressContextOptimizationResult(scannedOptimization, {
+      ? compressContextOptimizationResult(rankedOptimization, {
         query: dedupe.options.query,
         maxSentencesPerChunk: dedupe.options.maxSentencesPerChunk,
       })
-      : scannedOptimization;
+      : rankedOptimization;
     const event = await recordContextOptimizationEvent(db, tenantId, optimization, {
       riskScanned: scanRisk.scanRisk ?? false,
     });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -4,8 +4,9 @@ import type { Db } from "@provara/db";
 import { contextOptimizationEvents, contextQualityEvents, contextRetrievalEvents, guardrailRules } from "@provara/db";
 import type { ProviderRegistry } from "../src/providers/index.js";
 import type { CompletionRequest, CompletionResponse, Provider, StreamChunk } from "../src/providers/types.js";
+import type { EmbeddingProvider } from "../src/embeddings/index.js";
 import { optimizeContextChunks } from "../src/context/optimizer.js";
-import { createContextRoutes } from "../src/routes/context.js";
+import { createContextRoutes, type ContextRouteOptions } from "../src/routes/context.js";
 import { makeTestDb } from "./_setup/db.js";
 import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
 
@@ -46,11 +47,24 @@ function fakeRegistry(content = '{"rawScore": 4, "optimizedScore": 3, "rationale
   };
 }
 
-function buildApp(db: Db, registry?: ProviderRegistry) {
+function buildApp(db: Db, registry?: ProviderRegistry, routeOptions?: ContextRouteOptions) {
   const app = new Hono();
   app.use("/v1/context/*", requireIntelligenceTier(db));
-  app.route("/v1/context", createContextRoutes(db, registry));
+  app.route("/v1/context", createContextRoutes(db, registry, routeOptions));
   return app;
+}
+
+function fakeEmbeddings(vectors: Record<string, number[]>): EmbeddingProvider {
+  return {
+    name: "test-embeddings",
+    model: "test-embedding-model",
+    dim: 3,
+    async embed(text: string): Promise<number[]> {
+      const key = Object.keys(vectors).find((candidate) => text.includes(candidate));
+      if (!key) return [0, 0, 1];
+      return vectors[key];
+    },
+  };
 }
 
 describe("context optimizer core", () => {
@@ -763,6 +777,147 @@ describe("POST /v1/context/optimize", () => {
       lowRelevanceChunks: body.optimization.metrics.lowRelevanceChunks,
       rerankedChunks: body.optimization.metrics.rerankedChunks,
     });
+  });
+
+  it("records relevance analytics for embedding ranking", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const embeddings = fakeEmbeddings({
+      refund: [1, 0, 0],
+      billing: [0.2, 0.8, 0],
+      security: [0, 1, 0],
+    });
+    const app = buildApp(db, undefined, { embeddings });
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        rankMode: "embedding",
+        query: "refund",
+        minRelevanceScore: 0.5,
+        chunks: [
+          { id: "security", content: "security controls and saml setup" },
+          { id: "billing", content: "billing workspace invoices" },
+          { id: "refunds", content: "refund policy for paid accounts" },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: {
+        optimized: Array<{ id: string; relevanceScore?: number }>;
+        metrics: {
+          avgRelevanceScore: number | null;
+          lowRelevanceChunks: number;
+          rerankedChunks: number;
+        };
+      };
+      event: {
+        avgRelevanceScore: number | null;
+        lowRelevanceChunks: number;
+        rerankedChunks: number;
+      };
+      retrieval: {
+        avgRelevanceScore: number | null;
+        lowRelevanceChunks: number;
+        rerankedChunks: number;
+      };
+    };
+
+    expect(body.optimization.optimized.map((chunk) => chunk.id)).toEqual(["refunds", "billing", "security"]);
+    expect(body.optimization.optimized[0].relevanceScore).toBe(1);
+    expect(body.optimization.metrics.avgRelevanceScore).toEqual(expect.any(Number));
+    expect(body.optimization.metrics.lowRelevanceChunks).toBeGreaterThan(0);
+    expect(body.optimization.metrics.rerankedChunks).toBe(2);
+    expect(body.event).toMatchObject({
+      avgRelevanceScore: body.optimization.metrics.avgRelevanceScore,
+      lowRelevanceChunks: body.optimization.metrics.lowRelevanceChunks,
+      rerankedChunks: body.optimization.metrics.rerankedChunks,
+    });
+    expect(body.retrieval).toMatchObject({
+      avgRelevanceScore: body.optimization.metrics.avgRelevanceScore,
+      lowRelevanceChunks: body.optimization.metrics.lowRelevanceChunks,
+      rerankedChunks: body.optimization.metrics.rerankedChunks,
+    });
+  });
+
+  it("falls back to lexical relevance when embedding ranking is unavailable", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db, undefined, { embeddings: null });
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        rankMode: "embedding",
+        query: "refund paid account",
+        minRelevanceScore: 0.2,
+        chunks: [
+          { id: "security", content: "Enterprise plans include audit logs and SAML single sign on." },
+          { id: "refunds", content: "Refunds are available for paid accounts during the 30 day refund window." },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: {
+        optimized: Array<{ id: string; relevanceScore?: number }>;
+        metrics: { avgRelevanceScore: number | null; rerankedChunks: number };
+      };
+    };
+
+    expect(body.optimization.optimized.map((chunk) => chunk.id)).toEqual(["refunds", "security"]);
+    expect(body.optimization.optimized[0].relevanceScore).toEqual(expect.any(Number));
+    expect(body.optimization.metrics.avgRelevanceScore).toEqual(expect.any(Number));
+    expect(body.optimization.metrics.rerankedChunks).toBe(2);
+  });
+
+  it("falls back to lexical relevance when embedding ranking fails", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const embeddings: EmbeddingProvider = {
+      name: "broken",
+      model: "broken",
+      dim: 3,
+      async embed(): Promise<number[]> {
+        throw new Error("embedding provider unavailable");
+      },
+    };
+    const app = buildApp(db, undefined, { embeddings });
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        rankMode: "embedding",
+        query: "refund paid account",
+        chunks: [
+          { id: "security", content: "Enterprise plans include audit logs and SAML single sign on." },
+          { id: "refunds", content: "Refunds are available for paid accounts during the 30 day refund window." },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: { optimized: Array<{ id: string; relevanceScore?: number }> };
+    };
+
+    expect(body.optimization.optimized.map((chunk) => chunk.id)).toEqual(["refunds", "security"]);
+    expect(body.optimization.optimized[0].relevanceScore).toEqual(expect.any(Number));
   });
 
   it("records near-duplicate analytics for semantic mode", async () => {


### PR DESCRIPTION
Closes #357

## Summary
- adds rankMode=embedding for Context Optimizer relevance scoring
- reuses the existing embedding provider and cosine similarity implementation
- bounds embedding inputs and batches chunk embedding calls
- falls back to lexical relevance when embeddings are unavailable or fail
- updates OpenAPI, docs, roadmap, changelog, and route tests

## Verification
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts
- npx tsc --noEmit -p packages/gateway/tsconfig.json
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts tests/demo.test.ts
- node -e OpenAPI YAML parse
- git diff --check
- npm test --workspace @provara/gateway
- npm run build --workspace @provara/gateway
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
