### PR TITLE
feat(#361): add context optimizer controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable Provara changes are tracked here.
   - Context Optimizer conflicting-context detection with `conflictMode: "heuristic"`, bounded status/numeric/metadata checks, conflict metrics, demo rows, APIs, and dashboard visibility.
   - Context Optimizer scored contradiction detection with `conflictMode: "scored"`, bounded conflict scores, severity bands, APIs, and dashboard visibility.
   - Context Optimizer extractive compression with `compressionMode: "extractive"`, bounded sentence selection, compression savings metrics, demo rows, APIs, and dashboard visibility.
+  - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
 - Optional semantic and hybrid prompt-injection scan modes using the configured judge model.
@@ -37,7 +38,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, and extractive compression as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive compression, and dashboard configuration controls as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -183,6 +183,42 @@ interface LoadState {
   gate: GateState | null;
 }
 
+type DedupeMode = "exact" | "semantic";
+type RankMode = "none" | "lexical" | "embedding";
+type FreshnessMode = "off" | "metadata";
+type ConflictMode = "off" | "heuristic" | "scored";
+type CompressionMode = "off" | "extractive";
+
+interface OptimizerDraftSettings {
+  dedupeMode: DedupeMode;
+  semanticThreshold: number;
+  rankMode: RankMode;
+  query: string;
+  minRelevanceScore: number;
+  freshnessMode: FreshnessMode;
+  maxContextAgeDays: number;
+  conflictMode: ConflictMode;
+  compressionMode: CompressionMode;
+  maxSentencesPerChunk: number;
+  scanRisk: boolean;
+}
+
+const OPTIMIZER_SETTINGS_STORAGE_KEY = "provara:context-optimizer:settings";
+
+const DEFAULT_OPTIMIZER_SETTINGS: OptimizerDraftSettings = {
+  dedupeMode: "semantic",
+  semanticThreshold: 0.72,
+  rankMode: "embedding",
+  query: "What is the refund policy for paid accounts?",
+  minRelevanceScore: 0.2,
+  freshnessMode: "metadata",
+  maxContextAgeDays: 180,
+  conflictMode: "scored",
+  compressionMode: "extractive",
+  maxSentencesPerChunk: 3,
+  scanRisk: true,
+};
+
 function formatInteger(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
 }
@@ -230,6 +266,235 @@ function deltaTone(value: number | null | undefined): string {
   if (value < 0) return "text-red-300";
   if (value > 0) return "text-emerald-300";
   return "text-zinc-200";
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, value));
+}
+
+function readStoredOptimizerSettings(): OptimizerDraftSettings {
+  if (typeof window === "undefined") return DEFAULT_OPTIMIZER_SETTINGS;
+  try {
+    const raw = window.localStorage.getItem(OPTIMIZER_SETTINGS_STORAGE_KEY);
+    if (!raw) return DEFAULT_OPTIMIZER_SETTINGS;
+    const parsed = JSON.parse(raw) as Partial<OptimizerDraftSettings>;
+    return {
+      dedupeMode: parsed.dedupeMode === "exact" || parsed.dedupeMode === "semantic"
+        ? parsed.dedupeMode
+        : DEFAULT_OPTIMIZER_SETTINGS.dedupeMode,
+      semanticThreshold: clampNumber(Number(parsed.semanticThreshold), 0.5, 1),
+      rankMode: parsed.rankMode === "none" || parsed.rankMode === "lexical" || parsed.rankMode === "embedding"
+        ? parsed.rankMode
+        : DEFAULT_OPTIMIZER_SETTINGS.rankMode,
+      query: typeof parsed.query === "string" ? parsed.query.slice(0, 2000) : DEFAULT_OPTIMIZER_SETTINGS.query,
+      minRelevanceScore: clampNumber(Number(parsed.minRelevanceScore), 0, 1),
+      freshnessMode: parsed.freshnessMode === "off" || parsed.freshnessMode === "metadata"
+        ? parsed.freshnessMode
+        : DEFAULT_OPTIMIZER_SETTINGS.freshnessMode,
+      maxContextAgeDays: Math.round(clampNumber(Number(parsed.maxContextAgeDays), 1, 3650)),
+      conflictMode: parsed.conflictMode === "off" || parsed.conflictMode === "heuristic" || parsed.conflictMode === "scored"
+        ? parsed.conflictMode
+        : DEFAULT_OPTIMIZER_SETTINGS.conflictMode,
+      compressionMode: parsed.compressionMode === "off" || parsed.compressionMode === "extractive"
+        ? parsed.compressionMode
+        : DEFAULT_OPTIMIZER_SETTINGS.compressionMode,
+      maxSentencesPerChunk: Math.round(clampNumber(Number(parsed.maxSentencesPerChunk), 1, 8)),
+      scanRisk: typeof parsed.scanRisk === "boolean" ? parsed.scanRisk : DEFAULT_OPTIMIZER_SETTINGS.scanRisk,
+    };
+  } catch {
+    return DEFAULT_OPTIMIZER_SETTINGS;
+  }
+}
+
+function buildOptimizerPayload(settings: OptimizerDraftSettings) {
+  return {
+    dedupeMode: settings.dedupeMode,
+    semanticThreshold: settings.semanticThreshold,
+    rankMode: settings.rankMode,
+    query: settings.query,
+    minRelevanceScore: settings.minRelevanceScore,
+    freshnessMode: settings.freshnessMode,
+    maxContextAgeDays: settings.maxContextAgeDays,
+    conflictMode: settings.conflictMode,
+    compressionMode: settings.compressionMode,
+    maxSentencesPerChunk: settings.maxSentencesPerChunk,
+    scanRisk: settings.scanRisk,
+    chunks: [
+      {
+        id: "refunds-current.md#2",
+        content: "Refunds are available for paid accounts within 30 days when a receipt is present.",
+        source: "help-center",
+        metadata: { conflictKey: "refund-policy", status: "active", updatedAt: "2026-04-01T00:00:00.000Z" },
+      },
+      {
+        id: "refunds-legacy.md#8",
+        content: "Refunds are available for paid accounts within 14 days.",
+        source: "legacy-docs",
+        metadata: { conflictKey: "refund-policy", status: "deprecated", updatedAt: "2024-01-15T00:00:00.000Z" },
+      },
+    ],
+  };
+}
+
+function SelectField<T extends string>({ label, value, options, onChange }: {
+  label: string;
+  value: T;
+  options: Array<{ value: T; label: string }>;
+  onChange: (value: T) => void;
+}) {
+  return (
+    <label className="block text-xs font-medium uppercase tracking-wider text-zinc-500">
+      {label}
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value as T)}
+        className="mt-2 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm font-normal normal-case tracking-normal text-zinc-100 outline-none focus:border-blue-500"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>{option.label}</option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function NumberField({ label, value, min, max, step, onChange }: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}) {
+  return (
+    <label className="block text-xs font-medium uppercase tracking-wider text-zinc-500">
+      {label}
+      <input
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(clampNumber(Number(event.target.value), min, max))}
+        className="mt-2 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm font-normal normal-case tracking-normal text-zinc-100 outline-none focus:border-blue-500"
+      />
+    </label>
+  );
+}
+
+function OptimizerConfigPanel() {
+  const [settings, setSettings] = useState<OptimizerDraftSettings>(() => readStoredOptimizerSettings());
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(OPTIMIZER_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    } catch {
+      // Ignore storage failures in locked-down browser contexts.
+    }
+  }, [settings]);
+
+  const payload = useMemo(() => buildOptimizerPayload(settings), [settings]);
+  const payloadText = useMemo(() => JSON.stringify(payload, null, 2), [payload]);
+
+  async function copyPayload() {
+    try {
+      await navigator.clipboard.writeText(payloadText);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  function update<K extends keyof OptimizerDraftSettings>(key: K, value: OptimizerDraftSettings[K]) {
+    setSettings((prev) => ({ ...prev, [key]: value }));
+  }
+
+  return (
+    <section className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-100">Configuration</h2>
+          <p className="mt-1 text-sm text-zinc-500">Draft optimizer modes and export the request payload.</p>
+        </div>
+        <button
+          type="button"
+          onClick={copyPayload}
+          className="inline-flex items-center justify-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-500"
+        >
+          {copied ? "Copied" : "Copy API Payload"}
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <SelectField
+          label="Dedupe"
+          value={settings.dedupeMode}
+          options={[{ value: "exact", label: "Exact" }, { value: "semantic", label: "Semantic" }]}
+          onChange={(value) => update("dedupeMode", value)}
+        />
+        <SelectField
+          label="Ranking"
+          value={settings.rankMode}
+          options={[{ value: "none", label: "None" }, { value: "lexical", label: "Lexical" }, { value: "embedding", label: "Embedding" }]}
+          onChange={(value) => update("rankMode", value)}
+        />
+        <SelectField
+          label="Freshness"
+          value={settings.freshnessMode}
+          options={[{ value: "off", label: "Off" }, { value: "metadata", label: "Metadata" }]}
+          onChange={(value) => update("freshnessMode", value)}
+        />
+        <SelectField
+          label="Conflicts"
+          value={settings.conflictMode}
+          options={[{ value: "off", label: "Off" }, { value: "heuristic", label: "Heuristic" }, { value: "scored", label: "Scored" }]}
+          onChange={(value) => update("conflictMode", value)}
+        />
+        <SelectField
+          label="Compression"
+          value={settings.compressionMode}
+          options={[{ value: "off", label: "Off" }, { value: "extractive", label: "Extractive" }]}
+          onChange={(value) => update("compressionMode", value)}
+        />
+      </div>
+
+      <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <NumberField label="Semantic Threshold" value={settings.semanticThreshold} min={0.5} max={1} step={0.01} onChange={(value) => update("semanticThreshold", value)} />
+        <NumberField label="Min Relevance" value={settings.minRelevanceScore} min={0} max={1} step={0.01} onChange={(value) => update("minRelevanceScore", value)} />
+        <NumberField label="Max Age Days" value={settings.maxContextAgeDays} min={1} max={3650} step={1} onChange={(value) => update("maxContextAgeDays", Math.round(value))} />
+        <NumberField label="Max Sentences" value={settings.maxSentencesPerChunk} min={1} max={8} step={1} onChange={(value) => update("maxSentencesPerChunk", Math.round(value))} />
+        <label className="flex min-h-[66px] items-center justify-between rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-200">
+          <span>
+            <span className="block text-xs font-medium uppercase tracking-wider text-zinc-500">Risk Scan</span>
+            <span className="mt-1 block text-zinc-300">{settings.scanRisk ? "Enabled" : "Disabled"}</span>
+          </span>
+          <input
+            aria-label="Risk Scan"
+            type="checkbox"
+            checked={settings.scanRisk}
+            onChange={(event) => update("scanRisk", event.target.checked)}
+            className="h-4 w-4 accent-blue-600"
+          />
+        </label>
+      </div>
+
+      <label className="mt-3 block text-xs font-medium uppercase tracking-wider text-zinc-500">
+        Query
+        <input
+          value={settings.query}
+          onChange={(event) => update("query", event.target.value.slice(0, 2000))}
+          className="mt-2 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm font-normal normal-case tracking-normal text-zinc-100 outline-none focus:border-blue-500"
+        />
+      </label>
+
+      <pre className="mt-4 max-h-72 overflow-auto rounded-md border border-zinc-800 bg-zinc-950 p-3 text-xs text-zinc-300">
+        {payloadText}
+      </pre>
+    </section>
+  );
 }
 
 function StatTile({ label, value, detail, tone }: {
@@ -455,6 +720,8 @@ export function ContextOptimizerPanel() {
           tone={metricTone(summary?.reductionPct ?? 0)}
         />
       </div>
+
+      <OptimizerConfigPanel />
 
       <section>
         <div className="mb-3">

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ContextOptimizerPanel } from "../src/components/context-optimizer-panel";
 import { gatewayFetchRaw } from "../src/lib/gateway-client";
 
@@ -20,6 +20,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}) {
 describe("ContextOptimizerPanel", () => {
   beforeEach(() => {
     mockedFetch.mockReset();
+    window.localStorage.clear();
   });
 
   it("renders summary metrics and recent events", async () => {
@@ -219,6 +220,8 @@ describe("ContextOptimizerPanel", () => {
 
     expect(await screen.findByText("Context Optimizer")).toBeInTheDocument();
     expect(screen.getByText("270")).toBeInTheDocument();
+    expect(screen.getByText("Configuration")).toBeInTheDocument();
+    expect(document.body.textContent).toContain('"rankMode": "embedding"');
     expect(screen.getByText("10 input chunks scanned")).toBeInTheDocument();
     expect(screen.getByText("27%")).toBeInTheDocument();
     expect(screen.getByText("chunk-b")).toBeInTheDocument();
@@ -235,9 +238,103 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getAllByText("Conflicts").length).toBeGreaterThan(0);
     expect(screen.getByText(/medium 0.76/i)).toBeInTheDocument();
     expect(screen.getByText("Conflict Rate")).toBeInTheDocument();
-    expect(screen.getByText("Compression")).toBeInTheDocument();
+    expect(screen.getAllByText("Compression").length).toBeGreaterThan(0);
     expect(screen.getByText("Semantic Rate")).toBeInTheDocument();
     expect(screen.getAllByText("chunk-risky").length).toBeGreaterThan(0);
+  });
+
+  it("updates and persists optimizer payload controls", async () => {
+    mockedFetch.mockImplementation((path) => {
+      if (path === "/v1/context/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            inputChunks: 0,
+            outputChunks: 0,
+            droppedChunks: 0,
+            nearDuplicateChunks: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            savedTokens: 0,
+            reductionPct: 0,
+            avgRelevanceScore: null,
+            lowRelevanceChunks: 0,
+            rerankedChunks: 0,
+            avgFreshnessScore: null,
+            staleChunks: 0,
+            conflictChunks: 0,
+            conflictGroups: 0,
+            compressedChunks: 0,
+            compressionSavedTokens: 0,
+            compressionRatePct: 0,
+            flaggedChunks: 0,
+            quarantinedChunks: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/quality/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            regressedCount: 0,
+            avgRawScore: null,
+            avgOptimizedScore: null,
+            avgDelta: null,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/retrieval/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            retrievedChunks: 0,
+            usedChunks: 0,
+            unusedChunks: 0,
+            duplicateChunks: 0,
+            nearDuplicateChunks: 0,
+            riskyChunks: 0,
+            retrievedTokens: 0,
+            usedTokens: 0,
+            unusedTokens: 0,
+            avgRelevanceScore: null,
+            lowRelevanceChunks: 0,
+            rerankedChunks: 0,
+            avgFreshnessScore: null,
+            staleChunks: 0,
+            conflictChunks: 0,
+            conflictGroups: 0,
+            compressedChunks: 0,
+            compressionSavedTokens: 0,
+            compressionRatePct: 0,
+            efficiencyPct: 0,
+            duplicateRatePct: 0,
+            nearDuplicateRatePct: 0,
+            riskyRatePct: 0,
+            conflictRatePct: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      return Promise.resolve(jsonResponse({ events: [] }));
+    });
+
+    render(<ContextOptimizerPanel />);
+
+    expect(await screen.findByText("Configuration")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Ranking"), { target: { value: "lexical" } });
+    fireEvent.change(screen.getByLabelText("Conflicts"), { target: { value: "heuristic" } });
+    fireEvent.change(screen.getByLabelText("Max Sentences"), { target: { value: "5" } });
+    fireEvent.click(screen.getByLabelText("Risk Scan"));
+
+    expect(document.body.textContent).toContain('"rankMode": "lexical"');
+    expect(document.body.textContent).toContain('"conflictMode": "heuristic"');
+    expect(document.body.textContent).toContain('"maxSentencesPerChunk": 5');
+    expect(document.body.textContent).toContain('"scanRisk": false');
+    await waitFor(() => {
+      expect(window.localStorage.getItem("provara:context-optimizer:settings")).toContain('"rankMode":"lexical"');
+    });
   });
 
   it("shows the empty state", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -13,6 +13,7 @@ Implemented as of `0.2.0`:
 - Persisted `context_optimization_events`.
 - Tenant-scoped `GET /v1/context/summary` and `GET /v1/context/events`.
 - Dashboard visibility at `/dashboard/context`.
+- Dashboard configuration controls for optimizer modes and copyable API payloads.
 - Demo tenant seed data for screenshot-ready examples.
 - Optional retrieved-context risk scanning with active Guardrails rules.
 - Flagged and quarantined context reporting in API events and the dashboard.
@@ -26,6 +27,7 @@ Implemented as of `0.2.0`:
 - Optional conflicting-context detection with bounded heuristic status/numeric/metadata checks and dashboard visibility.
 - Optional scored contradiction severity bands for retained-context conflicts.
 - Optional extractive compression with bounded sentence selection, compression savings metrics, and dashboard visibility.
+- Dashboard configuration controls for drafting optimizer payloads.
 
 Next planned layer:
 - Abstractive compression with strict provenance and fallback behavior.
@@ -68,6 +70,7 @@ Capabilities:
 - Stale-context and freshness reporting. Shipped in V1.2.
 - Conflicting-context reporting. Shipped in V1.2.
 - Extractive-compression reporting. Shipped in V1.2.
+- Optimizer configuration controls and copyable request payloads. Shipped in V1.2.
 - Request-detail integration.
 - Dashboard cards for saved tokens, dropped chunks, reduction, and risk flags.
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,6 +21,7 @@ The shipped V1 implementation is intentionally narrow:
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
+- Dashboard configuration controls for composing and copying an optimization request payload.
 
 It does not yet perform embedding-backed semantic deduplication, abstractive compression, or persistent review workflows. Those belong to later roadmap phases.
 
@@ -138,6 +139,8 @@ It shows five summary cards:
 - **Dropped Chunks**: duplicate chunks removed from model context.
 - **Risky Chunks**: flagged and quarantined chunks removed by risk scanning.
 - **Reduction**: saved tokens divided by estimated input tokens.
+
+The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
 The Recent Events table shows:
 


### PR DESCRIPTION
Closes #361

## Summary
- adds Context Optimizer dashboard controls for dedupe, ranking, freshness, conflict, compression, and risk scan modes
- adds threshold inputs for semantic similarity, relevance, max context age, and extractive sentence count
- persists draft settings in browser localStorage
- generates and copies a POST /v1/context/optimize JSON payload with representative chunks
- updates Context Optimizer docs, roadmap, changelog, and web tests

## Verification
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npx tsc --noEmit -p apps/web/tsconfig.json
- git diff --check
- npm test --workspace @provara/web
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
