### PR TITLE
feat(#377): add connector ingestion foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable Provara changes are tracked here.
   - Canonical pre-approval policy checks that run active Guardrails rules before approval, persist policy evidence, block risky approvals, and surface policy status in the dashboard review queue.
   - Bulk canonical policy-check and review actions with per-block results, tenant isolation, audit events, and dashboard row selection.
   - Context governance alerts for policy-check failures, stale canonical review queues, and approved-export delta thresholds in the existing Alerts workflow.
+  - Connector ingestion foundation with tenant-scoped manual sources, idempotent source sync into managed documents and blocks, failed-sync status, and dashboard source visibility.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -45,7 +46,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, and context governance alerts as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, and connector ingestion foundation as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -60,7 +61,7 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, canonical blocks, review audit events, and canonical policy checks, run database migrations through `0057_context_policy_checks`.
+- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, canonical blocks, review audit events, canonical policy checks, and connector ingestion foundation, run database migrations through `0058_context_sources`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
@@ -69,6 +70,7 @@ All notable Provara changes are tracked here.
   - `context_retrieval_events`
   - `context_collections`
   - `context_documents`
+  - `context_sources`
   - `context_blocks`
   - `context_canonical_blocks`
   - `context_canonical_review_events`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -203,6 +203,21 @@ export interface ContextCanonicalBlock {
   updatedAt: string;
 }
 
+export interface ContextSource {
+  id: string;
+  collectionId: string;
+  name: string;
+  type: "manual";
+  externalId: string | null;
+  sourceUri: string | null;
+  syncStatus: "pending" | "synced" | "failed";
+  lastSyncedAt: string | null;
+  lastDocumentId: string | null;
+  documentCount: number;
+  lastError: string | null;
+  updatedAt: string;
+}
+
 interface BulkCanonicalResult {
   id: string;
   ok: boolean;
@@ -226,6 +241,7 @@ interface LoadState {
   retrievalSummary: ContextRetrievalSummary | null;
   retrievalEvents: ContextRetrievalEvent[];
   collections: ContextCollection[];
+  sources: ContextSource[];
   canonicalBlocks: ContextCanonicalBlock[];
   loading: boolean;
   error: string | null;
@@ -597,6 +613,7 @@ export function ContextOptimizerPanel() {
     retrievalSummary: null,
     retrievalEvents: [],
     collections: [],
+    sources: [],
     canonicalBlocks: [],
     loading: true,
     error: null,
@@ -652,6 +669,7 @@ export function ContextOptimizerPanel() {
               retrievalSummary: null,
               retrievalEvents: [],
               collections: [],
+              sources: [],
               canonicalBlocks: [],
               loading: false,
               error: null,
@@ -676,10 +694,20 @@ export function ContextOptimizerPanel() {
         const retrievalEventsBody = await retrievalEventsRes.json() as { events: ContextRetrievalEvent[] };
         const collectionsBody = await collectionsRes.json() as { collections: ContextCollection[] };
         let canonicalBlocks: ContextCanonicalBlock[] = [];
+        let sources: ContextSource[] = [];
         const firstCollection = collectionsBody.collections[0];
-        if (firstCollection && firstCollection.canonicalBlockCount > 0) {
-          const canonicalRes = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/canonical-blocks?reviewStatus=draft`);
-          if (canonicalRes.ok) {
+        if (firstCollection) {
+          const [sourcesRes, canonicalRes] = await Promise.all([
+            gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`),
+            firstCollection.canonicalBlockCount > 0
+              ? gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/canonical-blocks?reviewStatus=draft`)
+              : Promise.resolve(null),
+          ]);
+          if (sourcesRes.ok) {
+            const sourcesBody = await sourcesRes.json() as { sources: ContextSource[] };
+            sources = sourcesBody.sources;
+          }
+          if (canonicalRes?.ok) {
             const canonicalBody = await canonicalRes.json() as { canonicalBlocks: ContextCanonicalBlock[] };
             canonicalBlocks = canonicalBody.canonicalBlocks;
           }
@@ -694,6 +722,7 @@ export function ContextOptimizerPanel() {
             retrievalSummary: retrievalSummaryBody.summary,
             retrievalEvents: retrievalEventsBody.events,
             collections: collectionsBody.collections,
+            sources,
             canonicalBlocks,
             loading: false,
             error: null,
@@ -710,6 +739,7 @@ export function ContextOptimizerPanel() {
             retrievalSummary: null,
             retrievalEvents: [],
             collections: [],
+            sources: [],
             canonicalBlocks: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
@@ -732,6 +762,7 @@ export function ContextOptimizerPanel() {
   const retrievalSummary = state.retrievalSummary;
   const retrievalRows = useMemo(() => state.retrievalEvents, [state.retrievalEvents]);
   const collectionRows = useMemo(() => state.collections, [state.collections]);
+  const sourceRows = useMemo(() => state.sources, [state.sources]);
   const canonicalRows = useMemo(() => state.canonicalBlocks, [state.canonicalBlocks]);
   const visibleCanonicalRows = useMemo(() => canonicalRows.slice(0, 10), [canonicalRows]);
   const selectedCanonicalSet = useMemo(() => new Set(selectedCanonicalIds), [selectedCanonicalIds]);
@@ -946,6 +977,72 @@ export function ContextOptimizerPanel() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
                         {formatTimestamp(collection.updatedAt)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Collection Sources</h2>
+          <p className="mt-1 text-sm text-zinc-500">Manual connector sources and sync status for the first managed collection.</p>
+        </div>
+
+        {state.loading ? (
+          <LoadingRows />
+        ) : sourceRows.length === 0 ? (
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-8 text-center text-sm text-zinc-400">
+            No context sources in the first managed collection.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                  <tr>
+                    <th className="px-4 py-3 text-left font-medium">Source</th>
+                    <th className="px-4 py-3 text-left font-medium">Type</th>
+                    <th className="px-4 py-3 text-left font-medium">Sync</th>
+                    <th className="px-4 py-3 text-right font-medium">Documents</th>
+                    <th className="px-4 py-3 text-left font-medium">Last Synced</th>
+                    <th className="px-4 py-3 text-left font-medium">Updated</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-zinc-800">
+                  {sourceRows.map((source) => (
+                    <tr key={source.id}>
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-zinc-200">{source.name}</div>
+                        <div className="mt-1 max-w-xl truncate text-xs text-zinc-500">
+                          {source.sourceUri || source.externalId || source.id}
+                        </div>
+                        {source.lastError && <div className="mt-1 text-xs text-red-300">{source.lastError}</div>}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{source.type}</td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <span className={`rounded border px-2 py-0.5 text-xs capitalize ${
+                          source.syncStatus === "synced"
+                            ? "border-emerald-900/70 bg-emerald-950/20 text-emerald-200"
+                            : source.syncStatus === "failed"
+                              ? "border-red-900/70 bg-red-950/20 text-red-200"
+                              : "border-amber-900/70 bg-amber-950/20 text-amber-200"
+                        }`}>
+                          {source.syncStatus}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right tabular-nums text-zinc-300">
+                        {formatInteger(source.documentCount)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
+                        {formatTimestamp(source.lastSyncedAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
+                        {formatTimestamp(source.updatedAt)}
                       </td>
                     </tr>
                   ))}

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -208,6 +208,26 @@ describe("ContextOptimizerPanel", () => {
           ],
         }));
       }
+      if (path === "/v1/context/collections/collection-1/sources") {
+        return Promise.resolve(jsonResponse({
+          sources: [
+            {
+              id: "source-1",
+              collectionId: "collection-1",
+              name: "Refund source",
+              type: "manual",
+              externalId: "refunds.md",
+              sourceUri: "file://refunds.md",
+              syncStatus: "synced",
+              lastSyncedAt: "2026-05-01T22:03:00.000Z",
+              lastDocumentId: "doc-1",
+              documentCount: 1,
+              lastError: null,
+              updatedAt: "2026-05-01T22:03:00.000Z",
+            },
+          ],
+        }));
+      }
       if (path === "/v1/context/canonical-blocks/bulk-policy-check") {
         return Promise.resolve(jsonResponse({
           results: [
@@ -330,6 +350,9 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("Managed Collections")).toBeInTheDocument();
     expect(screen.getByText("Support KB")).toBeInTheDocument();
     expect(screen.getByText("Approved support context")).toBeInTheDocument();
+    expect(screen.getByText("Collection Sources")).toBeInTheDocument();
+    expect(screen.getByText("Refund source")).toBeInTheDocument();
+    expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Canonical Review Queue")).toBeInTheDocument();

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -35,9 +35,10 @@ Implemented as of `0.2.0`:
 - Canonical pre-approval policy checks with active Guardrails scans, persisted evidence, approval blocking, and dashboard status visibility.
 - Bulk canonical policy-check and review actions with dashboard row selection and per-block failures.
 - Context governance alerts for policy-check failures, stale draft queues, and approved-export delta thresholds.
+- Connector ingestion foundation with tenant-scoped manual sources, idempotent sync, failed-sync status, and dashboard source visibility.
 
 Next planned layer:
-- Connector ingestion.
+- Specific external connector implementations.
 
 ## V1: Runtime Context Optimizer
 
@@ -120,6 +121,13 @@ Capabilities:
 ## V2.2: Connectors
 
 Automatically ingest enterprise knowledge.
+
+Foundation shipped:
+- Tenant-scoped context source records.
+- Manual source creation and listing.
+- Idempotent source sync into managed context documents and blocks.
+- Failed-sync status and error persistence.
+- Dashboard source and sync-status visibility.
 
 Candidate connectors:
 - GitHub repositories.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,13 +21,14 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
+- Connector ingestion foundation with tenant-scoped manual sources and sync status.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
 
-It does not yet perform automated pre-approval policy checks or connector-backed ingestion. Those belong to later roadmap phases.
+It does not yet perform specific external connector pulls from systems such as GitHub, Confluence, Drive, or S3. Those belong to later roadmap phases.
 
 ## API
 
@@ -113,6 +114,9 @@ Managed collection APIs:
 GET /v1/context/collections
 POST /v1/context/collections
 POST /v1/context/collections/{id}/documents
+GET /v1/context/collections/{id}/sources
+POST /v1/context/collections/{id}/sources
+POST /v1/context/sources/{id}/sync
 POST /v1/context/collections/{id}/distill
 GET /v1/context/collections/{id}/canonical-blocks
 POST /v1/context/canonical-blocks/{id}/policy-check
@@ -124,6 +128,8 @@ GET /v1/context/collections/{id}/export
 ```
 
 Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters.
+
+Manual sources are the connector foundation. `POST /v1/context/collections/{id}/sources` creates a tenant-scoped source with content, source URI, external ID, and metadata. `POST /v1/context/sources/{id}/sync` ingests that source into the existing `context_documents` and `context_blocks` pipeline, records `synced` or `failed` status on the source, persists the last error for failed syncs, and skips unchanged already-synced sources without duplicating documents.
 
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
@@ -174,7 +180,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual sources for the first managed collection, including source URI, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -213,7 +219,7 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is connector ingestion:
+The next behavior layer is specific external connector ingestion:
 
 - GitHub, Confluence, Google Drive, SharePoint, Notion, Zendesk/Intercom, and S3/file upload connectors.
 - Source provenance and sync metadata for managed collections.

--- a/packages/db/drizzle/0058_context_sources.sql
+++ b/packages/db/drizzle/0058_context_sources.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `context_sources` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `collection_id` text NOT NULL,
+  `name` text NOT NULL,
+  `type` text DEFAULT 'manual' NOT NULL,
+  `external_id` text,
+  `source_uri` text,
+  `content` text DEFAULT '' NOT NULL,
+  `content_hash` text NOT NULL,
+  `sync_status` text DEFAULT 'pending' NOT NULL,
+  `last_synced_at` integer,
+  `last_document_id` text,
+  `document_count` integer DEFAULT 0 NOT NULL,
+  `last_error` text,
+  `metadata` text DEFAULT '{}' NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  FOREIGN KEY (`collection_id`) REFERENCES `context_collections`(`id`) ON UPDATE no action ON DELETE no action,
+  FOREIGN KEY (`last_document_id`) REFERENCES `context_documents`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `context_sources_tenant_collection_idx` ON `context_sources` (`tenant_id`,`collection_id`);
+--> statement-breakpoint
+CREATE INDEX `context_sources_sync_idx` ON `context_sources` (`tenant_id`,`sync_status`,`updated_at`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `context_sources_collection_external_idx` ON `context_sources` (`collection_id`,`external_id`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1777677000000,
       "tag": "0057_context_policy_checks",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "6",
+      "when": 1777679100000,
+      "tag": "0058_context_sources",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -465,6 +465,36 @@ export const contextDocuments = sqliteTable("context_documents", {
   index("context_documents_hash_idx").on(table.contentHash),
 ]);
 
+export const contextSources = sqliteTable("context_sources", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  collectionId: text("collection_id")
+    .notNull()
+    .references(() => contextCollections.id),
+  name: text("name").notNull(),
+  type: text("type", { enum: ["manual"] }).notNull().default("manual"),
+  externalId: text("external_id"),
+  sourceUri: text("source_uri"),
+  content: text("content").notNull().default(""),
+  contentHash: text("content_hash").notNull(),
+  syncStatus: text("sync_status", { enum: ["pending", "synced", "failed"] }).notNull().default("pending"),
+  lastSyncedAt: integer("last_synced_at", { mode: "timestamp" }),
+  lastDocumentId: text("last_document_id").references(() => contextDocuments.id),
+  documentCount: integer("document_count").notNull().default(0),
+  lastError: text("last_error"),
+  metadata: text("metadata").notNull().default("{}"),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_sources_tenant_collection_idx").on(table.tenantId, table.collectionId),
+  index("context_sources_sync_idx").on(table.tenantId, table.syncStatus, table.updatedAt),
+  uniqueIndex("context_sources_collection_external_idx").on(table.collectionId, table.externalId),
+]);
+
 export const contextBlocks = sqliteTable("context_blocks", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -560,6 +560,109 @@ paths:
         "404":
           description: Collection not found.
 
+  /v1/context/collections/{id}/sources:
+    get:
+      tags: [Context Optimizer]
+      summary: List connector sources for a managed context collection
+      operationId: listContextSources
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Context sources
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [sources]
+                properties:
+                  sources:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextSource"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+    post:
+      tags: [Context Optimizer]
+      summary: Create a manual connector source for a managed context collection
+      operationId: createContextSource
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateContextSourceRequest"
+      responses:
+        "201":
+          description: Created source
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [source]
+                properties:
+                  source:
+                    $ref: "#/components/schemas/ContextSource"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
+  /v1/context/sources/{id}/sync:
+    post:
+      tags: [Context Optimizer]
+      summary: Sync a connector source into stored context documents and blocks
+      operationId: syncContextSource
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Source sync result
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [source, collection, document, blocks, synced]
+                properties:
+                  source:
+                    $ref: "#/components/schemas/ContextSource"
+                  collection:
+                    $ref: "#/components/schemas/ContextCollection"
+                  document:
+                    nullable: true
+                    allOf:
+                      - $ref: "#/components/schemas/ContextDocument"
+                  blocks:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextBlockMetadata"
+                  synced:
+                    type: boolean
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Source not found.
+        "500":
+          description: Source sync failed.
+
   /v1/context/collections/{id}/distill:
     post:
       tags: [Context Optimizer]
@@ -2912,6 +3015,30 @@ components:
           type: object
           additionalProperties: true
 
+    CreateContextSourceRequest:
+      type: object
+      required: [name, content]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        type:
+          type: string
+          enum: [manual]
+        externalId:
+          type: string
+          maxLength: 2000
+        sourceUri:
+          type: string
+          maxLength: 2000
+        content:
+          type: string
+          maxLength: 500000
+        metadata:
+          type: object
+          additionalProperties: true
+
     ContextCollection:
       type: object
       required: [id, tenantId, name, description, status, documentCount, blockCount, canonicalBlockCount, approvedBlockCount, tokenCount, createdAt, updatedAt]
@@ -2975,6 +3102,55 @@ components:
         tokenCount:
           type: integer
         createdAt:
+          type: string
+          format: date-time
+
+    ContextSource:
+      type: object
+      required: [id, tenantId, collectionId, name, type, externalId, sourceUri, contentHash, syncStatus, lastSyncedAt, lastDocumentId, documentCount, lastError, metadata, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        collectionId:
+          type: string
+        name:
+          type: string
+        type:
+          type: string
+          enum: [manual]
+        externalId:
+          type: string
+          nullable: true
+        sourceUri:
+          type: string
+          nullable: true
+        contentHash:
+          type: string
+        syncStatus:
+          type: string
+          enum: [pending, synced, failed]
+        lastSyncedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastDocumentId:
+          type: string
+          nullable: true
+        documentCount:
+          type: integer
+        lastError:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
           type: string
           format: date-time
 

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -6,6 +6,7 @@ import {
   contextCanonicalReviewEvents,
   contextCollections,
   contextDocuments,
+  contextSources,
 } from "@provara/db";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
@@ -96,6 +97,25 @@ export interface ContextDocument {
   createdAt: Date;
 }
 
+export interface ContextSource {
+  id: string;
+  tenantId: string | null;
+  collectionId: string;
+  name: string;
+  type: "manual";
+  externalId: string | null;
+  sourceUri: string | null;
+  contentHash: string;
+  syncStatus: "pending" | "synced" | "failed";
+  lastSyncedAt: Date | null;
+  lastDocumentId: string | null;
+  documentCount: number;
+  lastError: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface ContextBlock {
   id: string;
   tenantId: string | null;
@@ -115,6 +135,15 @@ export interface IngestContextDocumentInput {
   text: string;
   source?: string;
   sourceUri?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateContextSourceInput {
+  name: string;
+  type: "manual";
+  externalId?: string;
+  sourceUri?: string;
+  content: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -275,6 +304,27 @@ function documentFromRow(row: typeof contextDocuments.$inferSelect): ContextDocu
   };
 }
 
+function sourceFromRow(row: typeof contextSources.$inferSelect): ContextSource {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    collectionId: row.collectionId,
+    name: row.name,
+    type: row.type,
+    externalId: row.externalId,
+    sourceUri: row.sourceUri,
+    contentHash: row.contentHash,
+    syncStatus: row.syncStatus,
+    lastSyncedAt: row.lastSyncedAt,
+    lastDocumentId: row.lastDocumentId,
+    documentCount: row.documentCount,
+    lastError: row.lastError,
+    metadata: parseMetadata(row.metadata),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
 function blockFromRow(row: typeof contextBlocks.$inferSelect): ContextBlock {
   return {
     id: row.id,
@@ -346,6 +396,44 @@ export function validateIngestDocumentBody(value: unknown): ValidationResult<Ing
       text,
       source: source.value,
       sourceUri: sourceUri.value,
+      metadata,
+    },
+  };
+}
+
+export function validateCreateContextSourceBody(value: unknown): ValidationResult<CreateContextSourceInput> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { error: "body must be an object" };
+  }
+  const body = value as Record<string, unknown>;
+  const name = trimOptional(body.name, "name", MAX_DOCUMENT_TITLE_CHARS);
+  if (name.error) return { error: name.error };
+  if (!name.value) return { error: "name is required" };
+  if (body.type !== undefined && body.type !== "manual") return { error: "type must be manual" };
+  const externalId = trimOptional(body.externalId, "externalId", MAX_SOURCE_URI_CHARS);
+  if (externalId.error) return { error: externalId.error };
+  const sourceUri = trimOptional(body.sourceUri, "sourceUri", MAX_SOURCE_URI_CHARS);
+  if (sourceUri.error) return { error: sourceUri.error };
+  if (typeof body.content !== "string") return { error: "content is required" };
+  if (body.content.length > MAX_INGEST_TEXT_CHARS) return { error: `content must be at most ${MAX_INGEST_TEXT_CHARS} characters` };
+
+  let metadata: Record<string, unknown> | undefined;
+  if (body.metadata !== undefined) {
+    if (typeof body.metadata !== "object" || body.metadata === null || Array.isArray(body.metadata)) {
+      return { error: "metadata must be an object" };
+    }
+    const encoded = JSON.stringify(body.metadata);
+    if (encoded.length > MAX_METADATA_CHARS) return { error: `metadata must encode to at most ${MAX_METADATA_CHARS} characters` };
+    metadata = body.metadata as Record<string, unknown>;
+  }
+
+  return {
+    value: {
+      name: name.value,
+      type: "manual",
+      externalId: externalId.value,
+      sourceUri: sourceUri.value,
+      content: body.content,
       metadata,
     },
   };
@@ -473,6 +561,65 @@ export async function listContextCollections(db: Db, tenantId: string | null): P
   return rows.map(collectionFromRow);
 }
 
+export async function createContextSource(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+  input: CreateContextSourceInput,
+): Promise<ContextSource> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collection = await db.select().from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("collection not found");
+  if (collection.status !== "active") throw new Error("collection is archived");
+
+  const now = new Date();
+  const id = nanoid();
+  await db.insert(contextSources).values({
+    id,
+    tenantId,
+    collectionId,
+    name: input.name,
+    type: input.type,
+    externalId: input.externalId ?? id,
+    sourceUri: input.sourceUri ?? null,
+    content: input.content,
+    contentHash: hashContent(input.content),
+    syncStatus: "pending",
+    documentCount: 0,
+    metadata: JSON.stringify(input.metadata ?? {}),
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+
+  await db.update(contextCollections).set({ updatedAt: now }).where(eq(contextCollections.id, collectionId)).run();
+
+  const row = await db.select().from(contextSources).where(eq(contextSources.id, id)).get();
+  if (!row) throw new Error("Failed to create context source");
+  return sourceFromRow(row);
+}
+
+export async function listContextSources(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+): Promise<ContextSource[]> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collection = await db.select({ id: contextCollections.id }).from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("collection not found");
+
+  const conditions = [eq(contextSources.collectionId, collectionId)];
+  const tenantClause = tenantFilter(contextSources.tenantId, tenantId);
+  if (tenantClause) conditions.push(tenantClause);
+
+  const rows = await db
+    .select()
+    .from(contextSources)
+    .where(and(...conditions))
+    .orderBy(desc(contextSources.updatedAt), asc(contextSources.id))
+    .all();
+  return rows.map(sourceFromRow);
+}
+
 export async function ingestContextDocument(
   db: Db,
   tenantId: string | null,
@@ -549,6 +696,75 @@ export async function ingestContextDocument(
     document: documentFromRow(document),
     blocks: blocks.map(blockFromRow),
   };
+}
+
+export async function syncContextSource(
+  db: Db,
+  tenantId: string | null,
+  sourceId: string,
+): Promise<{ source: ContextSource; collection: ContextCollection; document: ContextDocument | null; blocks: ContextBlock[]; synced: boolean }> {
+  const sourceRow = await db.select().from(contextSources).where(eq(contextSources.id, sourceId)).get();
+  if (!sourceRow) throw new Error("source not found");
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, sourceRow.collectionId));
+  const collection = await db.select().from(contextCollections).where(collectionWhere).get();
+  if (!collection) throw new Error("source not found");
+
+  if (sourceRow.syncStatus === "synced" && sourceRow.lastDocumentId && sourceRow.documentCount > 0) {
+    const document = await db.select().from(contextDocuments).where(eq(contextDocuments.id, sourceRow.lastDocumentId)).get();
+    const blocks = document
+      ? await db.select().from(contextBlocks).where(eq(contextBlocks.documentId, document.id)).orderBy(contextBlocks.ordinal).all()
+      : [];
+    return {
+      source: sourceFromRow(sourceRow),
+      collection: collectionFromRow(collection),
+      document: document ? documentFromRow(document) : null,
+      blocks: blocks.map(blockFromRow),
+      synced: false,
+    };
+  }
+
+  const now = new Date();
+  try {
+    const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
+      title: sourceRow.name,
+      text: sourceRow.content,
+      source: `source:${sourceRow.type}`,
+      sourceUri: sourceRow.sourceUri ?? undefined,
+      metadata: {
+        ...parseMetadata(sourceRow.metadata),
+        contextSourceId: sourceRow.id,
+        contextSourceType: sourceRow.type,
+        externalId: sourceRow.externalId,
+      },
+    });
+
+    await db.update(contextSources).set({
+      syncStatus: "synced",
+      lastSyncedAt: now,
+      lastDocumentId: result.document.id,
+      documentCount: sourceRow.documentCount + 1,
+      lastError: null,
+      updatedAt: now,
+    }).where(eq(contextSources.id, sourceId)).run();
+
+    const syncedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceId)).get();
+    if (!syncedSource) throw new Error("Failed to sync context source");
+    return {
+      source: sourceFromRow(syncedSource),
+      collection: result.collection,
+      document: result.document,
+      blocks: result.blocks,
+      synced: true,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to sync context source";
+    await db.update(contextSources).set({
+      syncStatus: "failed",
+      lastError: message,
+      updatedAt: now,
+    }).where(eq(contextSources.id, sourceId)).run();
+    throw new Error(message);
+  }
 }
 
 export async function distillContextCollection(

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -30,6 +30,7 @@ import {
 } from "../context/retrieval.js";
 import {
   createContextCollection,
+  createContextSource,
   distillContextCollection,
   exportApprovedContextBlocks,
   getContextCanonicalBlock,
@@ -37,11 +38,14 @@ import {
   listContextCanonicalBlocks,
   listContextCanonicalReviewEvents,
   listContextCollections,
+  listContextSources,
   recordContextCanonicalPolicyCheck,
+  syncContextSource,
   updateContextCanonicalBlockReview,
   validateBulkPolicyCheckBody,
   validateBulkReviewBody,
   validateCreateCollectionBody,
+  validateCreateContextSourceBody,
   validateIngestDocumentBody,
   validateReviewStatusBody,
 } from "../context/store.js";
@@ -696,6 +700,82 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       const notFound = message.includes("not found");
       return c.json(
         { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.get("/collections/:id/sources", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+
+    try {
+      const sources = await listContextSources(db, tenantId, collectionId);
+      return c.json({ sources });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to list context sources";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.post("/collections/:id/sources", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateCreateContextSourceBody(body);
+    if (!parsed.value) {
+      return c.json(
+        { error: { message: parsed.error || "invalid source body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const source = await createContextSource(db, tenantId, collectionId, parsed.value);
+      return c.json({ source }, 201);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to create context source";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.post("/sources/:id/sync", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const sourceId = c.req.param("id");
+
+    try {
+      const result = await syncContextSource(db, tenantId, sourceId);
+      return c.json({
+        source: result.source,
+        collection: result.collection,
+        document: result.document,
+        blocks: result.blocks.map((block) => ({
+          id: block.id,
+          tenantId: block.tenantId,
+          collectionId: block.collectionId,
+          documentId: block.documentId,
+          ordinal: block.ordinal,
+          contentHash: block.contentHash,
+          tokenCount: block.tokenCount,
+          source: block.source,
+          metadata: block.metadata,
+          createdAt: block.createdAt,
+        })),
+        synced: result.synced,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to sync context source";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "sync_error" } },
         notFound ? 404 : 500,
       );
     }

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -12,6 +12,7 @@ import {
   contextOptimizationEvents,
   contextQualityEvents,
   contextRetrievalEvents,
+  contextSources,
   guardrailRules,
 } from "@provara/db";
 import type { ProviderRegistry } from "../src/providers/index.js";
@@ -1708,6 +1709,144 @@ describe("managed context collections", () => {
     expect(ingestRes.status).toBe(404);
     expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
     expect(await db.select().from(contextBlocks).all()).toHaveLength(0);
+  });
+
+  it("creates, lists, and idempotently syncs manual context sources", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Connector KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const collectionId = collectionBody.collection.id;
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionId}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Refund source",
+        type: "manual",
+        externalId: "refunds.md",
+        sourceUri: "file://refunds.md",
+        content: "Refunds require a receipt within 30 days.",
+        metadata: { owner: "support" },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as {
+      source: { id: string; syncStatus: string; documentCount: number; contentHash: string; metadata: Record<string, unknown> };
+    };
+    expect(sourceBody.source).toMatchObject({
+      syncStatus: "pending",
+      documentCount: 0,
+      metadata: { owner: "support" },
+    });
+    expect(sourceBody.source.contentHash).toEqual(expect.any(String));
+
+    const listRes = await app.request(`/v1/context/collections/${collectionId}/sources`, {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json() as { sources: Array<{ id: string; name: string }> };
+    expect(listBody.sources).toEqual([
+      expect.objectContaining({ id: sourceBody.source.id, name: "Refund source" }),
+    ]);
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const syncBody = await syncRes.json() as {
+      synced: boolean;
+      source: { syncStatus: string; documentCount: number; lastDocumentId: string | null; lastSyncedAt: string | null };
+      collection: { documentCount: number; blockCount: number };
+      document: { id: string; source: string; sourceUri: string; metadata: Record<string, unknown> };
+      blocks: Array<{ metadata: Record<string, unknown>; source: string }>;
+    };
+    expect(syncBody.synced).toBe(true);
+    expect(syncBody.source).toMatchObject({ syncStatus: "synced", documentCount: 1, lastDocumentId: syncBody.document.id });
+    expect(syncBody.source.lastSyncedAt).toEqual(expect.any(String));
+    expect(syncBody.collection).toMatchObject({ documentCount: 1, blockCount: 1 });
+    expect(syncBody.document).toMatchObject({
+      source: "source:manual",
+      sourceUri: "file://refunds.md",
+      metadata: expect.objectContaining({ contextSourceId: sourceBody.source.id, externalId: "refunds.md" }),
+    });
+    expect(syncBody.blocks[0]).toMatchObject({
+      source: "source:manual",
+      metadata: expect.objectContaining({ contextSourceId: sourceBody.source.id, contextSourceType: "manual" }),
+    });
+
+    const syncAgainRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncAgainRes.status).toBe(200);
+    const syncAgainBody = await syncAgainRes.json() as { synced: boolean; source: { documentCount: number } };
+    expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 1 } });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(1);
+    expect(await db.select().from(contextBlocks).all()).toHaveLength(1);
+  });
+
+  it("persists failed source sync status without writing documents", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Failed Source KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Empty source", type: "manual", content: "   " }),
+    });
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(500);
+    const rows = await db.select().from(contextSources).all();
+    expect(rows).toEqual([
+      expect.objectContaining({ syncStatus: "failed", lastError: "text is required", documentCount: 0 }),
+    ]);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+  });
+
+  it("does not list or sync another tenant's context sources", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Tenant Sources" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Private source", content: "Private source knowledge." }),
+    });
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const listRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      headers: { "x-test-tenant": "tenant-other" },
+    });
+    expect(listRes.status).toBe(404);
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-other" },
+    });
+    expect(syncRes.status).toBe(404);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
   });
 
   it("distills duplicate stored blocks into canonical draft blocks", async () => {


### PR DESCRIPTION
## Summary
- Add `context_sources` schema/migration for tenant-scoped manual connector sources.
- Add source create/list/sync APIs with idempotent sync and failed-sync persistence.
- Surface Collection Sources and sync status on the Context Optimizer dashboard.
- Update OpenAPI, changelog, and Context Optimizer docs/roadmap.

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/db/tsconfig.json`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- OpenAPI YAML parse check
- `git diff --check`
- `npm test --workspace @provara/gateway`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`

Closes #377

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
