### PR TITLE
feat(#365): add managed context collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable Provara changes are tracked here.
   - Context Optimizer scored contradiction detection with `conflictMode: "scored"`, bounded conflict scores, severity bands, APIs, and dashboard visibility.
   - Context Optimizer extractive compression with `compressionMode: "extractive"`, bounded sentence selection, compression savings metrics, demo rows, APIs, and dashboard visibility.
   - Context Optimizer abstractive compression with `compressionMode: "abstractive"`, provider summaries, provenance preservation, and extractive/original fallback on errors, refusals, or token growth.
+  - Managed context collections with tenant-scoped collection APIs, plain-text document ingestion, deterministic block chunking, source provenance, and dashboard visibility.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -39,7 +40,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, and dashboard configuration controls as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, and managed context collections as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -54,13 +55,16 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, and compression metrics, run database migrations through `0053_context_compression_metrics`.
+- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, and managed collections, run database migrations through `0054_context_content_store`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
   - `context_optimization_events`
   - `context_quality_events`
   - `context_retrieval_events`
+  - `context_collections`
+  - `context_documents`
+  - `context_blocks`
 - Existing tenants keep the safe default firewall settings:
   - `defaultScanMode: "signature"`
   - `toolCallAlignment: "block"`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -166,6 +166,19 @@ export interface ContextRetrievalEvent {
   createdAt: string;
 }
 
+export interface ContextCollection {
+  id: string;
+  tenantId: string | null;
+  name: string;
+  description: string | null;
+  status: "active" | "archived";
+  documentCount: number;
+  blockCount: number;
+  tokenCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface GateState {
   message: string;
   upgradeUrl?: string;
@@ -178,6 +191,7 @@ interface LoadState {
   qualityEvents: ContextQualityEvent[];
   retrievalSummary: ContextRetrievalSummary | null;
   retrievalEvents: ContextRetrievalEvent[];
+  collections: ContextCollection[];
   loading: boolean;
   error: string | null;
   gate: GateState | null;
@@ -544,6 +558,7 @@ export function ContextOptimizerPanel() {
     qualityEvents: [],
     retrievalSummary: null,
     retrievalEvents: [],
+    collections: [],
     loading: true,
     error: null,
     gate: null,
@@ -563,6 +578,7 @@ export function ContextOptimizerPanel() {
           qualityEventsRes,
           retrievalSummaryRes,
           retrievalEventsRes,
+          collectionsRes,
         ] = await Promise.all([
           gatewayFetchRaw("/v1/context/summary"),
           gatewayFetchRaw("/v1/context/events?limit=25"),
@@ -570,6 +586,7 @@ export function ContextOptimizerPanel() {
           gatewayFetchRaw("/v1/context/quality/events?limit=10"),
           gatewayFetchRaw("/v1/context/retrieval/summary"),
           gatewayFetchRaw("/v1/context/retrieval/events?limit=10"),
+          gatewayFetchRaw("/v1/context/collections"),
         ]);
 
         const responses = [
@@ -579,6 +596,7 @@ export function ContextOptimizerPanel() {
           qualityEventsRes,
           retrievalSummaryRes,
           retrievalEventsRes,
+          collectionsRes,
         ];
         if (
           responses.some((res) => res.status === 402)
@@ -594,6 +612,7 @@ export function ContextOptimizerPanel() {
               qualityEvents: [],
               retrievalSummary: null,
               retrievalEvents: [],
+              collections: [],
               loading: false,
               error: null,
               gate: {
@@ -615,6 +634,7 @@ export function ContextOptimizerPanel() {
         const qualityEventsBody = await qualityEventsRes.json() as { events: ContextQualityEvent[] };
         const retrievalSummaryBody = await retrievalSummaryRes.json() as { summary: ContextRetrievalSummary };
         const retrievalEventsBody = await retrievalEventsRes.json() as { events: ContextRetrievalEvent[] };
+        const collectionsBody = await collectionsRes.json() as { collections: ContextCollection[] };
 
         if (!cancelled) {
           setState({
@@ -624,6 +644,7 @@ export function ContextOptimizerPanel() {
             qualityEvents: qualityEventsBody.events,
             retrievalSummary: retrievalSummaryBody.summary,
             retrievalEvents: retrievalEventsBody.events,
+            collections: collectionsBody.collections,
             loading: false,
             error: null,
             gate: null,
@@ -638,6 +659,7 @@ export function ContextOptimizerPanel() {
             qualityEvents: [],
             retrievalSummary: null,
             retrievalEvents: [],
+            collections: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
             gate: null,
@@ -658,6 +680,7 @@ export function ContextOptimizerPanel() {
   const qualityRows = useMemo(() => state.qualityEvents, [state.qualityEvents]);
   const retrievalSummary = state.retrievalSummary;
   const retrievalRows = useMemo(() => state.retrievalEvents, [state.retrievalEvents]);
+  const collectionRows = useMemo(() => state.collections, [state.collections]);
 
   return (
     <div className="space-y-6">
@@ -722,6 +745,67 @@ export function ContextOptimizerPanel() {
       </div>
 
       <OptimizerConfigPanel />
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Managed Collections</h2>
+          <p className="mt-1 text-sm text-zinc-500">Persisted context collections for reusable knowledge blocks.</p>
+        </div>
+
+        {state.loading ? (
+          <LoadingRows />
+        ) : collectionRows.length === 0 ? (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center text-sm text-zinc-400">
+            No managed context collections yet.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">Collection</th>
+                    <th className="px-4 py-3 text-right font-medium">Documents</th>
+                    <th className="px-4 py-3 text-right font-medium">Blocks</th>
+                    <th className="px-4 py-3 text-right font-medium">Tokens</th>
+                    <th className="px-4 py-3 text-left font-medium">Status</th>
+                    <th className="px-4 py-3 text-left font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {collectionRows.map((collection) => (
+                    <tr key={collection.id}>
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-zinc-200">{collection.name}</div>
+                        <div className="mt-1 max-w-xl truncate text-xs text-zinc-500">
+                          {collection.description || collection.id}
+                        </div>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(collection.documentCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(collection.blockCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-emerald-300">
+                        {formatInteger(collection.tokenCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <span className="rounded border border-emerald-900/70 bg-emerald-950/20 px-2 py-0.5 text-xs capitalize text-emerald-200">
+                          {collection.status}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
+                        {formatTimestamp(collection.updatedAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
 
       <section>
         <div className="mb-3">

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -159,6 +159,24 @@ describe("ContextOptimizerPanel", () => {
           ],
         }));
       }
+      if (path === "/v1/context/collections") {
+        return Promise.resolve(jsonResponse({
+          collections: [
+            {
+              id: "collection-1",
+              tenantId: "tenant-pro",
+              name: "Support KB",
+              description: "Approved support context",
+              status: "active",
+              documentCount: 2,
+              blockCount: 8,
+              tokenCount: 1400,
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T22:00:00.000Z",
+            },
+          ],
+        }));
+      }
       return Promise.resolve(jsonResponse({
         events: [
           {
@@ -241,6 +259,9 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getAllByText("Compression").length).toBeGreaterThan(0);
     expect(screen.getByText("Semantic Rate")).toBeInTheDocument();
     expect(screen.getAllByText("chunk-risky").length).toBeGreaterThan(0);
+    expect(screen.getByText("Managed Collections")).toBeInTheDocument();
+    expect(screen.getByText("Support KB")).toBeInTheDocument();
+    expect(screen.getByText("Approved support context")).toBeInTheDocument();
   });
 
   it("updates and persists optimizer payload controls", async () => {
@@ -316,6 +337,9 @@ describe("ContextOptimizerPanel", () => {
             latestAt: null,
           },
         }));
+      }
+      if (path === "/v1/context/collections") {
+        return Promise.resolve(jsonResponse({ collections: [] }));
       }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
@@ -417,6 +441,9 @@ describe("ContextOptimizerPanel", () => {
       if (path === "/v1/context/retrieval/events?limit=10") {
         return Promise.resolve(jsonResponse({ events: [] }));
       }
+      if (path === "/v1/context/collections") {
+        return Promise.resolve(jsonResponse({ collections: [] }));
+      }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
 
@@ -425,6 +452,7 @@ describe("ContextOptimizerPanel", () => {
     expect(await screen.findByText("No context optimization events yet.")).toBeInTheDocument();
     expect(screen.getByText("No context quality checks yet.")).toBeInTheDocument();
     expect(screen.getByText("No context retrieval events yet.")).toBeInTheDocument();
+    expect(screen.getByText("No managed context collections yet.")).toBeInTheDocument();
   });
 
   it("shows upgrade messaging for gated tenants", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -29,9 +29,10 @@ Implemented as of `0.2.0`:
 - Optional extractive compression with bounded sentence selection, compression savings metrics, and dashboard visibility.
 - Optional abstractive compression with provider summaries, provenance preservation, and mechanical fallback.
 - Dashboard configuration controls for drafting optimizer payloads.
+- Managed context collections with plain-text ingestion into stored documents and reusable blocks.
 
 Next planned layer:
-- Persistent knowledge distillation and managed content stores.
+- Canonical knowledge distillation, review states, and approved-only export.
 
 ## V1: Runtime Context Optimizer
 
@@ -91,7 +92,7 @@ Capabilities:
 Move from per-request optimization to reusable canonical knowledge.
 
 Capabilities:
-- Batch document ingestion.
+- Batch document ingestion. Foundation shipped with managed collections and plain-text ingestion.
 - Canonical knowledge blocks.
 - Source references and provenance.
 - Versioning and diffs.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -20,11 +20,12 @@ The shipped V1 implementation is intentionally narrow:
 - Flagged and quarantined context buckets with rule evidence and source IDs.
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
+- Managed context collections with plain-text ingestion into reusable blocks.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
 
-It does not yet perform embedding-backed semantic deduplication or persistent review workflows. Those belong to later roadmap phases.
+It does not yet perform persistent review workflows or connector-backed ingestion. Those belong to later roadmap phases.
 
 ## API
 
@@ -104,6 +105,16 @@ GET /v1/context/retrieval/events
 
 These endpoints are tenant-scoped and require Intelligence access.
 
+Managed collection APIs:
+
+```text
+GET /v1/context/collections
+POST /v1/context/collections
+POST /v1/context/collections/{id}/documents
+```
+
+Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters. This is the V2 foundation for review queues, connectors, canonical knowledge blocks, and vector export.
+
 Quality evaluation is available through:
 
 ```text
@@ -143,6 +154,8 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
+The Managed Collections section lists persisted context collections, including document count, block count, estimated token count, status, and last update time. Creation and ingestion are available through the API in this release; richer collection management remains a follow-up.
+
 The Recent Events table shows:
 
 - Event time.
@@ -180,7 +193,8 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is retrieval quality:
+The next behavior layer is persistent knowledge distillation:
 
-- Stronger contradiction scoring beyond bounded heuristic checks.
-- Abstractive compression with strict provenance and fallback behavior.
+- Canonical block generation and deduplication across documents.
+- Human review and approval states for managed blocks.
+- Approved-only export controls for retrieval systems.

--- a/packages/db/drizzle/0054_context_content_store.sql
+++ b/packages/db/drizzle/0054_context_content_store.sql
@@ -1,0 +1,57 @@
+CREATE TABLE `context_collections` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `name` text NOT NULL,
+  `description` text,
+  `status` text DEFAULT 'active' NOT NULL,
+  `document_count` integer DEFAULT 0 NOT NULL,
+  `block_count` integer DEFAULT 0 NOT NULL,
+  `token_count` integer DEFAULT 0 NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `context_collections_tenant_updated_idx` ON `context_collections` (`tenant_id`,`updated_at`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `context_collections_tenant_name_idx` ON `context_collections` (`tenant_id`,`name`);
+--> statement-breakpoint
+CREATE TABLE `context_documents` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `collection_id` text NOT NULL,
+  `title` text NOT NULL,
+  `source` text,
+  `source_uri` text,
+  `content_hash` text NOT NULL,
+  `metadata` text DEFAULT '{}' NOT NULL,
+  `block_count` integer NOT NULL,
+  `token_count` integer NOT NULL,
+  `created_at` integer NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `context_collections`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `context_documents_tenant_collection_idx` ON `context_documents` (`tenant_id`,`collection_id`);
+--> statement-breakpoint
+CREATE INDEX `context_documents_hash_idx` ON `context_documents` (`content_hash`);
+--> statement-breakpoint
+CREATE TABLE `context_blocks` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `collection_id` text NOT NULL,
+  `document_id` text NOT NULL,
+  `ordinal` integer NOT NULL,
+  `content` text NOT NULL,
+  `content_hash` text NOT NULL,
+  `token_count` integer NOT NULL,
+  `source` text,
+  `metadata` text DEFAULT '{}' NOT NULL,
+  `created_at` integer NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `context_collections`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`document_id`) REFERENCES `context_documents`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `context_blocks_tenant_collection_idx` ON `context_blocks` (`tenant_id`,`collection_id`);
+--> statement-breakpoint
+CREATE INDEX `context_blocks_document_ordinal_idx` ON `context_blocks` (`document_id`,`ordinal`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `context_blocks_document_ordinal_unique_idx` ON `context_blocks` (`document_id`,`ordinal`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1777668600000,
       "tag": "0053_context_compression_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "6",
+      "when": 1777670700000,
+      "tag": "0054_context_content_store",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -422,6 +422,71 @@ export const contextRetrievalEvents = sqliteTable("context_retrieval_events", {
   index("context_retrieval_events_optimization_idx").on(table.optimizationEventId),
 ]);
 
+export const contextCollections = sqliteTable("context_collections", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  name: text("name").notNull(),
+  description: text("description"),
+  status: text("status", { enum: ["active", "archived"] }).notNull().default("active"),
+  documentCount: integer("document_count").notNull().default(0),
+  blockCount: integer("block_count").notNull().default(0),
+  tokenCount: integer("token_count").notNull().default(0),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_collections_tenant_updated_idx").on(table.tenantId, table.updatedAt),
+  uniqueIndex("context_collections_tenant_name_idx").on(table.tenantId, table.name),
+]);
+
+export const contextDocuments = sqliteTable("context_documents", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => contextCollections.id),
+  title: text("title").notNull(),
+  source: text("source"),
+  sourceUri: text("source_uri"),
+  contentHash: text("content_hash").notNull(),
+  metadata: text("metadata").notNull().default("{}"),
+  blockCount: integer("block_count").notNull(),
+  tokenCount: integer("token_count").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_documents_tenant_collection_idx").on(table.tenantId, table.collectionId),
+  index("context_documents_hash_idx").on(table.contentHash),
+]);
+
+export const contextBlocks = sqliteTable("context_blocks", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => contextCollections.id),
+  documentId: text("document_id")
+    .notNull()
+    .references(() => contextDocuments.id),
+  ordinal: integer("ordinal").notNull(),
+  content: text("content").notNull(),
+  contentHash: text("content_hash").notNull(),
+  tokenCount: integer("token_count").notNull(),
+  source: text("source"),
+  metadata: text("metadata").notNull().default("{}"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_blocks_tenant_collection_idx").on(table.tenantId, table.collectionId),
+  index("context_blocks_document_ordinal_idx").on(table.documentId, table.ordinal),
+  uniqueIndex("context_blocks_document_ordinal_unique_idx").on(table.documentId, table.ordinal),
+]);
+
 export const alertRules = sqliteTable("alert_rules", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -470,6 +470,96 @@ paths:
         "402":
           $ref: "#/components/responses/InsufficientTier"
 
+  /v1/context/collections:
+    get:
+      tags: [Context Optimizer]
+      summary: List managed context collections
+      operationId: listContextCollections
+      responses:
+        "200":
+          description: Managed context collections
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [collections]
+                properties:
+                  collections:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextCollection"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+    post:
+      tags: [Context Optimizer]
+      summary: Create a managed context collection
+      operationId: createContextCollection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateContextCollectionRequest"
+      responses:
+        "201":
+          description: Created collection
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [collection]
+                properties:
+                  collection:
+                    $ref: "#/components/schemas/ContextCollection"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "409":
+          description: Collection name already exists.
+
+  /v1/context/collections/{id}/documents:
+    post:
+      tags: [Context Optimizer]
+      summary: Ingest text into a managed context collection
+      description: Deterministically chunks plain text into stored context blocks with source and metadata provenance.
+      operationId: ingestContextDocument
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IngestContextDocumentRequest"
+      responses:
+        "201":
+          description: Ingested document and stored blocks
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [collection, document, blocks]
+                properties:
+                  collection:
+                    $ref: "#/components/schemas/ContextCollection"
+                  document:
+                    $ref: "#/components/schemas/ContextDocument"
+                  blocks:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextBlockMetadata"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
   /v1/context/summary:
     get:
       tags: [Context Optimizer]
@@ -2515,6 +2605,161 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    CreateContextCollectionRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        description:
+          type: string
+          maxLength: 1000
+
+    IngestContextDocumentRequest:
+      type: object
+      required: [text]
+      properties:
+        title:
+          type: string
+          maxLength: 200
+        text:
+          type: string
+          minLength: 1
+          maxLength: 500000
+        source:
+          type: string
+          maxLength: 120
+        sourceUri:
+          type: string
+          maxLength: 2000
+        metadata:
+          type: object
+          additionalProperties: true
+
+    ContextCollection:
+      type: object
+      required: [id, tenantId, name, description, status, documentCount, blockCount, tokenCount, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [active, archived]
+        documentCount:
+          type: integer
+        blockCount:
+          type: integer
+        tokenCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ContextDocument:
+      type: object
+      required: [id, tenantId, collectionId, title, source, sourceUri, contentHash, metadata, blockCount, tokenCount, createdAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        title:
+          type: string
+        source:
+          type: string
+          nullable: true
+        sourceUri:
+          type: string
+          nullable: true
+        contentHash:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: true
+        blockCount:
+          type: integer
+        tokenCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+
+    ContextBlock:
+      type: object
+      required: [id, tenantId, collectionId, documentId, ordinal, content, contentHash, tokenCount, source, metadata, createdAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        documentId:
+          type: string
+        ordinal:
+          type: integer
+        content:
+          type: string
+        contentHash:
+          type: string
+        tokenCount:
+          type: integer
+        source:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+
+    ContextBlockMetadata:
+      type: object
+      required: [id, tenantId, collectionId, documentId, ordinal, contentHash, tokenCount, source, metadata, createdAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        documentId:
+          type: string
+        ordinal:
+          type: integer
+        contentHash:
+          type: string
+        tokenCount:
+          type: integer
+        source:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
 
     ContextQualityEvaluateRequest:
       type: object

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -1,0 +1,332 @@
+import { createHash } from "node:crypto";
+import type { Db } from "@provara/db";
+import { contextBlocks, contextCollections, contextDocuments } from "@provara/db";
+import { and, desc, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { tenantFilter, tenantScoped } from "../auth/tenant.js";
+import { estimateContextTokens } from "./optimizer.js";
+
+const MAX_COLLECTION_NAME_CHARS = 120;
+const MAX_COLLECTION_DESCRIPTION_CHARS = 1_000;
+const MAX_DOCUMENT_TITLE_CHARS = 200;
+const MAX_SOURCE_CHARS = 120;
+const MAX_SOURCE_URI_CHARS = 2_000;
+const MAX_METADATA_CHARS = 20_000;
+const MAX_INGEST_TEXT_CHARS = 500_000;
+const TARGET_BLOCK_CHARS = 1_800;
+const MIN_BOUNDARY_CHARS = 900;
+const BLOCK_INSERT_BATCH_SIZE = 50;
+
+export interface ContextCollection {
+  id: string;
+  tenantId: string | null;
+  name: string;
+  description: string | null;
+  status: "active" | "archived";
+  documentCount: number;
+  blockCount: number;
+  tokenCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ContextDocument {
+  id: string;
+  tenantId: string | null;
+  collectionId: string;
+  title: string;
+  source: string | null;
+  sourceUri: string | null;
+  contentHash: string;
+  metadata: Record<string, unknown>;
+  blockCount: number;
+  tokenCount: number;
+  createdAt: Date;
+}
+
+export interface ContextBlock {
+  id: string;
+  tenantId: string | null;
+  collectionId: string;
+  documentId: string;
+  ordinal: number;
+  content: string;
+  contentHash: string;
+  tokenCount: number;
+  source: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface IngestContextDocumentInput {
+  title?: string;
+  text: string;
+  source?: string;
+  sourceUri?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ValidationResult<T> {
+  value?: T;
+  error?: string;
+}
+
+function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function parseMetadata(value: string | null): Record<string, unknown> {
+  if (!value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function collectionFromRow(row: typeof contextCollections.$inferSelect): ContextCollection {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    name: row.name,
+    description: row.description,
+    status: row.status,
+    documentCount: row.documentCount,
+    blockCount: row.blockCount,
+    tokenCount: row.tokenCount,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function documentFromRow(row: typeof contextDocuments.$inferSelect): ContextDocument {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    collectionId: row.collectionId,
+    title: row.title,
+    source: row.source,
+    sourceUri: row.sourceUri,
+    contentHash: row.contentHash,
+    metadata: parseMetadata(row.metadata),
+    blockCount: row.blockCount,
+    tokenCount: row.tokenCount,
+    createdAt: row.createdAt,
+  };
+}
+
+function blockFromRow(row: typeof contextBlocks.$inferSelect): ContextBlock {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    collectionId: row.collectionId,
+    documentId: row.documentId,
+    ordinal: row.ordinal,
+    content: row.content,
+    contentHash: row.contentHash,
+    tokenCount: row.tokenCount,
+    source: row.source,
+    metadata: parseMetadata(row.metadata),
+    createdAt: row.createdAt,
+  };
+}
+
+function trimOptional(value: unknown, field: string, maxChars: number): ValidationResult<string | undefined> {
+  if (value === undefined || value === null) return { value: undefined };
+  if (typeof value !== "string") return { error: `${field} must be a string` };
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return { value: undefined };
+  if (trimmed.length > maxChars) return { error: `${field} must be at most ${maxChars} characters` };
+  return { value: trimmed };
+}
+
+export function validateCreateCollectionBody(value: unknown): ValidationResult<{ name: string; description?: string }> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { error: "body must be an object" };
+  }
+  const body = value as Record<string, unknown>;
+  const name = trimOptional(body.name, "name", MAX_COLLECTION_NAME_CHARS);
+  if (name.error) return { error: name.error };
+  if (!name.value) return { error: "name is required" };
+  const description = trimOptional(body.description, "description", MAX_COLLECTION_DESCRIPTION_CHARS);
+  if (description.error) return { error: description.error };
+  return { value: { name: name.value, description: description.value } };
+}
+
+export function validateIngestDocumentBody(value: unknown): ValidationResult<IngestContextDocumentInput> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { error: "body must be an object" };
+  }
+  const body = value as Record<string, unknown>;
+  if (typeof body.text !== "string") return { error: "text is required" };
+  const text = body.text.trim();
+  if (text.length === 0) return { error: "text is required" };
+  if (text.length > MAX_INGEST_TEXT_CHARS) return { error: `text must be at most ${MAX_INGEST_TEXT_CHARS} characters` };
+
+  const title = trimOptional(body.title, "title", MAX_DOCUMENT_TITLE_CHARS);
+  if (title.error) return { error: title.error };
+  const source = trimOptional(body.source, "source", MAX_SOURCE_CHARS);
+  if (source.error) return { error: source.error };
+  const sourceUri = trimOptional(body.sourceUri, "sourceUri", MAX_SOURCE_URI_CHARS);
+  if (sourceUri.error) return { error: sourceUri.error };
+
+  let metadata: Record<string, unknown> | undefined;
+  if (body.metadata !== undefined) {
+    if (typeof body.metadata !== "object" || body.metadata === null || Array.isArray(body.metadata)) {
+      return { error: "metadata must be an object" };
+    }
+    const encoded = JSON.stringify(body.metadata);
+    if (encoded.length > MAX_METADATA_CHARS) return { error: `metadata must encode to at most ${MAX_METADATA_CHARS} characters` };
+    metadata = body.metadata as Record<string, unknown>;
+  }
+
+  return {
+    value: {
+      title: title.value,
+      text,
+      source: source.value,
+      sourceUri: sourceUri.value,
+      metadata,
+    },
+  };
+}
+
+export function chunkContextText(text: string): string[] {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+  const chunks: string[] = [];
+  let start = 0;
+
+  while (start < normalized.length) {
+    let end = Math.min(normalized.length, start + TARGET_BLOCK_CHARS);
+    if (end < normalized.length) {
+      const paragraph = normalized.lastIndexOf("\n\n", end);
+      const sentence = normalized.lastIndexOf(". ", end);
+      const space = normalized.lastIndexOf(" ", end);
+      const boundary = [paragraph, sentence > -1 ? sentence + 1 : -1, space]
+        .filter((index) => index >= start + MIN_BOUNDARY_CHARS)
+        .sort((left, right) => right - left)[0];
+      if (boundary !== undefined) end = boundary;
+    }
+
+    const chunk = normalized.slice(start, end).trim();
+    if (chunk) chunks.push(chunk);
+    start = end;
+    while (start < normalized.length && /\s/.test(normalized[start] ?? "")) start += 1;
+  }
+
+  return chunks;
+}
+
+export async function createContextCollection(
+  db: Db,
+  tenantId: string | null,
+  input: { name: string; description?: string },
+): Promise<ContextCollection> {
+  const duplicateWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.name, input.name));
+  const existing = await db.select({ id: contextCollections.id }).from(contextCollections).where(duplicateWhere).get();
+  if (existing) throw new Error("collection name already exists");
+
+  const id = nanoid();
+  const now = new Date();
+  await db.insert(contextCollections).values({
+    id,
+    tenantId,
+    name: input.name,
+    description: input.description ?? null,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+
+  const row = await db.select().from(contextCollections).where(eq(contextCollections.id, id)).get();
+  if (!row) throw new Error("Failed to create context collection");
+  return collectionFromRow(row);
+}
+
+export async function listContextCollections(db: Db, tenantId: string | null): Promise<ContextCollection[]> {
+  const rows = await db
+    .select()
+    .from(contextCollections)
+    .where(tenantFilter(contextCollections.tenantId, tenantId))
+    .orderBy(desc(contextCollections.updatedAt))
+    .all();
+  return rows.map(collectionFromRow);
+}
+
+export async function ingestContextDocument(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+  input: IngestContextDocumentInput,
+): Promise<{ collection: ContextCollection; document: ContextDocument; blocks: ContextBlock[] }> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collection = await db.select().from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("collection not found");
+  if (collection.status !== "active") throw new Error("collection is archived");
+
+  const rawBlocks = chunkContextText(input.text);
+  if (rawBlocks.length === 0) throw new Error("text is required");
+  const now = new Date();
+  const documentId = nanoid();
+  const blockRows = rawBlocks.map((content, index) => {
+    const metadata = {
+      ...(input.metadata ?? {}),
+      sourceDocumentId: documentId,
+      blockOrdinal: index,
+    };
+    return {
+      id: nanoid(),
+      tenantId,
+      collectionId,
+      documentId,
+      ordinal: index,
+      content,
+      contentHash: hashContent(content),
+      tokenCount: estimateContextTokens(content),
+      source: input.source ?? null,
+      metadata: JSON.stringify(metadata),
+      createdAt: now,
+    };
+  });
+  const tokenCount = blockRows.reduce((sum, block) => sum + block.tokenCount, 0);
+
+  await db.insert(contextDocuments).values({
+    id: documentId,
+    tenantId,
+    collectionId,
+    title: input.title ?? input.source ?? "Untitled document",
+    source: input.source ?? null,
+    sourceUri: input.sourceUri ?? null,
+    contentHash: hashContent(input.text),
+    metadata: JSON.stringify(input.metadata ?? {}),
+    blockCount: blockRows.length,
+    tokenCount,
+    createdAt: now,
+  }).run();
+  for (let index = 0; index < blockRows.length; index += BLOCK_INSERT_BATCH_SIZE) {
+    await db.insert(contextBlocks).values(blockRows.slice(index, index + BLOCK_INSERT_BATCH_SIZE)).run();
+  }
+
+  await db.update(contextCollections).set({
+    documentCount: collection.documentCount + 1,
+    blockCount: collection.blockCount + blockRows.length,
+    tokenCount: collection.tokenCount + tokenCount,
+    updatedAt: now,
+  }).where(eq(contextCollections.id, collectionId)).run();
+
+  const updatedCollection = await db.select().from(contextCollections).where(eq(contextCollections.id, collectionId)).get();
+  const document = await db.select().from(contextDocuments).where(eq(contextDocuments.id, documentId)).get();
+  const blocks = await db
+    .select()
+    .from(contextBlocks)
+    .where(and(eq(contextBlocks.documentId, documentId), eq(contextBlocks.collectionId, collectionId)))
+    .orderBy(contextBlocks.ordinal)
+    .all();
+
+  if (!updatedCollection || !document) throw new Error("Failed to ingest context document");
+  return {
+    collection: collectionFromRow(updatedCollection),
+    document: documentFromRow(document),
+    blocks: blocks.map(blockFromRow),
+  };
+}

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -28,6 +28,13 @@ import {
   recordContextRetrievalEvent,
   summarizeContextRetrievalEvents,
 } from "../context/retrieval.js";
+import {
+  createContextCollection,
+  ingestContextDocument,
+  listContextCollections,
+  validateCreateCollectionBody,
+  validateIngestDocumentBody,
+} from "../context/store.js";
 import { getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
@@ -610,6 +617,75 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
     });
 
     return c.json({ optimization, event, retrieval });
+  });
+
+  app.get("/collections", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collections = await listContextCollections(db, tenantId);
+    return c.json({ collections });
+  });
+
+  app.post("/collections", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateCreateCollectionBody(body);
+    if (!parsed.value) {
+      return c.json(
+        { error: { message: parsed.error || "invalid collection body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const collection = await createContextCollection(db, tenantId, parsed.value);
+      return c.json({ collection }, 201);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to create context collection";
+      return c.json(
+        { error: { message, type: message.includes("already exists") ? "conflict_error" : "store_error" } },
+        message.includes("already exists") ? 409 : 500,
+      );
+    }
+  });
+
+  app.post("/collections/:id/documents", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateIngestDocumentBody(body);
+    if (!parsed.value) {
+      return c.json(
+        { error: { message: parsed.error || "invalid document body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const result = await ingestContextDocument(db, tenantId, collectionId, parsed.value);
+      return c.json({
+        collection: result.collection,
+        document: result.document,
+        blocks: result.blocks.map((block) => ({
+          id: block.id,
+          tenantId: block.tenantId,
+          collectionId: block.collectionId,
+          documentId: block.documentId,
+          ordinal: block.ordinal,
+          contentHash: block.contentHash,
+          tokenCount: block.tokenCount,
+          source: block.source,
+          metadata: block.metadata,
+          createdAt: block.createdAt,
+        })),
+      }, 201);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to ingest context document";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
   });
 
   app.get("/events", async (c) => {

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
-import { contextOptimizationEvents, contextQualityEvents, contextRetrievalEvents, guardrailRules } from "@provara/db";
+import {
+  contextBlocks,
+  contextCollections,
+  contextDocuments,
+  contextOptimizationEvents,
+  contextQualityEvents,
+  contextRetrievalEvents,
+  guardrailRules,
+} from "@provara/db";
 import type { ProviderRegistry } from "../src/providers/index.js";
 import type { CompletionRequest, CompletionResponse, Provider, StreamChunk } from "../src/providers/types.js";
 import type { EmbeddingProvider } from "../src/embeddings/index.js";
@@ -1542,5 +1550,158 @@ describe("POST /v1/context/optimize", () => {
       avgDelta: 0.5,
     });
     expect(summaryBody.summary.latestAt).toEqual(expect.any(String));
+  });
+});
+
+describe("managed context collections", () => {
+  let db: Db;
+
+  beforeEach(async () => {
+    db = await makeTestDb();
+    resetTierEnv();
+    process.env.PROVARA_CLOUD = "true";
+  });
+
+  afterEach(() => {
+    resetTierEnv();
+  });
+
+  it("creates and lists tenant-scoped collections", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+
+    const createRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Support KB", description: "Approved support articles" }),
+    });
+    expect(createRes.status).toBe(201);
+    const createBody = await createRes.json() as {
+      collection: { id: string; tenantId: string; name: string; description: string; documentCount: number; blockCount: number };
+    };
+    expect(createBody.collection).toMatchObject({
+      tenantId: "tenant-pro",
+      name: "Support KB",
+      description: "Approved support articles",
+      documentCount: 0,
+      blockCount: 0,
+    });
+
+    await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({ name: "Other KB" }),
+    });
+
+    const listRes = await app.request("/v1/context/collections", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json() as { collections: Array<{ tenantId: string; name: string }> };
+    expect(listBody.collections).toEqual([
+      expect.objectContaining({ tenantId: "tenant-pro", name: "Support KB" }),
+    ]);
+  });
+
+  it("ingests text into deterministic blocks with provenance metadata", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Policy KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const text = [
+      "Refunds require a receipt and must be requested within 30 days.",
+      "Enterprise customers can request an exception through support.",
+      "Billing admins can download invoices from the billing workspace.",
+    ].join("\n\n");
+    const ingestRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        title: "Refund policy",
+        text,
+        source: "help-center",
+        sourceUri: "https://example.com/refunds",
+        metadata: { owner: "support" },
+      }),
+    });
+
+    expect(ingestRes.status).toBe(201);
+    const ingestBody = await ingestRes.json() as {
+      collection: { documentCount: number; blockCount: number; tokenCount: number };
+      document: { title: string; blockCount: number; tokenCount: number; metadata: Record<string, unknown> };
+      blocks: Array<{ ordinal: number; source: string; metadata: Record<string, unknown>; contentHash: string; tokenCount: number }>;
+    };
+    expect(ingestBody.collection.documentCount).toBe(1);
+    expect(ingestBody.collection.blockCount).toBe(1);
+    expect(ingestBody.collection.tokenCount).toBeGreaterThan(0);
+    expect(ingestBody.document).toMatchObject({
+      title: "Refund policy",
+      blockCount: 1,
+      metadata: { owner: "support" },
+    });
+    expect(ingestBody.blocks).toHaveLength(1);
+    expect(ingestBody.blocks[0]).toMatchObject({
+      ordinal: 0,
+      source: "help-center",
+      metadata: expect.objectContaining({ owner: "support", blockOrdinal: 0 }),
+      contentHash: expect.any(String),
+      tokenCount: expect.any(Number),
+    });
+
+    const rows = await db.select().from(contextBlocks).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toContain("Refunds require a receipt");
+  });
+
+  it("rejects invalid ingest requests before writing rows", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Empty guard" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const ingestRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ title: "Bad", text: "   " }),
+    });
+
+    expect(ingestRes.status).toBe(400);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+    expect(await db.select().from(contextBlocks).all()).toHaveLength(0);
+    const collections = await db.select().from(contextCollections).all();
+    expect(collections).toHaveLength(1);
+    expect(collections[0]).toMatchObject({ documentCount: 0, blockCount: 0, tokenCount: 0 });
+  });
+
+  it("does not ingest into another tenant collection", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Private KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const ingestRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({ title: "Cross tenant", text: "This should not write." }),
+    });
+
+    expect(ingestRes.status).toBe(404);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+    expect(await db.select().from(contextBlocks).all()).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #365

## Summary
- adds tenant-scoped context collections, documents, and blocks tables
- adds collection list/create APIs plus plain-text document ingestion into deterministic stored blocks
- preserves source/provenance metadata, content hashes, token estimates, and collection counters
- returns block metadata from ingestion without echoing large block contents
- surfaces Managed Collections on the Context Optimizer dashboard
- updates OpenAPI, docs, roadmap, changelog, and tests

## Verification
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npx tsc --noEmit -p packages/db/tsconfig.json
- npx tsc --noEmit -p packages/gateway/tsconfig.json
- npx tsc --noEmit -p apps/web/tsconfig.json
- node -e OpenAPI YAML parse
- git diff --check
- npm test --workspace @provara/gateway
- npm test --workspace @provara/web
- npm run build --workspace @provara/gateway
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
