### PR TITLE
feat(#363): add abstractive context compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable Provara changes are tracked here.
   - Context Optimizer conflicting-context detection with `conflictMode: "heuristic"`, bounded status/numeric/metadata checks, conflict metrics, demo rows, APIs, and dashboard visibility.
   - Context Optimizer scored contradiction detection with `conflictMode: "scored"`, bounded conflict scores, severity bands, APIs, and dashboard visibility.
   - Context Optimizer extractive compression with `compressionMode: "extractive"`, bounded sentence selection, compression savings metrics, demo rows, APIs, and dashboard visibility.
+  - Context Optimizer abstractive compression with `compressionMode: "abstractive"`, provider summaries, provenance preservation, and extractive/original fallback on errors, refusals, or token growth.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -38,7 +39,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive compression, and dashboard configuration controls as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, and dashboard configuration controls as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -187,7 +187,7 @@ type DedupeMode = "exact" | "semantic";
 type RankMode = "none" | "lexical" | "embedding";
 type FreshnessMode = "off" | "metadata";
 type ConflictMode = "off" | "heuristic" | "scored";
-type CompressionMode = "off" | "extractive";
+type CompressionMode = "off" | "extractive" | "abstractive";
 
 interface OptimizerDraftSettings {
   dedupeMode: DedupeMode;
@@ -296,7 +296,7 @@ function readStoredOptimizerSettings(): OptimizerDraftSettings {
       conflictMode: parsed.conflictMode === "off" || parsed.conflictMode === "heuristic" || parsed.conflictMode === "scored"
         ? parsed.conflictMode
         : DEFAULT_OPTIMIZER_SETTINGS.conflictMode,
-      compressionMode: parsed.compressionMode === "off" || parsed.compressionMode === "extractive"
+      compressionMode: parsed.compressionMode === "off" || parsed.compressionMode === "extractive" || parsed.compressionMode === "abstractive"
         ? parsed.compressionMode
         : DEFAULT_OPTIMIZER_SETTINGS.compressionMode,
       maxSentencesPerChunk: Math.round(clampNumber(Number(parsed.maxSentencesPerChunk), 1, 8)),
@@ -456,7 +456,7 @@ function OptimizerConfigPanel() {
         <SelectField
           label="Compression"
           value={settings.compressionMode}
-          options={[{ value: "off", label: "Off" }, { value: "extractive", label: "Extractive" }]}
+          options={[{ value: "off", label: "Off" }, { value: "extractive", label: "Extractive" }, { value: "abstractive", label: "Abstractive" }]}
           onChange={(value) => update("compressionMode", value)}
         />
       </div>

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -27,10 +27,11 @@ Implemented as of `0.2.0`:
 - Optional conflicting-context detection with bounded heuristic status/numeric/metadata checks and dashboard visibility.
 - Optional scored contradiction severity bands for retained-context conflicts.
 - Optional extractive compression with bounded sentence selection, compression savings metrics, and dashboard visibility.
+- Optional abstractive compression with provider summaries, provenance preservation, and mechanical fallback.
 - Dashboard configuration controls for drafting optimizer payloads.
 
 Next planned layer:
-- Abstractive compression with strict provenance and fallback behavior.
+- Persistent knowledge distillation and managed content stores.
 
 ## V1: Runtime Context Optimizer
 
@@ -45,6 +46,7 @@ Core capabilities:
 - Optional conflict detection across retained chunks.
 - Optional contradiction scoring and severity bands across retained chunks.
 - Optional extractive compression for retained chunks.
+- Optional abstractive compression for retained chunks.
 - Token savings estimation.
 - Source and citation preservation.
 - Prompt Injection Firewall risk scanning for retrieved context.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -13,6 +13,7 @@ The shipped V1 implementation is intentionally narrow:
 - Optional stale-context detection from bounded freshness metadata.
 - Optional conflicting-context detection with bounded heuristic claim checks and scored severity bands.
 - Optional extractive compression with bounded sentence selection.
+- Optional abstractive compression with provider summaries and mechanical fallback.
 - Source ID preservation when duplicate chunks are dropped.
 - Estimated token savings based on input and output context size.
 - Optional risk scanning with active Guardrails rules for retrieved context.
@@ -23,7 +24,7 @@ The shipped V1 implementation is intentionally narrow:
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
 
-It does not yet perform embedding-backed semantic deduplication, abstractive compression, or persistent review workflows. Those belong to later roadmap phases.
+It does not yet perform embedding-backed semantic deduplication or persistent review workflows. Those belong to later roadmap phases.
 
 ## API
 
@@ -45,7 +46,7 @@ The request accepts already-retrieved context chunks:
   "freshnessMode": "metadata",
   "maxContextAgeDays": 180,
   "conflictMode": "scored",
-  "compressionMode": "extractive",
+  "compressionMode": "abstractive",
   "maxSentencesPerChunk": 3,
   "scanRisk": true,
   "chunks": [
@@ -69,7 +70,7 @@ The request accepts already-retrieved context chunks:
 
 The response includes:
 
-- `optimization.optimized`: chunks retained for model context, optionally reranked, scored for relevance/freshness/conflicts, and extractively compressed.
+- `optimization.optimized`: chunks retained for model context, optionally reranked, scored for relevance/freshness/conflicts, and compressed.
 - `optimization.dropped`: exact duplicate and near-duplicate chunks removed from model context.
 - `optimization.conflicts`: lightweight conflict groups found across retained chunks.
 - `optimization.flagged`: risky chunks removed from model context but marked for operator review.
@@ -86,7 +87,7 @@ The response includes:
 
 `conflictMode` defaults to `off`. Set `conflictMode` to `heuristic` to detect lightweight contradictions across retained chunks. Set `conflictMode` to `scored` to include bounded contradiction `score` values and `low`/`medium`/`high` severity bands on conflict groups and retained chunks. The detector uses local signals: shared metadata keys, status disagreements, and numeric claim disagreements such as different day/hour/percent/USD values on the same topic. It caps extracted signals and pair comparisons, so this stays deterministic and local; NLI-backed contradiction checks remain future paid-layer work.
 
-`compressionMode` defaults to `off`. Set `compressionMode` to `extractive` to keep the highest-value sentences from retained chunks. The selector uses bounded sentence splitting, capped query tokens, stable local scoring, and preserves original sentence order in the compressed chunk. It records `compressedChunks`, `compressionSavedTokens`, and `compressionRatePct`. `maxSentencesPerChunk` defaults to `3` and accepts values from `1` to `8`. Abstractive/LLM compression is intentionally out of scope for this mode.
+`compressionMode` defaults to `off`. Set `compressionMode` to `extractive` to keep the highest-value sentences from retained chunks. The selector uses bounded sentence splitting, capped query tokens, stable local scoring, and preserves original sentence order in the compressed chunk. Set `compressionMode` to `abstractive` to summarize retained chunks through the configured provider; Provara preserves source IDs and token provenance, and falls back to extractive or original content if the model call fails, refuses, returns empty text, or increases token count. It records `compressedChunks`, `compressionSavedTokens`, and `compressionRatePct`. `maxSentencesPerChunk` defaults to `3` and accepts values from `1` to `8` for the extractive fallback.
 
 `scanRisk` defaults to `false` for backwards compatibility. When enabled, Provara uses active Guardrails rules against the `retrieved_context` surface after duplicate removal. `flag` and `redact` actions become flagged context; `block` actions become quarantined context.
 

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -2138,9 +2138,9 @@ components:
           description: Heuristic mode detects lightweight status, numeric, and metadata conflicts across retained chunks. Scored mode emits bounded contradiction scores and severity bands.
         compressionMode:
           type: string
-          enum: [off, extractive]
+          enum: [off, extractive, abstractive]
           default: off
-          description: Extractive mode keeps the highest-value sentences from retained chunks using deterministic local scoring.
+          description: Extractive mode keeps the highest-value sentences using deterministic local scoring. Abstractive mode summarizes retained chunks with the configured provider and falls back to extractive/original content on errors, refusals, or token growth.
         maxSentencesPerChunk:
           type: number
           minimum: 1
@@ -2185,7 +2185,7 @@ components:
               description: Highest severity band for conflicts involving this retained chunk.
             compressed:
               type: boolean
-              description: Whether extractive compression shortened this chunk.
+              description: Whether compression shortened this chunk.
             originalTokens:
               type: integer
               description: Pre-compression token estimate for this retained chunk.

--- a/packages/gateway/src/context/optimizer.ts
+++ b/packages/gateway/src/context/optimizer.ts
@@ -88,7 +88,7 @@ export interface ContextOptimizationOptions {
   maxContextAgeDays?: number;
   referenceTime?: Date;
   conflictMode?: "off" | "heuristic" | "scored";
-  compressionMode?: "off" | "extractive";
+  compressionMode?: "off" | "extractive" | "abstractive";
   maxSentencesPerChunk?: number;
 }
 

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import {
   compressContextOptimizationResult,
+  estimateContextTokens,
   optimizeContextChunks,
   rankContextOptimizationResultLexically,
   rankContextOptimizationResultWithEmbeddings,
@@ -30,9 +31,11 @@ import {
 import { getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
+import type { Provider } from "../providers/types.js";
 
 const MAX_CHUNKS = 200;
 const MAX_CHUNK_CHARS = 100_000;
+const ABSTRACTIVE_COMPRESSION_BATCH_SIZE = 4;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -140,8 +143,13 @@ function validateDedupeOptions(value: Record<string, unknown>): { options?: Cont
     return { error: "conflictMode must be either off, heuristic, or scored" };
   }
   const compressionMode = value.compressionMode;
-  if (compressionMode !== undefined && compressionMode !== "off" && compressionMode !== "extractive") {
-    return { error: "compressionMode must be either off or extractive" };
+  if (
+    compressionMode !== undefined &&
+    compressionMode !== "off" &&
+    compressionMode !== "extractive" &&
+    compressionMode !== "abstractive"
+  ) {
+    return { error: "compressionMode must be either off, extractive, or abstractive" };
   }
   const maxSentencesPerChunk = value.maxSentencesPerChunk;
   if (
@@ -167,7 +175,7 @@ function validateDedupeOptions(value: Record<string, unknown>): { options?: Cont
       maxContextAgeDays: typeof maxContextAgeDays === "number" ? maxContextAgeDays : undefined,
       referenceTime: parsedReferenceTime,
       conflictMode: conflictMode === "heuristic" || conflictMode === "scored" ? conflictMode : "off",
-      compressionMode: compressionMode === "extractive" ? "extractive" : "off",
+      compressionMode: compressionMode === "extractive" || compressionMode === "abstractive" ? compressionMode : "off",
       maxSentencesPerChunk: typeof maxSentencesPerChunk === "number" ? maxSentencesPerChunk : undefined,
     },
   };
@@ -402,6 +410,133 @@ async function applyRequestedRanking(
   }
 }
 
+function resolveCompressionTarget(registry?: ProviderRegistry): { provider: Provider; model: string } | null {
+  if (!registry) return null;
+  const providerName = process.env.PROVARA_CONTEXT_COMPRESSION_PROVIDER;
+  const modelName = process.env.PROVARA_CONTEXT_COMPRESSION_MODEL;
+  if (providerName && modelName) {
+    const provider = registry.get(providerName);
+    return provider && provider.models.includes(modelName) ? { provider, model: modelName } : null;
+  }
+  if (modelName) {
+    const provider = registry.getForModel(modelName);
+    return provider ? { provider, model: modelName } : null;
+  }
+  for (const provider of registry.list()) {
+    const model = provider.models[0];
+    if (model) return { provider, model };
+  }
+  return null;
+}
+
+function stripSummaryScaffolding(content: string): string {
+  return content
+    .replace(/^```(?:text|markdown)?/i, "")
+    .replace(/```$/i, "")
+    .trim();
+}
+
+function buildCompressionPrompt(chunk: OptimizedContextChunk, query: string | undefined): string {
+  const sourceIds = chunk.sourceIds.join(", ");
+  return [
+    "Compress the retrieved context below for model input.",
+    "Keep only facts supported by the source text. Do not add new facts.",
+    "Preserve names, numbers, dates, statuses, policy limits, and caveats.",
+    "Return plain text only. No bullets unless the source text requires them.",
+    query ? `User query: ${query}` : "",
+    `Source IDs: ${sourceIds}`,
+    "",
+    "Retrieved context:",
+    chunk.content,
+  ].filter(Boolean).join("\n");
+}
+
+async function summarizeChunk(
+  chunk: OptimizedContextChunk,
+  target: { provider: Provider; model: string },
+  query: string | undefined,
+): Promise<OptimizedContextChunk | null> {
+  const response = await target.provider.complete({
+    model: target.model,
+    routing_hint: "summarization",
+    temperature: 0,
+    max_tokens: Math.max(64, Math.min(512, Math.ceil(chunk.outputTokens * 0.7))),
+    messages: [
+      {
+        role: "system",
+        content: "You compress retrieved context for downstream model calls. You only preserve supported facts.",
+      },
+      {
+        role: "user",
+        content: buildCompressionPrompt(chunk, query),
+      },
+    ],
+  });
+
+  if (response.finish_reason === "content_filter") return null;
+  const content = stripSummaryScaffolding(response.content);
+  if (!content) return null;
+  const compressedTokens = estimateContextTokens(content);
+  if (compressedTokens >= chunk.outputTokens) return null;
+
+  return {
+    ...chunk,
+    content,
+    outputTokens: compressedTokens,
+    compressed: true,
+    originalTokens: chunk.originalTokens ?? chunk.outputTokens,
+    compressedTokens,
+  };
+}
+
+async function compressContextOptimizationResultAbstractively(
+  result: ContextOptimizationResult,
+  registry: ProviderRegistry | undefined,
+  options: { query?: string; maxSentencesPerChunk?: number },
+): Promise<ContextOptimizationResult> {
+  const fallback = compressContextOptimizationResult(result, options);
+  const target = resolveCompressionTarget(registry);
+  if (!target) return fallback;
+
+  const compressed: OptimizedContextChunk[] = [];
+  for (let index = 0; index < fallback.optimized.length; index += ABSTRACTIVE_COMPRESSION_BATCH_SIZE) {
+    const batch = fallback.optimized.slice(index, index + ABSTRACTIVE_COMPRESSION_BATCH_SIZE);
+    compressed.push(...await Promise.all(batch.map(async (chunk) => {
+      try {
+        return await summarizeChunk(chunk, target, options.query) ?? chunk;
+      } catch {
+        return chunk;
+      }
+    })));
+  }
+
+  const outputTokens = compressed.reduce((sum, chunk) => sum + chunk.outputTokens, 0);
+  const savedTokens = Math.max(0, result.metrics.inputTokens - outputTokens);
+  const compressionSavedTokens = compressed.reduce(
+    (sum, chunk) => sum + Math.max(0, (chunk.originalTokens ?? chunk.inputTokens) - chunk.outputTokens),
+    0,
+  );
+  const preCompressionTokens = outputTokens + compressionSavedTokens;
+
+  return {
+    ...fallback,
+    optimized: compressed,
+    metrics: {
+      ...fallback.metrics,
+      outputTokens,
+      savedTokens,
+      reductionPct: result.metrics.inputTokens === 0
+        ? 0
+        : Number(((savedTokens / result.metrics.inputTokens) * 100).toFixed(2)),
+      compressedChunks: compressed.filter((chunk) => chunk.compressed).length,
+      compressionSavedTokens,
+      compressionRatePct: preCompressionTokens === 0
+        ? 0
+        : Number(((compressionSavedTokens / preCompressionTokens) * 100).toFixed(2)),
+    },
+  };
+}
+
 export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOptions: ContextRouteOptions = {}) {
   const app = new Hono();
 
@@ -440,7 +575,11 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
     }
 
     const deferAsyncRanking = dedupe.options.rankMode === "embedding";
-    const deferCompression = (scanRisk.scanRisk || deferAsyncRanking) && dedupe.options.compressionMode === "extractive";
+    const deferCompression = dedupe.options.compressionMode !== "off" && (
+      scanRisk.scanRisk ||
+      deferAsyncRanking ||
+      dedupe.options.compressionMode === "abstractive"
+    );
     const baseOptions = deferCompression
       ? { ...dedupe.options, rankMode: deferAsyncRanking ? "none" as const : dedupe.options.rankMode, compressionMode: "off" as const }
       : deferAsyncRanking
@@ -451,7 +590,13 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       ? await applyRiskScan(db, tenantId, baseOptimization)
       : baseOptimization;
     const rankedOptimization = await applyRequestedRanking(scannedOptimization, dedupe.options, routeOptions);
-    const optimization = deferCompression
+    const compressionOptions = {
+      query: dedupe.options.query,
+      maxSentencesPerChunk: dedupe.options.maxSentencesPerChunk,
+    };
+    const optimization = dedupe.options.compressionMode === "abstractive"
+      ? await compressContextOptimizationResultAbstractively(rankedOptimization, registry, compressionOptions)
+      : deferCompression
       ? compressContextOptimizationResult(rankedOptimization, {
         query: dedupe.options.query,
         maxSentencesPerChunk: dedupe.options.maxSentencesPerChunk,

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -17,7 +17,10 @@ vi.mock("../src/auth/tenant.js", async (importOriginal) => ({
 
 import { requireIntelligenceTier } from "../src/auth/tier.js";
 
-function fakeRegistry(content = '{"rawScore": 4, "optimizedScore": 3, "rationale": "Optimized answer omitted one detail."}'): ProviderRegistry {
+function fakeRegistry(
+  content = '{"rawScore": 4, "optimizedScore": 3, "rationale": "Optimized answer omitted one detail."}',
+  finishReason: CompletionResponse["finish_reason"] = "stop",
+): ProviderRegistry {
   const provider: Provider = {
     name: "test-judge",
     models: ["gpt-4o-mini"],
@@ -27,7 +30,7 @@ function fakeRegistry(content = '{"rawScore": 4, "optimizedScore": 3, "rationale
         provider: "test-judge",
         model: request.model,
         content,
-        finish_reason: "stop",
+        finish_reason: finishReason,
         usage: { inputTokens: 10, outputTokens: 8 },
         latencyMs: 1,
       };
@@ -752,6 +755,107 @@ describe("POST /v1/context/optimize", () => {
       compressionSavedTokens: body.optimization.metrics.compressionSavedTokens,
       compressionRatePct: body.optimization.metrics.compressionRatePct,
     });
+  });
+
+  it("records abstractive compression analytics with provider summaries", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db, fakeRegistry("Refunds require a receipt within 30 days."));
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        compressionMode: "abstractive",
+        query: "What is the refund policy?",
+        chunks: [
+          {
+            id: "refunds-long",
+            content: [
+              "Refunds are available for paid accounts during the 30 day refund window.",
+              "A receipt is required before the support team can issue the refund.",
+              "Office locations are listed in the company directory.",
+              "Marketing launch notes are maintained by the brand team.",
+            ].join(" "),
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: {
+        optimized: Array<{ id: string; content: string; compressed?: boolean; originalTokens?: number; compressedTokens?: number }>;
+        metrics: { compressedChunks: number; compressionSavedTokens: number; compressionRatePct: number };
+      };
+      event: { compressedChunks: number; compressionSavedTokens: number; compressionRatePct: number };
+      retrieval: { compressedChunks: number; compressionSavedTokens: number; compressionRatePct: number };
+    };
+
+    expect(body.optimization.optimized[0]).toMatchObject({
+      content: "Refunds require a receipt within 30 days.",
+      compressed: true,
+      originalTokens: expect.any(Number),
+      compressedTokens: expect.any(Number),
+    });
+    expect(body.optimization.metrics.compressedChunks).toBe(1);
+    expect(body.optimization.metrics.compressionSavedTokens).toBeGreaterThan(0);
+    expect(body.event).toMatchObject({
+      compressedChunks: body.optimization.metrics.compressedChunks,
+      compressionSavedTokens: body.optimization.metrics.compressionSavedTokens,
+      compressionRatePct: body.optimization.metrics.compressionRatePct,
+    });
+    expect(body.retrieval).toMatchObject({
+      compressedChunks: body.optimization.metrics.compressedChunks,
+      compressionSavedTokens: body.optimization.metrics.compressionSavedTokens,
+      compressionRatePct: body.optimization.metrics.compressionRatePct,
+    });
+  });
+
+  it("falls back to extractive compression when abstractive compression is refused", async () => {
+    process.env.PROVARA_CLOUD = "true";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db, fakeRegistry("", "content_filter"));
+
+    const res = await app.request("/v1/context/optimize", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-test-tenant": "tenant-pro",
+      },
+      body: JSON.stringify({
+        compressionMode: "abstractive",
+        maxSentencesPerChunk: 1,
+        query: "refund receipt",
+        chunks: [
+          {
+            id: "refunds-long",
+            content: [
+              "Refunds are available for paid accounts during the 30 day refund window.",
+              "A receipt is required before the support team can issue the refund.",
+              "Office locations are listed in the company directory.",
+            ].join(" "),
+          },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      optimization: {
+        optimized: Array<{ content: string; compressed?: boolean }>;
+        metrics: { compressedChunks: number; compressionSavedTokens: number };
+      };
+    };
+
+    expect(body.optimization.optimized[0].content).toContain("receipt");
+    expect(body.optimization.optimized[0].content).not.toBe("");
+    expect(body.optimization.optimized[0].compressed).toBe(true);
+    expect(body.optimization.metrics.compressedChunks).toBe(1);
+    expect(body.optimization.metrics.compressionSavedTokens).toBeGreaterThan(0);
   });
 
   it("records relevance analytics for lexical ranking", async () => {


### PR DESCRIPTION
Closes #363

## Summary
- adds compressionMode=abstractive for Context Optimizer
- summarizes retained chunks through the configured provider when explicitly requested
- preserves provenance and compression metrics while falling back to extractive/original content on errors, refusals, empty summaries, or token growth
- keeps risk scanning before model-backed compression
- updates GUI option, OpenAPI, docs, roadmap, changelog, and route tests

## Verification
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npx tsc --noEmit -p packages/gateway/tsconfig.json
- npx tsc --noEmit -p apps/web/tsconfig.json
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts tests/demo.test.ts
- node -e OpenAPI YAML parse
- git diff --check
- npm test --workspace @provara/gateway
- npm test --workspace @provara/web
- npm run build --workspace @provara/gateway
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
