### PR TITLE
feat(#369): add canonical review audit trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable Provara changes are tracked here.
   - Context Optimizer abstractive compression with `compressionMode: "abstractive"`, provider summaries, provenance preservation, and extractive/original fallback on errors, refusals, or token growth.
   - Managed context collections with tenant-scoped collection APIs, plain-text document ingestion, deterministic block chunking, source provenance, and dashboard visibility.
   - Canonical context blocks with deterministic collection distillation, source coalescing, review statuses, approved-only export, and dashboard counts.
+  - Canonical block governance with reviewer notes, reviewed-by metadata, reviewed timestamps, tenant-scoped review audit events, and a dashboard draft review queue.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -41,7 +42,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, and canonical block distillation as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, and canonical review audit trails as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -56,7 +57,7 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, and canonical blocks, run database migrations through `0055_context_canonical_blocks`.
+- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, canonical blocks, and review audit events, run database migrations through `0056_context_review_audit`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
@@ -67,6 +68,7 @@ All notable Provara changes are tracked here.
   - `context_documents`
   - `context_blocks`
   - `context_canonical_blocks`
+  - `context_canonical_review_events`
 - Existing tenants keep the safe default firewall settings:
   - `defaultScanMode: "signature"`
   - `toolCallAlignment: "block"`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -181,6 +181,19 @@ export interface ContextCollection {
   updatedAt: string;
 }
 
+export interface ContextCanonicalBlock {
+  id: string;
+  collectionId: string;
+  content: string;
+  tokenCount: number;
+  sourceCount: number;
+  reviewStatus: "draft" | "approved" | "rejected";
+  reviewNote: string | null;
+  reviewedByUserId: string | null;
+  reviewedAt: string | null;
+  updatedAt: string;
+}
+
 interface GateState {
   message: string;
   upgradeUrl?: string;
@@ -194,6 +207,7 @@ interface LoadState {
   retrievalSummary: ContextRetrievalSummary | null;
   retrievalEvents: ContextRetrievalEvent[];
   collections: ContextCollection[];
+  canonicalBlocks: ContextCanonicalBlock[];
   loading: boolean;
   error: string | null;
   gate: GateState | null;
@@ -561,6 +575,7 @@ export function ContextOptimizerPanel() {
     retrievalSummary: null,
     retrievalEvents: [],
     collections: [],
+    canonicalBlocks: [],
     loading: true,
     error: null,
     gate: null,
@@ -615,6 +630,7 @@ export function ContextOptimizerPanel() {
               retrievalSummary: null,
               retrievalEvents: [],
               collections: [],
+              canonicalBlocks: [],
               loading: false,
               error: null,
               gate: {
@@ -637,6 +653,15 @@ export function ContextOptimizerPanel() {
         const retrievalSummaryBody = await retrievalSummaryRes.json() as { summary: ContextRetrievalSummary };
         const retrievalEventsBody = await retrievalEventsRes.json() as { events: ContextRetrievalEvent[] };
         const collectionsBody = await collectionsRes.json() as { collections: ContextCollection[] };
+        let canonicalBlocks: ContextCanonicalBlock[] = [];
+        const firstCollection = collectionsBody.collections[0];
+        if (firstCollection && firstCollection.canonicalBlockCount > 0) {
+          const canonicalRes = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/canonical-blocks?reviewStatus=draft`);
+          if (canonicalRes.ok) {
+            const canonicalBody = await canonicalRes.json() as { canonicalBlocks: ContextCanonicalBlock[] };
+            canonicalBlocks = canonicalBody.canonicalBlocks;
+          }
+        }
 
         if (!cancelled) {
           setState({
@@ -647,6 +672,7 @@ export function ContextOptimizerPanel() {
             retrievalSummary: retrievalSummaryBody.summary,
             retrievalEvents: retrievalEventsBody.events,
             collections: collectionsBody.collections,
+            canonicalBlocks,
             loading: false,
             error: null,
             gate: null,
@@ -662,6 +688,7 @@ export function ContextOptimizerPanel() {
             retrievalSummary: null,
             retrievalEvents: [],
             collections: [],
+            canonicalBlocks: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
             gate: null,
@@ -683,6 +710,7 @@ export function ContextOptimizerPanel() {
   const retrievalSummary = state.retrievalSummary;
   const retrievalRows = useMemo(() => state.retrievalEvents, [state.retrievalEvents]);
   const collectionRows = useMemo(() => state.collections, [state.collections]);
+  const canonicalRows = useMemo(() => state.canonicalBlocks, [state.canonicalBlocks]);
 
   return (
     <div className="space-y-6">
@@ -807,6 +835,61 @@ export function ContextOptimizerPanel() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
                         {formatTimestamp(collection.updatedAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Canonical Review Queue</h2>
+          <p className="mt-1 text-sm text-zinc-500">Draft canonical blocks awaiting approval.</p>
+        </div>
+
+        {state.loading ? (
+          <LoadingRows />
+        ) : canonicalRows.length === 0 ? (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center text-sm text-zinc-400">
+            No draft canonical blocks in the first managed collection.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">Content</th>
+                    <th className="px-4 py-3 text-right font-medium">Sources</th>
+                    <th className="px-4 py-3 text-right font-medium">Tokens</th>
+                    <th className="px-4 py-3 text-left font-medium">Status</th>
+                    <th className="px-4 py-3 text-left font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {canonicalRows.slice(0, 10).map((block) => (
+                    <tr key={block.id}>
+                      <td className="max-w-3xl px-4 py-3 text-zinc-300">
+                        <div className="line-clamp-2">{block.content}</div>
+                        {block.reviewNote && <div className="mt-1 text-xs text-zinc-500">{block.reviewNote}</div>}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(block.sourceCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(block.tokenCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <span className="rounded border border-amber-900/70 bg-amber-950/20 px-2 py-0.5 text-xs capitalize text-amber-200">
+                          {block.reviewStatus}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
+                        {formatTimestamp(block.updatedAt)}
                       </td>
                     </tr>
                   ))}

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -179,6 +179,24 @@ describe("ContextOptimizerPanel", () => {
           ],
         }));
       }
+      if (path === "/v1/context/collections/collection-1/canonical-blocks?reviewStatus=draft") {
+        return Promise.resolve(jsonResponse({
+          canonicalBlocks: [
+            {
+              id: "canonical-1",
+              collectionId: "collection-1",
+              content: "Refunds require a receipt within 30 days.",
+              tokenCount: 8,
+              sourceCount: 2,
+              reviewStatus: "draft",
+              reviewNote: null,
+              reviewedByUserId: null,
+              reviewedAt: null,
+              updatedAt: "2026-05-01T22:05:00.000Z",
+            },
+          ],
+        }));
+      }
       return Promise.resolve(jsonResponse({
         events: [
           {
@@ -266,6 +284,8 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("Approved support context")).toBeInTheDocument();
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
+    expect(screen.getByText("Canonical Review Queue")).toBeInTheDocument();
+    expect(screen.getByText("Refunds require a receipt within 30 days.")).toBeInTheDocument();
   });
 
   it("updates and persists optimizer payload controls", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -31,9 +31,10 @@ Implemented as of `0.2.0`:
 - Dashboard configuration controls for drafting optimizer payloads.
 - Managed context collections with plain-text ingestion into stored documents and reusable blocks.
 - Canonical context blocks with deterministic distillation, source coalescing, review status, and approved-only export.
+- Canonical review audit events with reviewer notes, actor attribution, and dashboard draft queue visibility.
 
 Next planned layer:
-- Governance review queues, audit logs, and pre-approval policy checks.
+- Pre-approval policy checks for PII and prompt injection risk.
 
 ## V1: Runtime Context Optimizer
 
@@ -104,9 +105,9 @@ Capabilities:
 Make optimized knowledge trustworthy for regulated teams.
 
 Capabilities:
-- Human review queue.
+- Human review queue. Foundation shipped as dashboard draft queue visibility.
 - Approval states. Foundation shipped as draft/approved/rejected canonical block status.
-- Audit logs.
+- Audit logs. Shipped as canonical review events.
 - Conflict detection.
 - PII and prompt-injection policy checks.
 - Approved-only export controls.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -22,11 +22,12 @@ The shipped V1 implementation is intentionally narrow:
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
 - Canonical context block distillation with review status and approved-only export.
+- Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
 
-It does not yet perform persistent review workflows or connector-backed ingestion. Those belong to later roadmap phases.
+It does not yet perform automated pre-approval policy checks or connector-backed ingestion. Those belong to later roadmap phases.
 
 ## API
 
@@ -115,12 +116,15 @@ POST /v1/context/collections/{id}/documents
 POST /v1/context/collections/{id}/distill
 GET /v1/context/collections/{id}/canonical-blocks
 PATCH /v1/context/canonical-blocks/{id}/review
+GET /v1/context/canonical-review-events
 GET /v1/context/collections/{id}/export
 ```
 
 Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters.
 
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
+
+Review updates accept an optional `note`, persist `reviewedAt`, and attach `reviewedByUserId` when the caller is a dashboard session user. Each status change also writes a tenant-scoped review event with from-status, to-status, note, actor, canonical block ID, collection ID, and timestamp.
 
 Quality evaluation is available through:
 
@@ -161,7 +165,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, status, and update time. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -200,8 +204,8 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is governance:
+The next behavior layer is pre-approval policy checks:
 
-- Human review queue ergonomics.
-- Audit logs for review decisions.
 - PII and prompt-injection checks before approval.
+- Block approval when required policy checks fail.
+- Surface policy evidence in the review queue.

--- a/packages/db/drizzle/0056_context_review_audit.sql
+++ b/packages/db/drizzle/0056_context_review_audit.sql
@@ -1,0 +1,23 @@
+ALTER TABLE `context_canonical_blocks` ADD `review_note` text;
+--> statement-breakpoint
+ALTER TABLE `context_canonical_blocks` ADD `reviewed_by_user_id` text;
+--> statement-breakpoint
+ALTER TABLE `context_canonical_blocks` ADD `reviewed_at` integer;
+--> statement-breakpoint
+CREATE TABLE `context_canonical_review_events` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `collection_id` text NOT NULL,
+  `canonical_block_id` text NOT NULL,
+  `from_status` text NOT NULL,
+  `to_status` text NOT NULL,
+  `note` text,
+  `actor_user_id` text,
+  `created_at` integer NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `context_collections`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`canonical_block_id`) REFERENCES `context_canonical_blocks`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `context_canonical_review_events_tenant_created_idx` ON `context_canonical_review_events` (`tenant_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `context_canonical_review_events_block_idx` ON `context_canonical_review_events` (`canonical_block_id`,`created_at`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1777672800000,
       "tag": "0055_context_canonical_blocks",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "6",
+      "when": 1777674900000,
+      "tag": "0056_context_review_audit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -502,6 +502,9 @@ export const contextCanonicalBlocks = sqliteTable("context_canonical_blocks", {
   sourceDocumentIds: text("source_document_ids").notNull().default("[]"),
   sourceCount: integer("source_count").notNull().default(0),
   reviewStatus: text("review_status", { enum: ["draft", "approved", "rejected"] }).notNull().default("draft"),
+  reviewNote: text("review_note"),
+  reviewedByUserId: text("reviewed_by_user_id"),
+  reviewedAt: integer("reviewed_at", { mode: "timestamp" }),
   metadata: text("metadata").notNull().default("{}"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .notNull()
@@ -513,6 +516,27 @@ export const contextCanonicalBlocks = sqliteTable("context_canonical_blocks", {
   index("context_canonical_blocks_tenant_collection_idx").on(table.tenantId, table.collectionId),
   index("context_canonical_blocks_review_idx").on(table.tenantId, table.collectionId, table.reviewStatus),
   uniqueIndex("context_canonical_blocks_collection_hash_idx").on(table.collectionId, table.contentHash),
+]);
+
+export const contextCanonicalReviewEvents = sqliteTable("context_canonical_review_events", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => contextCollections.id),
+  canonicalBlockId: text("canonical_block_id")
+    .notNull()
+    .references(() => contextCanonicalBlocks.id),
+  fromStatus: text("from_status", { enum: ["draft", "approved", "rejected"] }).notNull(),
+  toStatus: text("to_status", { enum: ["draft", "approved", "rejected"] }).notNull(),
+  note: text("note"),
+  actorUserId: text("actor_user_id"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_canonical_review_events_tenant_created_idx").on(table.tenantId, table.createdAt),
+  index("context_canonical_review_events_block_idx").on(table.canonicalBlockId, table.createdAt),
 ]);
 
 export const alertRules = sqliteTable("alert_rules", {

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -665,6 +665,38 @@ paths:
         "404":
           description: Canonical block not found.
 
+  /v1/context/canonical-review-events:
+    get:
+      tags: [Context Optimizer]
+      summary: List canonical block review audit events
+      operationId: listContextCanonicalReviewEvents
+      parameters:
+        - in: query
+          name: collectionId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Recent canonical review events
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [events]
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextCanonicalReviewEvent"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+
   /v1/context/collections/{id}/export:
     get:
       tags: [Context Optimizer]
@@ -2912,6 +2944,9 @@ components:
         reviewStatus:
           type: string
           enum: [draft, approved, rejected]
+        note:
+          type: string
+          maxLength: 2000
 
     ContextCanonicalBlock:
       type: object
@@ -2926,6 +2961,9 @@ components:
         - sourceDocumentIds
         - sourceCount
         - reviewStatus
+        - reviewNote
+        - reviewedByUserId
+        - reviewedAt
         - metadata
         - createdAt
         - updatedAt
@@ -2956,6 +2994,16 @@ components:
         reviewStatus:
           type: string
           enum: [draft, approved, rejected]
+        reviewNote:
+          type: string
+          nullable: true
+        reviewedByUserId:
+          type: string
+          nullable: true
+        reviewedAt:
+          type: string
+          format: date-time
+          nullable: true
         metadata:
           type: object
           additionalProperties: true
@@ -2963,6 +3011,35 @@ components:
           type: string
           format: date-time
         updatedAt:
+          type: string
+          format: date-time
+
+    ContextCanonicalReviewEvent:
+      type: object
+      required: [id, tenantId, collectionId, canonicalBlockId, fromStatus, toStatus, note, actorUserId, createdAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        canonicalBlockId:
+          type: string
+        fromStatus:
+          type: string
+          enum: [draft, approved, rejected]
+        toStatus:
+          type: string
+          enum: [draft, approved, rejected]
+        note:
+          type: string
+          nullable: true
+        actorUserId:
+          type: string
+          nullable: true
+        createdAt:
           type: string
           format: date-time
 

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -1,6 +1,12 @@
 import { createHash } from "node:crypto";
 import type { Db } from "@provara/db";
-import { contextBlocks, contextCanonicalBlocks, contextCollections, contextDocuments } from "@provara/db";
+import {
+  contextBlocks,
+  contextCanonicalBlocks,
+  contextCanonicalReviewEvents,
+  contextCollections,
+  contextDocuments,
+} from "@provara/db";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { tenantFilter, tenantScoped } from "../auth/tenant.js";
@@ -12,6 +18,7 @@ const MAX_DOCUMENT_TITLE_CHARS = 200;
 const MAX_SOURCE_CHARS = 120;
 const MAX_SOURCE_URI_CHARS = 2_000;
 const MAX_METADATA_CHARS = 20_000;
+const MAX_REVIEW_NOTE_CHARS = 2_000;
 const MAX_INGEST_TEXT_CHARS = 500_000;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
@@ -43,9 +50,24 @@ export interface ContextCanonicalBlock {
   sourceDocumentIds: string[];
   sourceCount: number;
   reviewStatus: "draft" | "approved" | "rejected";
+  reviewNote: string | null;
+  reviewedByUserId: string | null;
+  reviewedAt: Date | null;
   metadata: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface ContextCanonicalReviewEvent {
+  id: string;
+  tenantId: string | null;
+  collectionId: string;
+  canonicalBlockId: string;
+  fromStatus: ContextCanonicalBlock["reviewStatus"];
+  toStatus: ContextCanonicalBlock["reviewStatus"];
+  note: string | null;
+  actorUserId: string | null;
+  createdAt: Date;
 }
 
 export interface ContextDocument {
@@ -142,9 +164,26 @@ function canonicalBlockFromRow(row: typeof contextCanonicalBlocks.$inferSelect):
     sourceDocumentIds: parseStringArray(row.sourceDocumentIds),
     sourceCount: row.sourceCount,
     reviewStatus: row.reviewStatus,
+    reviewNote: row.reviewNote,
+    reviewedByUserId: row.reviewedByUserId,
+    reviewedAt: row.reviewedAt,
     metadata: parseMetadata(row.metadata),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  };
+}
+
+function reviewEventFromRow(row: typeof contextCanonicalReviewEvents.$inferSelect): ContextCanonicalReviewEvent {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    collectionId: row.collectionId,
+    canonicalBlockId: row.canonicalBlockId,
+    fromStatus: row.fromStatus,
+    toStatus: row.toStatus,
+    note: row.note,
+    actorUserId: row.actorUserId,
+    createdAt: row.createdAt,
   };
 }
 
@@ -266,15 +305,18 @@ export function validateIngestDocumentBody(value: unknown): ValidationResult<Ing
   };
 }
 
-export function validateReviewStatusBody(value: unknown): ValidationResult<{ reviewStatus: ContextCanonicalBlock["reviewStatus"] }> {
+export function validateReviewStatusBody(value: unknown): ValidationResult<{ reviewStatus: ContextCanonicalBlock["reviewStatus"]; note?: string }> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return { error: "body must be an object" };
   }
-  const reviewStatus = (value as Record<string, unknown>).reviewStatus;
+  const body = value as Record<string, unknown>;
+  const reviewStatus = body.reviewStatus;
   if (reviewStatus !== "draft" && reviewStatus !== "approved" && reviewStatus !== "rejected") {
     return { error: "reviewStatus must be draft, approved, or rejected" };
   }
-  return { value: { reviewStatus } };
+  const note = trimOptional(body.note, "note", MAX_REVIEW_NOTE_CHARS);
+  if (note.error) return { error: note.error };
+  return { value: { reviewStatus, note: note.value } };
 }
 
 export function chunkContextText(text: string): string[] {
@@ -532,6 +574,7 @@ export async function updateContextCanonicalBlockReview(
   tenantId: string | null,
   blockId: string,
   reviewStatus: ContextCanonicalBlock["reviewStatus"],
+  options: { note?: string; actorUserId?: string | null } = {},
 ): Promise<ContextCanonicalBlock> {
   const existing = await db.select().from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.id, blockId)).get();
   if (!existing) throw new Error("canonical block not found");
@@ -540,15 +583,52 @@ export async function updateContextCanonicalBlockReview(
   if (!collection) throw new Error("canonical block not found");
 
   const now = new Date();
+  const reviewNote = options.note ?? null;
+  const actorUserId = options.actorUserId ?? null;
   await db.update(contextCanonicalBlocks).set({
     reviewStatus,
+    reviewNote,
+    reviewedByUserId: actorUserId,
+    reviewedAt: now,
     updatedAt: now,
   }).where(eq(contextCanonicalBlocks.id, blockId)).run();
+  await db.insert(contextCanonicalReviewEvents).values({
+    id: nanoid(),
+    tenantId,
+    collectionId: existing.collectionId,
+    canonicalBlockId: blockId,
+    fromStatus: existing.reviewStatus,
+    toStatus: reviewStatus,
+    note: reviewNote,
+    actorUserId,
+    createdAt: now,
+  }).run();
   await refreshCollectionCanonicalCounts(db, existing.collectionId, now);
 
   const row = await db.select().from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.id, blockId)).get();
   if (!row) throw new Error("Failed to update canonical block review status");
   return canonicalBlockFromRow(row);
+}
+
+export async function listContextCanonicalReviewEvents(
+  db: Db,
+  tenantId: string | null,
+  options: { collectionId?: string; limit?: number } = {},
+): Promise<ContextCanonicalReviewEvent[]> {
+  const limit = Math.max(1, Math.min(100, Math.floor(options.limit ?? 25)));
+  const conditions = [];
+  const tenantClause = tenantFilter(contextCanonicalReviewEvents.tenantId, tenantId);
+  if (tenantClause) conditions.push(tenantClause);
+  if (options.collectionId) conditions.push(eq(contextCanonicalReviewEvents.collectionId, options.collectionId));
+
+  const rows = await db
+    .select()
+    .from(contextCanonicalReviewEvents)
+    .where(conditions.length === 0 ? undefined : and(...conditions))
+    .orderBy(desc(contextCanonicalReviewEvents.createdAt))
+    .limit(limit)
+    .all();
+  return rows.map(reviewEventFromRow);
 }
 
 export async function exportApprovedContextBlocks(

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -34,13 +34,14 @@ import {
   exportApprovedContextBlocks,
   ingestContextDocument,
   listContextCanonicalBlocks,
+  listContextCanonicalReviewEvents,
   listContextCollections,
   updateContextCanonicalBlockReview,
   validateCreateCollectionBody,
   validateIngestDocumentBody,
   validateReviewStatusBody,
 } from "../context/store.js";
-import { getTenantId } from "../auth/tenant.js";
+import { getSessionUserId, getTenantId } from "../auth/tenant.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
 import type { Provider } from "../providers/types.js";
@@ -750,7 +751,10 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
     }
 
     try {
-      const canonicalBlock = await updateContextCanonicalBlockReview(db, tenantId, blockId, parsed.value.reviewStatus);
+      const canonicalBlock = await updateContextCanonicalBlockReview(db, tenantId, blockId, parsed.value.reviewStatus, {
+        note: parsed.value.note,
+        actorUserId: getSessionUserId(c.req.raw),
+      });
       return c.json({ canonicalBlock });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to update canonical block";
@@ -760,6 +764,15 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
         notFound ? 404 : 500,
       );
     }
+  });
+
+  app.get("/canonical-review-events", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const rawLimit = Number(c.req.query("limit") ?? 25);
+    const limit = Number.isFinite(rawLimit) ? rawLimit : 25;
+    const collectionId = c.req.query("collectionId") || undefined;
+    const events = await listContextCanonicalReviewEvents(db, tenantId, { collectionId, limit });
+    return c.json({ events });
   });
 
   app.get("/collections/:id/export", async (c) => {

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -4,6 +4,7 @@ import type { Db } from "@provara/db";
 import {
   contextBlocks,
   contextCanonicalBlocks,
+  contextCanonicalReviewEvents,
   contextCollections,
   contextDocuments,
   contextOptimizationEvents,
@@ -22,6 +23,7 @@ import { grantIntelligenceAccess, resetTierEnv } from "./_setup/tier.js";
 vi.mock("../src/auth/tenant.js", async (importOriginal) => ({
   ...await importOriginal<typeof import("../src/auth/tenant.js")>(),
   getTenantId: (req: Request) => req.headers.get("x-test-tenant"),
+  getSessionUserId: (req: Request) => req.headers.get("x-test-user"),
 }));
 
 import { requireIntelligenceTier } from "../src/auth/tier.js";
@@ -1783,12 +1785,48 @@ describe("managed context collections", () => {
     const approvedId = distillBody.canonicalBlocks[0].id;
     const reviewRes = await app.request(`/v1/context/canonical-blocks/${approvedId}/review`, {
       method: "PATCH",
-      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
-      body: JSON.stringify({ reviewStatus: "approved" }),
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro", "x-test-user": "user-reviewer" },
+      body: JSON.stringify({ reviewStatus: "approved", note: "Ready for retrieval." }),
     });
     expect(reviewRes.status).toBe(200);
-    const reviewBody = await reviewRes.json() as { canonicalBlock: { reviewStatus: string } };
-    expect(reviewBody.canonicalBlock.reviewStatus).toBe("approved");
+    const reviewBody = await reviewRes.json() as {
+      canonicalBlock: { reviewStatus: string; reviewNote: string; reviewedByUserId: string; reviewedAt: string };
+    };
+    expect(reviewBody.canonicalBlock).toMatchObject({
+      reviewStatus: "approved",
+      reviewNote: "Ready for retrieval.",
+      reviewedByUserId: "user-reviewer",
+    });
+    expect(reviewBody.canonicalBlock.reviewedAt).toEqual(expect.any(String));
+
+    const auditRows = await db.select().from(contextCanonicalReviewEvents).all();
+    expect(auditRows).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant-pro",
+        canonicalBlockId: approvedId,
+        fromStatus: "draft",
+        toStatus: "approved",
+        note: "Ready for retrieval.",
+        actorUserId: "user-reviewer",
+      }),
+    ]);
+
+    const auditRes = await app.request("/v1/context/canonical-review-events", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(auditRes.status).toBe(200);
+    const auditBody = await auditRes.json() as {
+      events: Array<{ canonicalBlockId: string; fromStatus: string; toStatus: string; note: string; actorUserId: string }>;
+    };
+    expect(auditBody.events).toEqual([
+      expect.objectContaining({
+        canonicalBlockId: approvedId,
+        fromStatus: "draft",
+        toStatus: "approved",
+        note: "Ready for retrieval.",
+        actorUserId: "user-reviewer",
+      }),
+    ]);
 
     const exportRes = await app.request(`/v1/context/collections/${collectionId}/export`, {
       headers: { "x-test-tenant": "tenant-pro" },


### PR DESCRIPTION
Closes #369

## Summary
- adds review notes, reviewer attribution, and reviewed timestamps to canonical blocks
- adds tenant-scoped canonical review audit events for status changes
- adds recent review event API and preserves review status filtering
- surfaces a minimal draft canonical review queue on the Context dashboard
- updates OpenAPI, docs, roadmap, changelog, and tests

## Verification
- npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npx tsc --noEmit -p packages/db/tsconfig.json
- npx tsc --noEmit -p packages/gateway/tsconfig.json
- npx tsc --noEmit -p apps/web/tsconfig.json
- node -e OpenAPI YAML parse
- git diff --check
- npm test --workspace @provara/gateway
- npm test --workspace @provara/web
- npm run build --workspace @provara/gateway
- npm run build --workspace @provara/web

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
