### PR TITLE
feat(#375): add context governance alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable Provara changes are tracked here.
   - Canonical block governance with reviewer notes, reviewed-by metadata, reviewed timestamps, tenant-scoped review audit events, and a dashboard draft review queue.
   - Canonical pre-approval policy checks that run active Guardrails rules before approval, persist policy evidence, block risky approvals, and surface policy status in the dashboard review queue.
   - Bulk canonical policy-check and review actions with per-block results, tenant isolation, audit events, and dashboard row selection.
+  - Context governance alerts for policy-check failures, stale canonical review queues, and approved-export delta thresholds in the existing Alerts workflow.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -44,7 +45,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, and bulk review actions as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, and context governance alerts as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/app/dashboard/alerts/page.tsx
+++ b/apps/web/src/app/dashboard/alerts/page.tsx
@@ -33,6 +33,9 @@ const METRICS = [
   { value: "latency_avg", label: "Avg Latency (ms)", unit: "ms" },
   { value: "latency_p95", label: "P95 Latency (ms)", unit: "ms" },
   { value: "request_count", label: "Request Count", unit: "" },
+  { value: "context_policy_failures", label: "Context Policy Failures", unit: "" },
+  { value: "context_stale_drafts", label: "Stale Context Drafts", unit: "" },
+  { value: "context_approved_export_delta", label: "Approved Context Export Delta", unit: "" },
 ];
 
 const CONDITIONS = [

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -34,9 +34,10 @@ Implemented as of `0.2.0`:
 - Canonical review audit events with reviewer notes, actor attribution, and dashboard draft queue visibility.
 - Canonical pre-approval policy checks with active Guardrails scans, persisted evidence, approval blocking, and dashboard status visibility.
 - Bulk canonical policy-check and review actions with dashboard row selection and per-block failures.
+- Context governance alerts for policy-check failures, stale draft queues, and approved-export delta thresholds.
 
 Next planned layer:
-- Richer governance alerts.
+- Connector ingestion.
 
 ## V1: Runtime Context Optimizer
 
@@ -114,6 +115,7 @@ Capabilities:
 - PII and prompt-injection policy checks. Shipped as canonical pre-approval checks using active Guardrails rules.
 - Approved-only export controls.
 - Bulk review operations. Shipped as selected-row policy-check, approve, and reject actions with per-block failures.
+- Governance alerts. Shipped through existing Alerts history for policy failures and stale canonical draft queues.
 
 ## V2.2: Connectors
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -131,6 +131,8 @@ Before a canonical block can be approved, `POST /v1/context/canonical-blocks/{id
 
 Bulk review endpoints accept up to 100 `blockIds` and return per-block results. `POST /v1/context/canonical-blocks/bulk-policy-check` loads active Guardrails rules once, checks each selected block, and records pass/fail evidence independently. `PATCH /v1/context/canonical-blocks/bulk-review` updates selected blocks that pass validation and returns item-level `policy_error` or `not_found` failures without aborting the whole batch.
 
+Context governance alerts use the existing Alerts workflow. Provara provisions default alert rules for `context_policy_failures`, `context_stale_drafts`, and `context_approved_export_delta`. Failed single or bulk policy checks append alert history with the canonical block ID and decision. The Alerts evaluator checks for draft canonical blocks that have stayed in review past the rule window and writes standard alert history entries.
+
 Review updates accept an optional `note`, persist `reviewedAt`, and attach `reviewedByUserId` when the caller is a dashboard session user. Each status change also writes a tenant-scoped review event with from-status, to-status, note, actor, canonical block ID, collection ID, and timestamp.
 
 Quality evaluation is available through:
@@ -172,7 +174,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -211,8 +213,8 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is pre-approval policy checks:
+The next behavior layer is connector ingestion:
 
-- PII and prompt-injection checks before approval.
-- Block approval when required policy checks fail.
-- Add richer governance alerts for policy failures and stale review queues.
+- GitHub, Confluence, Google Drive, SharePoint, Notion, Zendesk/Intercom, and S3/file upload connectors.
+- Source provenance and sync metadata for managed collections.
+- Connector-level review and policy defaults.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -547,7 +547,7 @@ export const alertRules = sqliteTable("alert_rules", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),
   name: text("name").notNull(),
-  metric: text("metric", { enum: ["spend", "latency_p95", "latency_avg", "error_rate", "request_count"] }).notNull(),
+  metric: text("metric", { enum: ["spend", "latency_p95", "latency_avg", "error_rate", "request_count", "context_policy_failures", "context_stale_drafts", "context_approved_export_delta"] }).notNull(),
   condition: text("condition", { enum: ["gt", "lt", "gte", "lte"] }).notNull().default("gt"),
   threshold: real("threshold").notNull(),
   window: text("window", { enum: ["1h", "6h", "24h", "7d"] }).notNull().default("1h"),

--- a/packages/gateway/src/context/governance-alerts.ts
+++ b/packages/gateway/src/context/governance-alerts.ts
@@ -1,0 +1,139 @@
+import type { Db } from "@provara/db";
+import { alertLogs, alertRules, contextCanonicalBlocks, contextCanonicalReviewEvents } from "@provara/db";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { tenantFilter } from "../auth/tenant.js";
+
+export const CONTEXT_POLICY_FAILURES_METRIC = "context_policy_failures";
+export const CONTEXT_STALE_DRAFTS_METRIC = "context_stale_drafts";
+export const CONTEXT_APPROVED_EXPORT_DELTA_METRIC = "context_approved_export_delta";
+
+export type ContextGovernanceMetric =
+  | typeof CONTEXT_POLICY_FAILURES_METRIC
+  | typeof CONTEXT_STALE_DRAFTS_METRIC
+  | typeof CONTEXT_APPROVED_EXPORT_DELTA_METRIC;
+
+const DEFAULT_CONTEXT_ALERT_RULES: Record<ContextGovernanceMetric, {
+  name: string;
+  condition: "gt" | "lt" | "gte" | "lte";
+  threshold: number;
+  window: "1h" | "6h" | "24h" | "7d";
+}> = {
+  context_policy_failures: {
+    name: "Context policy failures",
+    condition: "gt",
+    threshold: 0,
+    window: "1h",
+  },
+  context_stale_drafts: {
+    name: "Stale canonical review queue",
+    condition: "gt",
+    threshold: 0,
+    window: "24h",
+  },
+  context_approved_export_delta: {
+    name: "Approved context export change",
+    condition: "gte",
+    threshold: 10,
+    window: "24h",
+  },
+};
+
+export async function ensureContextGovernanceAlertRule(
+  db: Db,
+  tenantId: string | null,
+  metric: ContextGovernanceMetric,
+) {
+  const tenantClause = tenantFilter(alertRules.tenantId, tenantId);
+  const whereClause = tenantClause
+    ? and(eq(alertRules.metric, metric), tenantClause)
+    : eq(alertRules.metric, metric);
+  const existing = await db.select().from(alertRules).where(whereClause).get();
+  if (existing) return existing;
+
+  const defaults = DEFAULT_CONTEXT_ALERT_RULES[metric];
+  const id = nanoid();
+  await db.insert(alertRules).values({
+    id,
+    tenantId,
+    name: defaults.name,
+    metric,
+    condition: defaults.condition,
+    threshold: defaults.threshold,
+    window: defaults.window,
+    channel: "webhook",
+    webhookUrl: null,
+    enabled: true,
+  }).run();
+
+  const created = await db.select().from(alertRules).where(eq(alertRules.id, id)).get();
+  if (!created) throw new Error("Failed to create context governance alert rule");
+  return created;
+}
+
+export async function ensureContextGovernanceAlertRules(db: Db, tenantId: string | null) {
+  await ensureContextGovernanceAlertRule(db, tenantId, CONTEXT_POLICY_FAILURES_METRIC);
+  await ensureContextGovernanceAlertRule(db, tenantId, CONTEXT_STALE_DRAFTS_METRIC);
+  await ensureContextGovernanceAlertRule(db, tenantId, CONTEXT_APPROVED_EXPORT_DELTA_METRIC);
+}
+
+export async function recordContextPolicyFailureAlert(
+  db: Db,
+  tenantId: string | null,
+  details: { blockId: string; decision: string; violationCount: number },
+): Promise<void> {
+  const rule = await ensureContextGovernanceAlertRule(db, tenantId, CONTEXT_POLICY_FAILURES_METRIC);
+  if (!rule.enabled) return;
+
+  await db.insert(alertLogs).values({
+    id: nanoid(),
+    ruleId: rule.id,
+    ruleName: `${rule.name}: ${details.blockId} ${details.decision}`,
+    metric: CONTEXT_POLICY_FAILURES_METRIC,
+    value: Math.max(1, details.violationCount),
+    threshold: rule.threshold,
+  }).run();
+
+  await db.update(alertRules)
+    .set({ lastTriggeredAt: new Date() })
+    .where(eq(alertRules.id, rule.id))
+    .run();
+}
+
+export async function countStaleCanonicalDrafts(
+  db: Db,
+  tenantId: string | null,
+  olderThan: Date,
+): Promise<number> {
+  const conditions = [
+    eq(contextCanonicalBlocks.reviewStatus, "draft"),
+    lt(contextCanonicalBlocks.updatedAt, olderThan),
+  ];
+  const tenantClause = tenantFilter(contextCanonicalBlocks.tenantId, tenantId);
+  if (tenantClause) conditions.push(tenantClause);
+
+  const row = await db.select({ count: sql<number>`count(*)` })
+    .from(contextCanonicalBlocks)
+    .where(and(...conditions))
+    .get();
+  return row?.count ?? 0;
+}
+
+export async function countApprovedContextDelta(
+  db: Db,
+  tenantId: string | null,
+  since: Date,
+): Promise<number> {
+  const conditions = [
+    eq(contextCanonicalReviewEvents.toStatus, "approved"),
+    gte(contextCanonicalReviewEvents.createdAt, since),
+  ];
+  const tenantClause = tenantFilter(contextCanonicalReviewEvents.tenantId, tenantId);
+  if (tenantClause) conditions.push(tenantClause);
+
+  const row = await db.select({ count: sql<number>`count(*)` })
+    .from(contextCanonicalReviewEvents)
+    .where(and(...conditions))
+    .get();
+  return row?.count ?? 0;
+}

--- a/packages/gateway/src/routes/alerts.ts
+++ b/packages/gateway/src/routes/alerts.ts
@@ -4,6 +4,24 @@ import { alertRules, alertLogs, requests, costLogs } from "@provara/db";
 import { eq, and, sql, gte, desc } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { getTenantId, tenantFilter } from "../auth/tenant.js";
+import {
+  CONTEXT_APPROVED_EXPORT_DELTA_METRIC,
+  CONTEXT_STALE_DRAFTS_METRIC,
+  CONTEXT_POLICY_FAILURES_METRIC,
+  countApprovedContextDelta,
+  countStaleCanonicalDrafts,
+  ensureContextGovernanceAlertRules,
+} from "../context/governance-alerts.js";
+
+type AlertMetric =
+  | "spend"
+  | "latency_p95"
+  | "latency_avg"
+  | "error_rate"
+  | "request_count"
+  | typeof CONTEXT_POLICY_FAILURES_METRIC
+  | typeof CONTEXT_STALE_DRAFTS_METRIC
+  | typeof CONTEXT_APPROVED_EXPORT_DELTA_METRIC;
 
 /**
  * Validate a webhook URL before storing/invoking it. Guards against SSRF:
@@ -69,6 +87,7 @@ export function createAlertRoutes(db: Db) {
   // List alert rules
   app.get("/rules", async (c) => {
     const tenantId = getTenantId(c.req.raw);
+    await ensureContextGovernanceAlertRules(db, tenantId);
     const rules = await db
       .select()
       .from(alertRules)
@@ -90,7 +109,7 @@ export function createAlertRoutes(db: Db) {
       webhookUrl?: string;
     }>();
 
-    if (!body.name || !body.metric || !body.threshold) {
+    if (!body.name || !body.metric || body.threshold === undefined || !Number.isFinite(body.threshold)) {
       return c.json({ error: { message: "name, metric, and threshold are required", type: "validation_error" } }, 400);
     }
 
@@ -104,7 +123,7 @@ export function createAlertRoutes(db: Db) {
       id,
       tenantId,
       name: body.name,
-      metric: body.metric as "spend" | "latency_p95" | "latency_avg" | "error_rate" | "request_count",
+      metric: body.metric as AlertMetric,
       condition: (body.condition || "gt") as "gt" | "lt" | "gte" | "lte",
       threshold: body.threshold,
       window: (body.window || "1h") as "1h" | "6h" | "24h" | "7d",
@@ -199,6 +218,7 @@ export function createAlertRoutes(db: Db) {
   // Evaluate all rules (called on a schedule or manually)
   app.post("/evaluate", async (c) => {
     const tenantId = getTenantId(c.req.raw);
+    await ensureContextGovernanceAlertRules(db, tenantId);
     const rules = await db
       .select()
       .from(alertRules)
@@ -292,6 +312,10 @@ async function evaluateMetric(db: Db, metric: string, window: string, tenantId: 
   const costTenantCondition = tenantFilter(costLogs.tenantId, tenantId);
 
   switch (metric) {
+    case CONTEXT_STALE_DRAFTS_METRIC:
+      return countStaleCanonicalDrafts(db, tenantId, since);
+    case CONTEXT_APPROVED_EXPORT_DELTA_METRIC:
+      return countApprovedContextDelta(db, tenantId, since);
     case "spend": {
       const conditions = [gte(costLogs.createdAt, since)];
       if (costTenantCondition) conditions.push(costTenantCondition);

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -46,6 +46,7 @@ import {
   validateReviewStatusBody,
 } from "../context/store.js";
 import { getSessionUserId, getTenantId } from "../auth/tenant.js";
+import { recordContextPolicyFailureAlert } from "../context/governance-alerts.js";
 import { ensureBuiltInRules, loadRules, scanContent } from "../guardrails/engine.js";
 import type { ProviderRegistry } from "../providers/index.js";
 import type { Provider } from "../providers/types.js";
@@ -752,6 +753,13 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       const rules = await loadRules(db, tenantId);
       const scan = scanContent(block.content, rules, "retrieved_context");
       const canonicalBlock = await recordContextCanonicalPolicyCheck(db, tenantId, blockId, scan);
+      if (canonicalBlock.policyStatus === "failed") {
+        await recordContextPolicyFailureAlert(db, tenantId, {
+          blockId,
+          decision: scan.decision,
+          violationCount: scan.violations.length,
+        }).catch(() => {});
+      }
       return c.json({
         canonicalBlock,
         policy: {
@@ -789,6 +797,13 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
         const block = await getContextCanonicalBlock(db, tenantId, blockId);
         const scan = scanContent(block.content, rules, "retrieved_context");
         const canonicalBlock = await recordContextCanonicalPolicyCheck(db, tenantId, blockId, scan);
+        if (canonicalBlock.policyStatus === "failed") {
+          await recordContextPolicyFailureAlert(db, tenantId, {
+            blockId,
+            decision: scan.decision,
+            violationCount: scan.violations.length,
+          }).catch(() => {});
+        }
         results.push({
           id: blockId,
           ok: true,

--- a/packages/gateway/tests/alerts.test.ts
+++ b/packages/gateway/tests/alerts.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
+import { alertLogs, alertRules, contextCanonicalBlocks, contextCanonicalReviewEvents, contextCollections } from "@provara/db";
+import { eq } from "drizzle-orm";
 import { createAlertRoutes } from "../src/routes/alerts.js";
 import { makeTestDb } from "./_setup/db.js";
 
@@ -8,6 +10,13 @@ async function buildApp() {
   const app = new Hono();
   app.route("/v1/admin/alerts", createAlertRoutes(db));
   return app;
+}
+
+async function buildFixture() {
+  const db = await makeTestDb();
+  const app = new Hono();
+  app.route("/v1/admin/alerts", createAlertRoutes(db));
+  return { app, db };
 }
 
 function postRule(app: Hono, body: unknown) {
@@ -84,5 +93,171 @@ describe("alert webhook URL validation (SSRF guard)", () => {
     const app = await buildApp();
     const res = await postRule(app, baseRule);
     expect(res.status).toBe(201);
+  });
+});
+
+describe("context governance alerts", () => {
+  it("provisions default context governance alert rules in alert management", async () => {
+    const { app, db } = await buildFixture();
+    const res = await app.request("/v1/admin/alerts/rules");
+    expect(res.status).toBe(200);
+    const body = await res.json() as { rules: Array<{ name: string; metric: string; threshold: number; window: string }> };
+    expect(body.rules).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "Context policy failures", metric: "context_policy_failures", threshold: 0 }),
+      expect.objectContaining({ name: "Stale canonical review queue", metric: "context_stale_drafts", window: "24h" }),
+      expect.objectContaining({ name: "Approved context export change", metric: "context_approved_export_delta" }),
+    ]));
+    expect(await db.select().from(alertRules).all()).toHaveLength(3);
+  });
+
+  it("evaluates stale canonical draft queues into alert history", async () => {
+    const { app, db } = await buildFixture();
+    const now = new Date();
+    const stale = new Date(now.getTime() - 48 * 3600_000);
+    await db.insert(contextCollections).values({
+      id: "collection-stale",
+      tenantId: null,
+      name: "Stale KB",
+      description: null,
+      status: "active",
+      documentCount: 0,
+      blockCount: 0,
+      canonicalBlockCount: 1,
+      approvedBlockCount: 0,
+      tokenCount: 0,
+      createdAt: stale,
+      updatedAt: stale,
+    }).run();
+    await db.insert(contextCanonicalBlocks).values({
+      id: "canonical-stale",
+      tenantId: null,
+      collectionId: "collection-stale",
+      content: "Stale draft knowledge.",
+      contentHash: "hash-stale",
+      tokenCount: 4,
+      sourceBlockIds: "[]",
+      sourceDocumentIds: "[]",
+      sourceCount: 0,
+      reviewStatus: "draft",
+      policyStatus: "passed",
+      policyDetails: "[]",
+      metadata: "{}",
+      createdAt: stale,
+      updatedAt: stale,
+    }).run();
+
+    const res = await app.request("/v1/admin/alerts/evaluate", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { fired: string[] };
+    expect(body.fired).toContain("Stale canonical review queue");
+
+    const alerts = await db.select().from(alertLogs).all();
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        ruleName: "Stale canonical review queue",
+        metric: "context_stale_drafts",
+        value: 1,
+        threshold: 0,
+      }),
+    ]);
+  });
+
+  it("evaluates approved context export deltas into alert history", async () => {
+    const { app, db } = await buildFixture();
+    await app.request("/v1/admin/alerts/rules");
+    const deltaRule = await db.select().from(alertRules).where(eq(alertRules.metric, "context_approved_export_delta")).get();
+    expect(deltaRule).toBeTruthy();
+    await db.update(alertRules).set({ threshold: 1 }).where(eq(alertRules.id, deltaRule!.id)).run();
+
+    const now = new Date();
+    await db.insert(contextCollections).values({
+      id: "collection-approved-delta",
+      tenantId: null,
+      name: "Approved Delta KB",
+      description: null,
+      status: "active",
+      documentCount: 0,
+      blockCount: 0,
+      canonicalBlockCount: 2,
+      approvedBlockCount: 2,
+      tokenCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    await db.insert(contextCanonicalBlocks).values([
+      {
+        id: "canonical-approved-1",
+        tenantId: null,
+        collectionId: "collection-approved-delta",
+        content: "Approved knowledge one.",
+        contentHash: "hash-approved-1",
+        tokenCount: 3,
+        sourceBlockIds: "[]",
+        sourceDocumentIds: "[]",
+        sourceCount: 0,
+        reviewStatus: "approved",
+        policyStatus: "passed",
+        policyDetails: "[]",
+        metadata: "{}",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "canonical-approved-2",
+        tenantId: null,
+        collectionId: "collection-approved-delta",
+        content: "Approved knowledge two.",
+        contentHash: "hash-approved-2",
+        tokenCount: 3,
+        sourceBlockIds: "[]",
+        sourceDocumentIds: "[]",
+        sourceCount: 0,
+        reviewStatus: "approved",
+        policyStatus: "passed",
+        policyDetails: "[]",
+        metadata: "{}",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]).run();
+    await db.insert(contextCanonicalReviewEvents).values([
+      {
+        id: "review-approved-1",
+        tenantId: null,
+        collectionId: "collection-approved-delta",
+        canonicalBlockId: "canonical-approved-1",
+        fromStatus: "draft",
+        toStatus: "approved",
+        note: null,
+        actorUserId: null,
+        createdAt: now,
+      },
+      {
+        id: "review-approved-2",
+        tenantId: null,
+        collectionId: "collection-approved-delta",
+        canonicalBlockId: "canonical-approved-2",
+        fromStatus: "draft",
+        toStatus: "approved",
+        note: null,
+        actorUserId: null,
+        createdAt: now,
+      },
+    ]).run();
+
+    const res = await app.request("/v1/admin/alerts/evaluate", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { fired: string[] };
+    expect(body.fired).toContain("Approved context export change");
+
+    const alerts = await db.select().from(alertLogs).all();
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        ruleName: "Approved context export change",
+        metric: "context_approved_export_delta",
+        value: 2,
+        threshold: 1,
+      }),
+    ]);
   });
 });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import type { Db } from "@provara/db";
 import {
+  alertLogs,
+  alertRules,
   contextBlocks,
   contextCanonicalBlocks,
   contextCanonicalReviewEvents,
@@ -1938,6 +1940,24 @@ describe("managed context collections", () => {
 
     const rows = await db.select().from(contextCanonicalBlocks).all();
     expect(rows[0]).toMatchObject({ reviewStatus: "draft", policyStatus: "failed" });
+
+    const rules = await db.select().from(alertRules).all();
+    expect(rules).toEqual([
+      expect.objectContaining({
+        tenantId: "tenant-pro",
+        name: "Context policy failures",
+        metric: "context_policy_failures",
+      }),
+    ]);
+    const alerts = await db.select().from(alertLogs).all();
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        ruleName: expect.stringContaining(blockId),
+        metric: "context_policy_failures",
+        value: 1,
+        threshold: 0,
+      }),
+    ]);
   });
 
   it("bulk checks and reviews canonical blocks with per-item failures", async () => {
@@ -2006,6 +2026,14 @@ describe("managed context collections", () => {
     };
     expect(reviewBody.results.filter((result) => result.ok)).toHaveLength(2);
     expect(reviewBody.results.filter((result) => result.error?.type === "policy_error")).toHaveLength(1);
+
+    const policyFailureAlerts = await db.select().from(alertLogs).all();
+    expect(policyFailureAlerts).toEqual([
+      expect.objectContaining({
+        metric: "context_policy_failures",
+        ruleName: expect.stringContaining("quarantine"),
+      }),
+    ]);
 
     const auditRows = await db.select().from(contextCanonicalReviewEvents).all();
     expect(auditRows).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Add context governance alert metrics and default rule provisioning for policy failures, stale drafts, and approved-export deltas.
- Record alert history when single or bulk canonical policy checks fail.
- Extend the existing Alerts evaluator to count stale canonical drafts and approved review deltas.
- Surface context governance metrics in the Alerts dashboard and update docs/roadmap/changelog.

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts tests/alerts.test.ts`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npx tsc --noEmit -p packages/db/tsconfig.json`
- `node -e "const fs=require('fs'); const yaml=require('yaml'); yaml.parse(fs.readFileSync('packages/gateway/openapi.yaml', 'utf8'));"`
- `git diff --check`
- `npm test --workspace @provara/web`
- `npm test --workspace @provara/gateway` (first run hit unrelated refusal-fallback assertion; `tests/refusal-fallback.test.ts` passed on rerun, then full gateway suite passed)
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`

Closes #375

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
