### PR TITLE
feat(#367): add canonical context blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable Provara changes are tracked here.
   - Context Optimizer extractive compression with `compressionMode: "extractive"`, bounded sentence selection, compression savings metrics, demo rows, APIs, and dashboard visibility.
   - Context Optimizer abstractive compression with `compressionMode: "abstractive"`, provider summaries, provenance preservation, and extractive/original fallback on errors, refusals, or token growth.
   - Managed context collections with tenant-scoped collection APIs, plain-text document ingestion, deterministic block chunking, source provenance, and dashboard visibility.
+  - Canonical context blocks with deterministic collection distillation, source coalescing, review statuses, approved-only export, and dashboard counts.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -40,7 +41,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, and managed context collections as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, and canonical block distillation as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -55,7 +56,7 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, and managed collections, run database migrations through `0054_context_content_store`.
+- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, and canonical blocks, run database migrations through `0055_context_canonical_blocks`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
@@ -65,6 +66,7 @@ All notable Provara changes are tracked here.
   - `context_collections`
   - `context_documents`
   - `context_blocks`
+  - `context_canonical_blocks`
 - Existing tenants keep the safe default firewall settings:
   - `defaultScanMode: "signature"`
   - `toolCallAlignment: "block"`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -174,6 +174,8 @@ export interface ContextCollection {
   status: "active" | "archived";
   documentCount: number;
   blockCount: number;
+  canonicalBlockCount: number;
+  approvedBlockCount: number;
   tokenCount: number;
   createdAt: string;
   updatedAt: string;
@@ -767,6 +769,8 @@ export function ContextOptimizerPanel() {
                     <th className="px-4 py-3 text-left font-medium">Collection</th>
                     <th className="px-4 py-3 text-right font-medium">Documents</th>
                     <th className="px-4 py-3 text-right font-medium">Blocks</th>
+                    <th className="px-4 py-3 text-right font-medium">Canonical</th>
+                    <th className="px-4 py-3 text-right font-medium">Approved</th>
                     <th className="px-4 py-3 text-right font-medium">Tokens</th>
                     <th className="px-4 py-3 text-left font-medium">Status</th>
                     <th className="px-4 py-3 text-left font-medium">Updated</th>
@@ -786,6 +790,12 @@ export function ContextOptimizerPanel() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
                         {formatInteger(collection.blockCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(collection.canonicalBlockCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-emerald-300">
+                        {formatInteger(collection.approvedBlockCount)}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-emerald-300">
                         {formatInteger(collection.tokenCount)}

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -170,6 +170,8 @@ describe("ContextOptimizerPanel", () => {
               status: "active",
               documentCount: 2,
               blockCount: 8,
+              canonicalBlockCount: 5,
+              approvedBlockCount: 3,
               tokenCount: 1400,
               createdAt: "2026-05-01T20:00:00.000Z",
               updatedAt: "2026-05-01T22:00:00.000Z",
@@ -262,6 +264,8 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("Managed Collections")).toBeInTheDocument();
     expect(screen.getByText("Support KB")).toBeInTheDocument();
     expect(screen.getByText("Approved support context")).toBeInTheDocument();
+    expect(screen.getByText("Canonical")).toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
   });
 
   it("updates and persists optimizer payload controls", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -30,9 +30,10 @@ Implemented as of `0.2.0`:
 - Optional abstractive compression with provider summaries, provenance preservation, and mechanical fallback.
 - Dashboard configuration controls for drafting optimizer payloads.
 - Managed context collections with plain-text ingestion into stored documents and reusable blocks.
+- Canonical context blocks with deterministic distillation, source coalescing, review status, and approved-only export.
 
 Next planned layer:
-- Canonical knowledge distillation, review states, and approved-only export.
+- Governance review queues, audit logs, and pre-approval policy checks.
 
 ## V1: Runtime Context Optimizer
 
@@ -93,10 +94,10 @@ Move from per-request optimization to reusable canonical knowledge.
 
 Capabilities:
 - Batch document ingestion. Foundation shipped with managed collections and plain-text ingestion.
-- Canonical knowledge blocks.
-- Source references and provenance.
+- Canonical knowledge blocks. Shipped as deterministic canonical context blocks.
+- Source references and provenance. Shipped as source block/document IDs on canonical blocks.
 - Versioning and diffs.
-- JSONL/vector-ready export.
+- JSONL/vector-ready export. Shipped as approved-only JSON response for canonical blocks.
 
 ## V2.1: Governance
 
@@ -104,7 +105,7 @@ Make optimized knowledge trustworthy for regulated teams.
 
 Capabilities:
 - Human review queue.
-- Approval states.
+- Approval states. Foundation shipped as draft/approved/rejected canonical block status.
 - Audit logs.
 - Conflict detection.
 - PII and prompt-injection policy checks.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,6 +21,7 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
+- Canonical context block distillation with review status and approved-only export.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
@@ -111,9 +112,15 @@ Managed collection APIs:
 GET /v1/context/collections
 POST /v1/context/collections
 POST /v1/context/collections/{id}/documents
+POST /v1/context/collections/{id}/distill
+GET /v1/context/collections/{id}/canonical-blocks
+PATCH /v1/context/canonical-blocks/{id}/review
+GET /v1/context/collections/{id}/export
 ```
 
-Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters. This is the V2 foundation for review queues, connectors, canonical knowledge blocks, and vector export.
+Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters.
+
+Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
 Quality evaluation is available through:
 
@@ -154,7 +161,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, block count, estimated token count, status, and last update time. Creation and ingestion are available through the API in this release; richer collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -193,8 +200,8 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is persistent knowledge distillation:
+The next behavior layer is governance:
 
-- Canonical block generation and deduplication across documents.
-- Human review and approval states for managed blocks.
-- Approved-only export controls for retrieval systems.
+- Human review queue ergonomics.
+- Audit logs for review decisions.
+- PII and prompt-injection checks before approval.

--- a/packages/db/drizzle/0055_context_canonical_blocks.sql
+++ b/packages/db/drizzle/0055_context_canonical_blocks.sql
@@ -1,0 +1,26 @@
+ALTER TABLE `context_collections` ADD `canonical_block_count` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE `context_collections` ADD `approved_block_count` integer DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+CREATE TABLE `context_canonical_blocks` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `collection_id` text NOT NULL,
+  `content` text NOT NULL,
+  `content_hash` text NOT NULL,
+  `token_count` integer NOT NULL,
+  `source_block_ids` text DEFAULT '[]' NOT NULL,
+  `source_document_ids` text DEFAULT '[]' NOT NULL,
+  `source_count` integer DEFAULT 0 NOT NULL,
+  `review_status` text DEFAULT 'draft' NOT NULL,
+  `metadata` text DEFAULT '{}' NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `context_collections`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `context_canonical_blocks_tenant_collection_idx` ON `context_canonical_blocks` (`tenant_id`,`collection_id`);
+--> statement-breakpoint
+CREATE INDEX `context_canonical_blocks_review_idx` ON `context_canonical_blocks` (`tenant_id`,`collection_id`,`review_status`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `context_canonical_blocks_collection_hash_idx` ON `context_canonical_blocks` (`collection_id`,`content_hash`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1777670700000,
       "tag": "0054_context_content_store",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "6",
+      "when": 1777672800000,
+      "tag": "0055_context_canonical_blocks",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -430,6 +430,8 @@ export const contextCollections = sqliteTable("context_collections", {
   status: text("status", { enum: ["active", "archived"] }).notNull().default("active"),
   documentCount: integer("document_count").notNull().default(0),
   blockCount: integer("block_count").notNull().default(0),
+  canonicalBlockCount: integer("canonical_block_count").notNull().default(0),
+  approvedBlockCount: integer("approved_block_count").notNull().default(0),
   tokenCount: integer("token_count").notNull().default(0),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
@@ -485,6 +487,32 @@ export const contextBlocks = sqliteTable("context_blocks", {
   index("context_blocks_tenant_collection_idx").on(table.tenantId, table.collectionId),
   index("context_blocks_document_ordinal_idx").on(table.documentId, table.ordinal),
   uniqueIndex("context_blocks_document_ordinal_unique_idx").on(table.documentId, table.ordinal),
+]);
+
+export const contextCanonicalBlocks = sqliteTable("context_canonical_blocks", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => contextCollections.id),
+  content: text("content").notNull(),
+  contentHash: text("content_hash").notNull(),
+  tokenCount: integer("token_count").notNull(),
+  sourceBlockIds: text("source_block_ids").notNull().default("[]"),
+  sourceDocumentIds: text("source_document_ids").notNull().default("[]"),
+  sourceCount: integer("source_count").notNull().default(0),
+  reviewStatus: text("review_status", { enum: ["draft", "approved", "rejected"] }).notNull().default("draft"),
+  metadata: text("metadata").notNull().default("{}"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_canonical_blocks_tenant_collection_idx").on(table.tenantId, table.collectionId),
+  index("context_canonical_blocks_review_idx").on(table.tenantId, table.collectionId, table.reviewStatus),
+  uniqueIndex("context_canonical_blocks_collection_hash_idx").on(table.collectionId, table.contentHash),
 ]);
 
 export const alertRules = sqliteTable("alert_rules", {

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -560,6 +560,146 @@ paths:
         "404":
           description: Collection not found.
 
+  /v1/context/collections/{id}/distill:
+    post:
+      tags: [Context Optimizer]
+      summary: Distill stored context blocks into canonical blocks
+      description: Deterministically normalizes stored collection blocks, coalesces duplicates, and preserves source block provenance.
+      operationId: distillContextCollection
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Distillation result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [collection, canonicalBlocks, createdBlocks, mergedSources]
+                properties:
+                  collection:
+                    $ref: "#/components/schemas/ContextCollection"
+                  canonicalBlocks:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextCanonicalBlock"
+                  createdBlocks:
+                    type: integer
+                  mergedSources:
+                    type: integer
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
+  /v1/context/collections/{id}/canonical-blocks:
+    get:
+      tags: [Context Optimizer]
+      summary: List canonical blocks for a collection
+      operationId: listContextCanonicalBlocks
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: reviewStatus
+          schema:
+            type: string
+            enum: [draft, approved, rejected]
+      responses:
+        "200":
+          description: Canonical blocks
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [canonicalBlocks]
+                properties:
+                  canonicalBlocks:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextCanonicalBlock"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
+  /v1/context/canonical-blocks/{id}/review:
+    patch:
+      tags: [Context Optimizer]
+      summary: Update canonical block review status
+      operationId: reviewContextCanonicalBlock
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReviewContextCanonicalBlockRequest"
+      responses:
+        "200":
+          description: Updated canonical block
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [canonicalBlock]
+                properties:
+                  canonicalBlock:
+                    $ref: "#/components/schemas/ContextCanonicalBlock"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Canonical block not found.
+
+  /v1/context/collections/{id}/export:
+    get:
+      tags: [Context Optimizer]
+      summary: Export approved canonical blocks
+      operationId: exportApprovedContextBlocks
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Approved blocks ready for JSONL/vector export
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [format, reviewStatus, blocks]
+                properties:
+                  format:
+                    type: string
+                    enum: [jsonl]
+                  reviewStatus:
+                    type: string
+                    enum: [approved]
+                  blocks:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextCanonicalExportBlock"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
   /v1/context/summary:
     get:
       tags: [Context Optimizer]
@@ -2641,7 +2781,7 @@ components:
 
     ContextCollection:
       type: object
-      required: [id, tenantId, name, description, status, documentCount, blockCount, tokenCount, createdAt, updatedAt]
+      required: [id, tenantId, name, description, status, documentCount, blockCount, canonicalBlockCount, approvedBlockCount, tokenCount, createdAt, updatedAt]
       properties:
         id:
           type: string
@@ -2659,6 +2799,10 @@ components:
         documentCount:
           type: integer
         blockCount:
+          type: integer
+        canonicalBlockCount:
+          type: integer
+        approvedBlockCount:
           type: integer
         tokenCount:
           type: integer
@@ -2760,6 +2904,91 @@ components:
         createdAt:
           type: string
           format: date-time
+
+    ReviewContextCanonicalBlockRequest:
+      type: object
+      required: [reviewStatus]
+      properties:
+        reviewStatus:
+          type: string
+          enum: [draft, approved, rejected]
+
+    ContextCanonicalBlock:
+      type: object
+      required:
+        - id
+        - tenantId
+        - collectionId
+        - content
+        - contentHash
+        - tokenCount
+        - sourceBlockIds
+        - sourceDocumentIds
+        - sourceCount
+        - reviewStatus
+        - metadata
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        content:
+          type: string
+        contentHash:
+          type: string
+        tokenCount:
+          type: integer
+        sourceBlockIds:
+          type: array
+          items:
+            type: string
+        sourceDocumentIds:
+          type: array
+          items:
+            type: string
+        sourceCount:
+          type: integer
+        reviewStatus:
+          type: string
+          enum: [draft, approved, rejected]
+        metadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    ContextCanonicalExportBlock:
+      type: object
+      required: [id, content, contentHash, tokenCount, sourceBlockIds, sourceDocumentIds, metadata]
+      properties:
+        id:
+          type: string
+        content:
+          type: string
+        contentHash:
+          type: string
+        tokenCount:
+          type: integer
+        sourceBlockIds:
+          type: array
+          items:
+            type: string
+        sourceDocumentIds:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
 
     ContextQualityEvaluateRequest:
       type: object

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Db } from "@provara/db";
-import { contextBlocks, contextCollections, contextDocuments } from "@provara/db";
-import { and, desc, eq } from "drizzle-orm";
+import { contextBlocks, contextCanonicalBlocks, contextCollections, contextDocuments } from "@provara/db";
+import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { tenantFilter, tenantScoped } from "../auth/tenant.js";
 import { estimateContextTokens } from "./optimizer.js";
@@ -25,7 +25,25 @@ export interface ContextCollection {
   status: "active" | "archived";
   documentCount: number;
   blockCount: number;
+  canonicalBlockCount: number;
+  approvedBlockCount: number;
   tokenCount: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ContextCanonicalBlock {
+  id: string;
+  tenantId: string | null;
+  collectionId: string;
+  content: string;
+  contentHash: string;
+  tokenCount: number;
+  sourceBlockIds: string[];
+  sourceDocumentIds: string[];
+  sourceCount: number;
+  reviewStatus: "draft" | "approved" | "rejected";
+  metadata: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -94,10 +112,66 @@ function collectionFromRow(row: typeof contextCollections.$inferSelect): Context
     status: row.status,
     documentCount: row.documentCount,
     blockCount: row.blockCount,
+    canonicalBlockCount: row.canonicalBlockCount,
+    approvedBlockCount: row.approvedBlockCount,
     tokenCount: row.tokenCount,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+}
+
+function parseStringArray(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function canonicalBlockFromRow(row: typeof contextCanonicalBlocks.$inferSelect): ContextCanonicalBlock {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    collectionId: row.collectionId,
+    content: row.content,
+    contentHash: row.contentHash,
+    tokenCount: row.tokenCount,
+    sourceBlockIds: parseStringArray(row.sourceBlockIds),
+    sourceDocumentIds: parseStringArray(row.sourceDocumentIds),
+    sourceCount: row.sourceCount,
+    reviewStatus: row.reviewStatus,
+    metadata: parseMetadata(row.metadata),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function normalizeCanonicalContent(content: string): string {
+  return content
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function refreshCollectionCanonicalCounts(db: Db, collectionId: string, updatedAt = new Date()): Promise<void> {
+  const row = await db
+    .select({
+      canonicalBlockCount: sql<number>`count(*)`,
+      approvedBlockCount: sql<number>`coalesce(sum(case when ${contextCanonicalBlocks.reviewStatus} = 'approved' then 1 else 0 end), 0)`,
+    })
+    .from(contextCanonicalBlocks)
+    .where(eq(contextCanonicalBlocks.collectionId, collectionId))
+    .get();
+
+  await db.update(contextCollections).set({
+    canonicalBlockCount: row?.canonicalBlockCount ?? 0,
+    approvedBlockCount: row?.approvedBlockCount ?? 0,
+    updatedAt,
+  }).where(eq(contextCollections.id, collectionId)).run();
 }
 
 function documentFromRow(row: typeof contextDocuments.$inferSelect): ContextDocument {
@@ -190,6 +264,17 @@ export function validateIngestDocumentBody(value: unknown): ValidationResult<Ing
       metadata,
     },
   };
+}
+
+export function validateReviewStatusBody(value: unknown): ValidationResult<{ reviewStatus: ContextCanonicalBlock["reviewStatus"] }> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { error: "body must be an object" };
+  }
+  const reviewStatus = (value as Record<string, unknown>).reviewStatus;
+  if (reviewStatus !== "draft" && reviewStatus !== "approved" && reviewStatus !== "rejected") {
+    return { error: "reviewStatus must be draft, approved, or rejected" };
+  }
+  return { value: { reviewStatus } };
 }
 
 export function chunkContextText(text: string): string[] {
@@ -329,4 +414,147 @@ export async function ingestContextDocument(
     document: documentFromRow(document),
     blocks: blocks.map(blockFromRow),
   };
+}
+
+export async function distillContextCollection(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+): Promise<{ collection: ContextCollection; canonicalBlocks: ContextCanonicalBlock[]; createdBlocks: number; mergedSources: number }> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collection = await db.select().from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("collection not found");
+
+  const storedBlocks = await db
+    .select()
+    .from(contextBlocks)
+    .where(tenantScoped(contextBlocks.tenantId, tenantId, eq(contextBlocks.collectionId, collectionId)))
+    .orderBy(asc(contextBlocks.documentId), asc(contextBlocks.ordinal))
+    .all();
+  if (storedBlocks.length === 0) throw new Error("collection has no stored blocks");
+
+  const groups = new Map<string, { content: string; blockIds: string[]; documentIds: string[]; tokenCount: number }>();
+  for (const block of storedBlocks) {
+    const content = normalizeCanonicalContent(block.content);
+    if (!content) continue;
+    const contentHash = hashContent(content.toLowerCase());
+    const group = groups.get(contentHash);
+    if (group) {
+      group.blockIds.push(block.id);
+      if (!group.documentIds.includes(block.documentId)) group.documentIds.push(block.documentId);
+      continue;
+    }
+    groups.set(contentHash, {
+      content,
+      blockIds: [block.id],
+      documentIds: [block.documentId],
+      tokenCount: estimateContextTokens(content),
+    });
+  }
+
+  const now = new Date();
+  let createdBlocks = 0;
+  let mergedSources = 0;
+  for (const [contentHash, group] of groups) {
+    const existing = await db
+      .select()
+      .from(contextCanonicalBlocks)
+      .where(and(eq(contextCanonicalBlocks.collectionId, collectionId), eq(contextCanonicalBlocks.contentHash, contentHash)))
+      .get();
+    if (existing) {
+      const sourceBlockIds = [...new Set([...parseStringArray(existing.sourceBlockIds), ...group.blockIds])];
+      const sourceDocumentIds = [...new Set([...parseStringArray(existing.sourceDocumentIds), ...group.documentIds])];
+      await db.update(contextCanonicalBlocks).set({
+        sourceBlockIds: JSON.stringify(sourceBlockIds),
+        sourceDocumentIds: JSON.stringify(sourceDocumentIds),
+        sourceCount: sourceBlockIds.length,
+        updatedAt: now,
+      }).where(eq(contextCanonicalBlocks.id, existing.id)).run();
+      mergedSources += Math.max(0, sourceBlockIds.length - existing.sourceCount);
+      continue;
+    }
+
+    await db.insert(contextCanonicalBlocks).values({
+      id: nanoid(),
+      tenantId,
+      collectionId,
+      content: group.content,
+      contentHash,
+      tokenCount: group.tokenCount,
+      sourceBlockIds: JSON.stringify(group.blockIds),
+      sourceDocumentIds: JSON.stringify(group.documentIds),
+      sourceCount: group.blockIds.length,
+      reviewStatus: "draft",
+      metadata: JSON.stringify({ distillation: "deterministic-v1" }),
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    createdBlocks += 1;
+    mergedSources += Math.max(0, group.blockIds.length - 1);
+  }
+
+  await refreshCollectionCanonicalCounts(db, collectionId, now);
+  const updatedCollection = await db.select().from(contextCollections).where(eq(contextCollections.id, collectionId)).get();
+  const canonicalBlocks = await listContextCanonicalBlocks(db, tenantId, collectionId);
+  if (!updatedCollection) throw new Error("Failed to distill context collection");
+  return {
+    collection: collectionFromRow(updatedCollection),
+    canonicalBlocks,
+    createdBlocks,
+    mergedSources,
+  };
+}
+
+export async function listContextCanonicalBlocks(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+  options: { reviewStatus?: ContextCanonicalBlock["reviewStatus"] } = {},
+): Promise<ContextCanonicalBlock[]> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collection = await db.select({ id: contextCollections.id }).from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("collection not found");
+  const conditions = [eq(contextCanonicalBlocks.collectionId, collectionId)];
+  if (tenantId) conditions.push(eq(contextCanonicalBlocks.tenantId, tenantId));
+  if (options.reviewStatus) conditions.push(eq(contextCanonicalBlocks.reviewStatus, options.reviewStatus));
+
+  const rows = await db
+    .select()
+    .from(contextCanonicalBlocks)
+    .where(and(...conditions))
+    .orderBy(asc(contextCanonicalBlocks.createdAt), asc(contextCanonicalBlocks.id))
+    .all();
+  return rows.map(canonicalBlockFromRow);
+}
+
+export async function updateContextCanonicalBlockReview(
+  db: Db,
+  tenantId: string | null,
+  blockId: string,
+  reviewStatus: ContextCanonicalBlock["reviewStatus"],
+): Promise<ContextCanonicalBlock> {
+  const existing = await db.select().from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.id, blockId)).get();
+  if (!existing) throw new Error("canonical block not found");
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, existing.collectionId));
+  const collection = await db.select({ id: contextCollections.id }).from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("canonical block not found");
+
+  const now = new Date();
+  await db.update(contextCanonicalBlocks).set({
+    reviewStatus,
+    updatedAt: now,
+  }).where(eq(contextCanonicalBlocks.id, blockId)).run();
+  await refreshCollectionCanonicalCounts(db, existing.collectionId, now);
+
+  const row = await db.select().from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.id, blockId)).get();
+  if (!row) throw new Error("Failed to update canonical block review status");
+  return canonicalBlockFromRow(row);
+}
+
+export async function exportApprovedContextBlocks(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+): Promise<ContextCanonicalBlock[]> {
+  return listContextCanonicalBlocks(db, tenantId, collectionId, { reviewStatus: "approved" });
 }

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -30,15 +30,22 @@ import {
 } from "../context/retrieval.js";
 import {
   createContextCollection,
+  distillContextCollection,
+  exportApprovedContextBlocks,
   ingestContextDocument,
+  listContextCanonicalBlocks,
   listContextCollections,
+  updateContextCanonicalBlockReview,
   validateCreateCollectionBody,
   validateIngestDocumentBody,
+  validateReviewStatusBody,
 } from "../context/store.js";
 import { getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
 import type { Provider } from "../providers/types.js";
+
+type CanonicalReviewStatus = "draft" | "approved" | "rejected";
 
 const MAX_CHUNKS = 200;
 const MAX_CHUNK_CHARS = 100_000;
@@ -680,6 +687,102 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       }, 201);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to ingest context document";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.post("/collections/:id/distill", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+
+    try {
+      const result = await distillContextCollection(db, tenantId, collectionId);
+      return c.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to distill context collection";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.get("/collections/:id/canonical-blocks", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+    const reviewStatus = c.req.query("reviewStatus");
+    const parsedReviewStatus: CanonicalReviewStatus | undefined =
+      reviewStatus === "draft" || reviewStatus === "approved" || reviewStatus === "rejected"
+      ? reviewStatus
+      : undefined;
+    const options = parsedReviewStatus
+      ? { reviewStatus: parsedReviewStatus }
+      : {};
+
+    try {
+      const canonicalBlocks = await listContextCanonicalBlocks(db, tenantId, collectionId, options);
+      return c.json({ canonicalBlocks });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to list canonical blocks";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.patch("/canonical-blocks/:id/review", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const blockId = c.req.param("id");
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateReviewStatusBody(body);
+    if (!parsed.value) {
+      return c.json(
+        { error: { message: parsed.error || "invalid review body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const canonicalBlock = await updateContextCanonicalBlockReview(db, tenantId, blockId, parsed.value.reviewStatus);
+      return c.json({ canonicalBlock });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to update canonical block";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.get("/collections/:id/export", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+
+    try {
+      const blocks = await exportApprovedContextBlocks(db, tenantId, collectionId);
+      return c.json({
+        format: "jsonl",
+        reviewStatus: "approved",
+        blocks: blocks.map((block) => ({
+          id: block.id,
+          content: block.content,
+          contentHash: block.contentHash,
+          tokenCount: block.tokenCount,
+          sourceBlockIds: block.sourceBlockIds,
+          sourceDocumentIds: block.sourceDocumentIds,
+          metadata: block.metadata,
+        })),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to export canonical blocks";
       const notFound = message.includes("not found");
       return c.json(
         { error: { message, type: notFound ? "not_found" : "store_error" } },

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import {
   contextBlocks,
+  contextCanonicalBlocks,
   contextCollections,
   contextDocuments,
   contextOptimizationEvents,
@@ -1703,5 +1704,151 @@ describe("managed context collections", () => {
     expect(ingestRes.status).toBe(404);
     expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
     expect(await db.select().from(contextBlocks).all()).toHaveLength(0);
+  });
+
+  it("distills duplicate stored blocks into canonical draft blocks", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Canonical KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const collectionId = collectionBody.collection.id;
+
+    for (const title of ["Refunds A", "Refunds B"]) {
+      const ingestRes = await app.request(`/v1/context/collections/${collectionId}/documents`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+        body: JSON.stringify({
+          title,
+          text: "Refunds require a receipt and must be requested within 30 days.",
+          source: "help-center",
+        }),
+      });
+      expect(ingestRes.status).toBe(201);
+    }
+
+    const distillRes = await app.request(`/v1/context/collections/${collectionId}/distill`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(distillRes.status).toBe(200);
+    const distillBody = await distillRes.json() as {
+      collection: { canonicalBlockCount: number; approvedBlockCount: number };
+      canonicalBlocks: Array<{ id: string; reviewStatus: string; sourceBlockIds: string[]; sourceCount: number }>;
+      createdBlocks: number;
+      mergedSources: number;
+    };
+    expect(distillBody.createdBlocks).toBe(1);
+    expect(distillBody.mergedSources).toBe(1);
+    expect(distillBody.collection).toMatchObject({ canonicalBlockCount: 1, approvedBlockCount: 0 });
+    expect(distillBody.canonicalBlocks).toHaveLength(1);
+    expect(distillBody.canonicalBlocks[0]).toMatchObject({
+      reviewStatus: "draft",
+      sourceCount: 2,
+    });
+    expect(distillBody.canonicalBlocks[0].sourceBlockIds).toHaveLength(2);
+    expect(await db.select().from(contextCanonicalBlocks).all()).toHaveLength(1);
+  });
+
+  it("reviews canonical blocks and exports only approved knowledge", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Export KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const collectionId = collectionBody.collection.id;
+    await app.request(`/v1/context/collections/${collectionId}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        title: "Two facts",
+        text: "Refunds require a receipt.\n\nBilling admins can download invoices.",
+      }),
+    });
+    const distillRes = await app.request(`/v1/context/collections/${collectionId}/distill`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    const distillBody = await distillRes.json() as {
+      canonicalBlocks: Array<{ id: string; content: string; reviewStatus: string }>;
+    };
+    expect(distillBody.canonicalBlocks.length).toBeGreaterThan(0);
+
+    const approvedId = distillBody.canonicalBlocks[0].id;
+    const reviewRes = await app.request(`/v1/context/canonical-blocks/${approvedId}/review`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ reviewStatus: "approved" }),
+    });
+    expect(reviewRes.status).toBe(200);
+    const reviewBody = await reviewRes.json() as { canonicalBlock: { reviewStatus: string } };
+    expect(reviewBody.canonicalBlock.reviewStatus).toBe("approved");
+
+    const exportRes = await app.request(`/v1/context/collections/${collectionId}/export`, {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(exportRes.status).toBe(200);
+    const exportBody = await exportRes.json() as {
+      format: string;
+      reviewStatus: string;
+      blocks: Array<{ id: string; content: string; sourceBlockIds: string[] }>;
+    };
+    expect(exportBody).toMatchObject({ format: "jsonl", reviewStatus: "approved" });
+    expect(exportBody.blocks).toEqual([
+      expect.objectContaining({ id: approvedId, content: expect.any(String), sourceBlockIds: expect.any(Array) }),
+    ]);
+
+    const collectionsRes = await app.request("/v1/context/collections", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    const collectionsBody = await collectionsRes.json() as {
+      collections: Array<{ name: string; canonicalBlockCount: number; approvedBlockCount: number }>;
+    };
+    expect(collectionsBody.collections[0]).toMatchObject({
+      name: "Export KB",
+      canonicalBlockCount: distillBody.canonicalBlocks.length,
+      approvedBlockCount: 1,
+    });
+  });
+
+  it("does not review or export another tenant's canonical blocks", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Tenant Canonical" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const collectionId = collectionBody.collection.id;
+    await app.request(`/v1/context/collections/${collectionId}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ text: "Private approved knowledge." }),
+    });
+    const distillRes = await app.request(`/v1/context/collections/${collectionId}/distill`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    const distillBody = await distillRes.json() as { canonicalBlocks: Array<{ id: string }> };
+
+    const reviewRes = await app.request(`/v1/context/canonical-blocks/${distillBody.canonicalBlocks[0].id}/review`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({ reviewStatus: "approved" }),
+    });
+    expect(reviewRes.status).toBe(404);
+
+    const exportRes = await app.request(`/v1/context/collections/${collectionId}/export`, {
+      headers: { "x-test-tenant": "tenant-other" },
+    });
+    expect(exportRes.status).toBe(404);
   });
 });


### PR DESCRIPTION
Closes #367

## Summary
- adds tenant-scoped canonical context blocks and collection canonical/approved counters
- distills stored collection blocks through deterministic normalization and hash coalescing
- preserves source block/document provenance, token counts, content hashes, and review status
- adds review-status updates and approved-only export endpoints
- surfaces canonical and approved counts on the Context dashboard
- updates OpenAPI, docs, roadmap, changelog, and tests

## Verification
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npx tsc --noEmit -p packages/db/tsconfig.json
- npx tsc --noEmit -p packages/gateway/tsconfig.json
- npx tsc --noEmit -p apps/web/tsconfig.json
- node -e OpenAPI YAML parse
- git diff --check
- npm test --workspace @provara/gateway
- npm test --workspace @provara/web
- npm run build --workspace @provara/gateway
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
