### PR TITLE
feat(#379): add GitHub connector ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable Provara changes are tracked here.
   - Bulk canonical policy-check and review actions with per-block results, tenant isolation, audit events, and dashboard row selection.
   - Context governance alerts for policy-check failures, stale canonical review queues, and approved-export delta thresholds in the existing Alerts workflow.
   - Connector ingestion foundation with tenant-scoped manual sources, idempotent source sync into managed documents and blocks, failed-sync status, and dashboard source visibility.
+  - GitHub repository connector v1 with bounded tree/blob ingestion, path/extension/file-size filters, SHA-based idempotency, repo/path/SHA provenance, and dashboard source details.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -46,7 +47,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, and connector ingestion foundation as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, and GitHub repository connector v1 as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -207,7 +207,7 @@ export interface ContextSource {
   id: string;
   collectionId: string;
   name: string;
-  type: "manual";
+  type: "manual" | "github_repository";
   externalId: string | null;
   sourceUri: string | null;
   syncStatus: "pending" | "synced" | "failed";
@@ -215,6 +215,7 @@ export interface ContextSource {
   lastDocumentId: string | null;
   documentCount: number;
   lastError: string | null;
+  metadata: Record<string, unknown>;
   updatedAt: string;
 }
 
@@ -307,6 +308,25 @@ function formatTimestamp(value: string | null): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Unknown";
   return date.toLocaleString();
+}
+
+function formatContextSourceType(type: ContextSource["type"]): string {
+  if (type === "github_repository") return "GitHub";
+  return "Manual";
+}
+
+function formatContextSourceDetail(source: ContextSource): string {
+  if (source.type === "github_repository") {
+    const github = typeof source.metadata.github === "object" && source.metadata.github !== null && !Array.isArray(source.metadata.github)
+      ? source.metadata.github as Record<string, unknown>
+      : {};
+    const owner = typeof github.owner === "string" ? github.owner : "";
+    const repo = typeof github.repo === "string" ? github.repo : "";
+    const branch = typeof github.branch === "string" ? github.branch : "main";
+    const path = typeof github.path === "string" && github.path ? `/${github.path}` : "";
+    if (owner && repo) return `${owner}/${repo}@${branch}${path}`;
+  }
+  return source.sourceUri || source.externalId || source.id;
 }
 
 function metricTone(value: number): string {
@@ -1019,11 +1039,11 @@ export function ContextOptimizerPanel() {
                       <td className="px-4 py-3">
                         <div className="font-medium text-zinc-200">{source.name}</div>
                         <div className="mt-1 max-w-xl truncate text-xs text-zinc-500">
-                          {source.sourceUri || source.externalId || source.id}
+                          {formatContextSourceDetail(source)}
                         </div>
                         {source.lastError && <div className="mt-1 text-xs text-red-300">{source.lastError}</div>}
                       </td>
-                      <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{source.type}</td>
+                      <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{formatContextSourceType(source.type)}</td>
                       <td className="whitespace-nowrap px-4 py-3">
                         <span className={`rounded border px-2 py-0.5 text-xs capitalize ${
                           source.syncStatus === "synced"

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -223,7 +223,23 @@ describe("ContextOptimizerPanel", () => {
               lastDocumentId: "doc-1",
               documentCount: 1,
               lastError: null,
+              metadata: {},
               updatedAt: "2026-05-01T22:03:00.000Z",
+            },
+            {
+              id: "source-2",
+              collectionId: "collection-1",
+              name: "Docs repository",
+              type: "github_repository",
+              externalId: "github:acme/docs:main:docs",
+              sourceUri: "https://github.com/acme/docs/tree/main",
+              syncStatus: "synced",
+              lastSyncedAt: "2026-05-01T22:04:00.000Z",
+              lastDocumentId: "doc-2",
+              documentCount: 2,
+              lastError: null,
+              metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs" } },
+              updatedAt: "2026-05-01T22:04:00.000Z",
             },
           ],
         }));
@@ -353,6 +369,8 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("Collection Sources")).toBeInTheDocument();
     expect(screen.getByText("Refund source")).toBeInTheDocument();
     expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
+    expect(screen.getByText("Docs repository")).toBeInTheDocument();
+    expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Canonical Review Queue")).toBeInTheDocument();

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -36,9 +36,10 @@ Implemented as of `0.2.0`:
 - Bulk canonical policy-check and review actions with dashboard row selection and per-block failures.
 - Context governance alerts for policy-check failures, stale draft queues, and approved-export delta thresholds.
 - Connector ingestion foundation with tenant-scoped manual sources, idempotent sync, failed-sync status, and dashboard source visibility.
+- GitHub repository connector v1 with bounded tree/blob ingestion, SHA-based idempotency, and dashboard source details.
 
 Next planned layer:
-- Specific external connector implementations.
+- Additional external connector implementations.
 
 ## V1: Runtime Context Optimizer
 
@@ -128,9 +129,12 @@ Foundation shipped:
 - Idempotent source sync into managed context documents and blocks.
 - Failed-sync status and error persistence.
 - Dashboard source and sync-status visibility.
+- GitHub repository source creation and listing.
+- Bounded GitHub file selection by path, extension, file size, and file count.
+- GitHub blob SHA idempotency for incremental sync.
+- GitHub repo/path/SHA provenance on stored documents and blocks.
 
 Candidate connectors:
-- GitHub repositories.
 - Confluence.
 - Google Drive.
 - SharePoint.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,14 +21,14 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
-- Connector ingestion foundation with tenant-scoped manual sources and sync status.
+- Connector ingestion with tenant-scoped manual and GitHub repository sources.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
 
-It does not yet perform specific external connector pulls from systems such as GitHub, Confluence, Drive, or S3. Those belong to later roadmap phases.
+It does not yet perform connector pulls from systems such as Confluence, Drive, or S3. Those belong to later roadmap phases.
 
 ## API
 
@@ -131,6 +131,26 @@ Collections are tenant-scoped containers for reusable context. The document inge
 
 Manual sources are the connector foundation. `POST /v1/context/collections/{id}/sources` creates a tenant-scoped source with content, source URI, external ID, and metadata. `POST /v1/context/sources/{id}/sync` ingests that source into the existing `context_documents` and `context_blocks` pipeline, records `synced` or `failed` status on the source, persists the last error for failed syncs, and skips unchanged already-synced sources without duplicating documents.
 
+GitHub repository sources use `type: "github_repository"` with a `github` config object:
+
+```json
+{
+  "name": "Docs repository",
+  "type": "github_repository",
+  "github": {
+    "owner": "acme",
+    "repo": "docs",
+    "branch": "main",
+    "path": "docs",
+    "extensions": [".md", ".txt"],
+    "maxFiles": 100,
+    "maxFileBytes": 250000
+  }
+}
+```
+
+GitHub sync fetches the repository tree and selected blobs through GitHub's JSON API, bounds files by extension/count/size, stores repo/path/SHA metadata on ingested documents and blocks, and skips files whose blob SHA has already synced.
+
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
 Before a canonical block can be approved, `POST /v1/context/canonical-blocks/{id}/policy-check` runs active Guardrails rules against the block as `retrieved_context`. The result persists `policyStatus`, `policyCheckedAt`, and per-rule evidence. `block` and retrieved-context `quarantine` decisions set `policyStatus: "failed"` and approval returns `409 policy_error`; `draft` and `rejected` transitions remain available without a passing check.
@@ -180,7 +200,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual sources for the first managed collection, including source URI, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -219,8 +239,8 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 ## Next Roadmap Step
 
-The next behavior layer is specific external connector ingestion:
+The next behavior layer is additional external connector ingestion:
 
-- GitHub, Confluence, Google Drive, SharePoint, Notion, Zendesk/Intercom, and S3/file upload connectors.
+- Confluence, Google Drive, SharePoint, Notion, Zendesk/Intercom, and S3/file upload connectors.
 - Source provenance and sync metadata for managed collections.
 - Connector-level review and policy defaults.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -472,7 +472,7 @@ export const contextSources = sqliteTable("context_sources", {
     .notNull()
     .references(() => contextCollections.id),
   name: text("name").notNull(),
-  type: text("type", { enum: ["manual"] }).notNull().default("manual"),
+  type: text("type", { enum: ["manual", "github_repository"] }).notNull().default("manual"),
   externalId: text("external_id"),
   sourceUri: text("source_uri"),
   content: text("content").notNull().default(""),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -590,7 +590,7 @@ paths:
           description: Collection not found.
     post:
       tags: [Context Optimizer]
-      summary: Create a manual connector source for a managed context collection
+      summary: Create a connector source for a managed context collection
       operationId: createContextSource
       parameters:
         - in: path
@@ -3017,7 +3017,7 @@ components:
 
     CreateContextSourceRequest:
       type: object
-      required: [name, content]
+      required: [name]
       properties:
         name:
           type: string
@@ -3025,7 +3025,7 @@ components:
           maxLength: 200
         type:
           type: string
-          enum: [manual]
+          enum: [manual, github_repository]
         externalId:
           type: string
           maxLength: 2000
@@ -3034,10 +3034,52 @@ components:
           maxLength: 2000
         content:
           type: string
+          description: Required for manual sources.
           maxLength: 500000
+        github:
+          $ref: "#/components/schemas/GitHubContextSourceConfig"
         metadata:
           type: object
           additionalProperties: true
+
+    GitHubContextSourceConfig:
+      type: object
+      required: [owner, repo]
+      properties:
+        owner:
+          type: string
+          minLength: 1
+          maxLength: 100
+        repo:
+          type: string
+          minLength: 1
+          maxLength: 100
+        branch:
+          type: string
+          default: main
+          maxLength: 200
+        path:
+          type: string
+          description: Optional repository path prefix to ingest.
+          maxLength: 1000
+        extensions:
+          type: array
+          description: File extensions to ingest. Defaults to markdown/text documentation extensions.
+          minItems: 1
+          maxItems: 20
+          items:
+            type: string
+            maxLength: 24
+        maxFileBytes:
+          type: integer
+          minimum: 1
+          maximum: 250000
+          default: 250000
+        maxFiles:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 100
 
     ContextCollection:
       type: object
@@ -3120,7 +3162,7 @@ components:
           type: string
         type:
           type: string
-          enum: [manual]
+          enum: [manual, github_repository]
         externalId:
           type: string
           nullable: true

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -22,9 +22,28 @@ const MAX_METADATA_CHARS = 20_000;
 const MAX_REVIEW_NOTE_CHARS = 2_000;
 const MAX_BULK_CANONICAL_BLOCK_IDS = 100;
 const MAX_INGEST_TEXT_CHARS = 500_000;
+const MAX_GITHUB_OWNER_CHARS = 100;
+const MAX_GITHUB_REPO_CHARS = 100;
+const MAX_GITHUB_BRANCH_CHARS = 200;
+const MAX_GITHUB_PATH_CHARS = 1_000;
+const MAX_GITHUB_EXTENSION_CHARS = 24;
+const MAX_GITHUB_FILE_BYTES = 250_000;
+const MAX_GITHUB_FILES = 100;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
 const BLOCK_INSERT_BATCH_SIZE = 50;
+
+type ContextSourceType = "manual" | "github_repository";
+
+export interface GitHubSourceConfig {
+  owner: string;
+  repo: string;
+  branch: string;
+  path?: string;
+  extensions: string[];
+  maxFileBytes: number;
+  maxFiles: number;
+}
 
 export interface ContextCollection {
   id: string;
@@ -102,7 +121,7 @@ export interface ContextSource {
   tenantId: string | null;
   collectionId: string;
   name: string;
-  type: "manual";
+  type: ContextSourceType;
   externalId: string | null;
   sourceUri: string | null;
   contentHash: string;
@@ -140,16 +159,39 @@ export interface IngestContextDocumentInput {
 
 export interface CreateContextSourceInput {
   name: string;
-  type: "manual";
+  type: ContextSourceType;
   externalId?: string;
   sourceUri?: string;
-  content: string;
+  content?: string;
   metadata?: Record<string, unknown>;
+  github?: GitHubSourceConfig;
 }
 
 export interface ValidationResult<T> {
   value?: T;
   error?: string;
+}
+
+interface GitHubTreeItem {
+  path: string;
+  type: string;
+  sha: string;
+  size?: number;
+}
+
+interface GitHubFileCandidate {
+  path: string;
+  sha: string;
+  size: number;
+}
+
+interface GitHubSyncFile extends GitHubFileCandidate {
+  content: string;
+}
+
+export interface ContextSourceSyncOptions {
+  fetch?: typeof fetch;
+  githubToken?: string;
 }
 
 function hashContent(content: string): string {
@@ -164,6 +206,36 @@ function parseMetadata(value: string | null): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function normalizeGithubExtension(value: string): string {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return "";
+  return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function parseGithubConfig(metadata: Record<string, unknown>): GitHubSourceConfig {
+  const github = metadata.github;
+  if (typeof github !== "object" || github === null || Array.isArray(github)) {
+    throw new Error("github source config is required");
+  }
+  const raw = github as Record<string, unknown>;
+  const owner = typeof raw.owner === "string" ? raw.owner : "";
+  const repo = typeof raw.repo === "string" ? raw.repo : "";
+  const branch = typeof raw.branch === "string" ? raw.branch : "main";
+  const path = typeof raw.path === "string" && raw.path.trim() ? raw.path.trim().replace(/^\/+|\/+$/g, "") : undefined;
+  const extensions = Array.isArray(raw.extensions)
+    ? raw.extensions.filter((value): value is string => typeof value === "string").map(normalizeGithubExtension).filter(Boolean)
+    : [".md", ".mdx", ".txt", ".rst", ".adoc"];
+  const maxFileBytes = typeof raw.maxFileBytes === "number" && Number.isFinite(raw.maxFileBytes)
+    ? Math.min(Math.max(Math.trunc(raw.maxFileBytes), 1), MAX_GITHUB_FILE_BYTES)
+    : MAX_GITHUB_FILE_BYTES;
+  const maxFiles = typeof raw.maxFiles === "number" && Number.isFinite(raw.maxFiles)
+    ? Math.min(Math.max(Math.trunc(raw.maxFiles), 1), MAX_GITHUB_FILES)
+    : MAX_GITHUB_FILES;
+
+  if (!owner || !repo || !branch) throw new Error("github owner, repo, and branch are required");
+  return { owner, repo, branch, path, extensions, maxFileBytes, maxFiles };
 }
 
 function collectionFromRow(row: typeof contextCollections.$inferSelect): ContextCollection {
@@ -409,13 +481,17 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
   const name = trimOptional(body.name, "name", MAX_DOCUMENT_TITLE_CHARS);
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
-  if (body.type !== undefined && body.type !== "manual") return { error: "type must be manual" };
+  const type = body.type === undefined ? "manual" : body.type;
+  if (type !== "manual" && type !== "github_repository") return { error: "type must be manual or github_repository" };
   const externalId = trimOptional(body.externalId, "externalId", MAX_SOURCE_URI_CHARS);
   if (externalId.error) return { error: externalId.error };
   const sourceUri = trimOptional(body.sourceUri, "sourceUri", MAX_SOURCE_URI_CHARS);
   if (sourceUri.error) return { error: sourceUri.error };
-  if (typeof body.content !== "string") return { error: "content is required" };
-  if (body.content.length > MAX_INGEST_TEXT_CHARS) return { error: `content must be at most ${MAX_INGEST_TEXT_CHARS} characters` };
+  if (type === "manual" && typeof body.content !== "string") return { error: "content is required" };
+  if (body.content !== undefined && typeof body.content !== "string") return { error: "content must be a string" };
+  if (typeof body.content === "string" && body.content.length > MAX_INGEST_TEXT_CHARS) {
+    return { error: `content must be at most ${MAX_INGEST_TEXT_CHARS} characters` };
+  }
 
   let metadata: Record<string, unknown> | undefined;
   if (body.metadata !== undefined) {
@@ -427,14 +503,70 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
     metadata = body.metadata as Record<string, unknown>;
   }
 
+  let github: GitHubSourceConfig | undefined;
+  if (type === "github_repository") {
+    if (typeof body.github !== "object" || body.github === null || Array.isArray(body.github)) {
+      return { error: "github config is required" };
+    }
+    const raw = body.github as Record<string, unknown>;
+    const owner = trimOptional(raw.owner, "github.owner", MAX_GITHUB_OWNER_CHARS);
+    if (owner.error) return { error: owner.error };
+    if (!owner.value) return { error: "github.owner is required" };
+    const repo = trimOptional(raw.repo, "github.repo", MAX_GITHUB_REPO_CHARS);
+    if (repo.error) return { error: repo.error };
+    if (!repo.value) return { error: "github.repo is required" };
+    const branch = trimOptional(raw.branch, "github.branch", MAX_GITHUB_BRANCH_CHARS);
+    if (branch.error) return { error: branch.error };
+    const path = trimOptional(raw.path, "github.path", MAX_GITHUB_PATH_CHARS);
+    if (path.error) return { error: path.error };
+
+    let extensions = [".md", ".mdx", ".txt", ".rst", ".adoc"];
+    if (raw.extensions !== undefined) {
+      if (!Array.isArray(raw.extensions)) return { error: "github.extensions must be an array" };
+      if (raw.extensions.length === 0 || raw.extensions.length > 20) return { error: "github.extensions must contain 1 to 20 entries" };
+      extensions = [];
+      for (const [index, entry] of raw.extensions.entries()) {
+        if (typeof entry !== "string") return { error: `github.extensions[${index}] must be a string` };
+        const normalized = normalizeGithubExtension(entry);
+        if (!normalized) return { error: `github.extensions[${index}] is required` };
+        if (normalized.length > MAX_GITHUB_EXTENSION_CHARS) {
+          return { error: `github.extensions[${index}] must be at most ${MAX_GITHUB_EXTENSION_CHARS} characters` };
+        }
+        if (!extensions.includes(normalized)) extensions.push(normalized);
+      }
+    }
+
+    const maxFileBytes = raw.maxFileBytes === undefined ? MAX_GITHUB_FILE_BYTES : raw.maxFileBytes;
+    if (typeof maxFileBytes !== "number" || !Number.isFinite(maxFileBytes)) return { error: "github.maxFileBytes must be a number" };
+    if (maxFileBytes < 1 || maxFileBytes > MAX_GITHUB_FILE_BYTES) {
+      return { error: `github.maxFileBytes must be between 1 and ${MAX_GITHUB_FILE_BYTES}` };
+    }
+    const maxFiles = raw.maxFiles === undefined ? MAX_GITHUB_FILES : raw.maxFiles;
+    if (typeof maxFiles !== "number" || !Number.isFinite(maxFiles)) return { error: "github.maxFiles must be a number" };
+    if (maxFiles < 1 || maxFiles > MAX_GITHUB_FILES) {
+      return { error: `github.maxFiles must be between 1 and ${MAX_GITHUB_FILES}` };
+    }
+
+    github = {
+      owner: owner.value,
+      repo: repo.value,
+      branch: branch.value ?? "main",
+      path: path.value?.replace(/^\/+|\/+$/g, ""),
+      extensions,
+      maxFileBytes: Math.trunc(maxFileBytes),
+      maxFiles: Math.trunc(maxFiles),
+    };
+  }
+
   return {
     value: {
       name: name.value,
-      type: "manual",
+      type,
       externalId: externalId.value,
       sourceUri: sourceUri.value,
-      content: body.content,
+      content: typeof body.content === "string" ? body.content : undefined,
       metadata,
+      github,
     },
   };
 }
@@ -574,19 +706,27 @@ export async function createContextSource(
 
   const now = new Date();
   const id = nanoid();
+  const metadata = input.github
+    ? { ...(input.metadata ?? {}), github: input.github, githubSyncedFiles: {} }
+    : input.metadata ?? {};
+  const sourceUri = input.sourceUri
+    ?? (input.github ? `https://github.com/${input.github.owner}/${input.github.repo}/tree/${encodeURIComponent(input.github.branch)}` : null);
+  const externalId = input.externalId
+    ?? (input.github ? `github:${input.github.owner}/${input.github.repo}:${input.github.branch}:${input.github.path ?? ""}` : id);
+  const content = input.content ?? "";
   await db.insert(contextSources).values({
     id,
     tenantId,
     collectionId,
     name: input.name,
     type: input.type,
-    externalId: input.externalId ?? id,
-    sourceUri: input.sourceUri ?? null,
-    content: input.content,
-    contentHash: hashContent(input.content),
+    externalId,
+    sourceUri,
+    content,
+    contentHash: hashContent(input.github ? JSON.stringify(input.github) : content),
     syncStatus: "pending",
     documentCount: 0,
-    metadata: JSON.stringify(input.metadata ?? {}),
+    metadata: JSON.stringify(metadata),
     createdAt: now,
     updatedAt: now,
   }).run();
@@ -698,16 +838,219 @@ export async function ingestContextDocument(
   };
 }
 
+function githubHeaders(token?: string): HeadersInit {
+  return {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "provara-context-connector",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function githubApiUrl(path: string): string {
+  return `https://api.github.com${path}`;
+}
+
+function shouldIngestGithubFile(item: GitHubTreeItem, config: GitHubSourceConfig): boolean {
+  if (item.type !== "blob") return false;
+  if (typeof item.size === "number" && item.size > config.maxFileBytes) return false;
+  if (config.path && item.path !== config.path && !item.path.startsWith(`${config.path}/`)) return false;
+  const lowerPath = item.path.toLowerCase();
+  return config.extensions.some((extension) => lowerPath.endsWith(extension));
+}
+
+async function fetchGithubJson(fetchFn: typeof fetch, url: string, token?: string): Promise<unknown> {
+  const response = await fetchFn(url, { headers: githubHeaders(token) });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const detail = text ? `: ${text.slice(0, 200)}` : "";
+    throw new Error(`GitHub request failed (${response.status})${detail}`);
+  }
+  return response.json() as Promise<unknown>;
+}
+
+async function fetchGithubCandidates(
+  fetchFn: typeof fetch,
+  config: GitHubSourceConfig,
+  token?: string,
+): Promise<GitHubFileCandidate[]> {
+  const treeUrl = githubApiUrl(`/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/git/trees/${encodeURIComponent(config.branch)}?recursive=1`);
+  const payload = await fetchGithubJson(fetchFn, treeUrl, token);
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) throw new Error("GitHub tree response is invalid");
+  const tree = (payload as { tree?: unknown }).tree;
+  if (!Array.isArray(tree)) throw new Error("GitHub tree response is missing files");
+  return tree
+    .filter((item): item is GitHubTreeItem => (
+      typeof item === "object"
+      && item !== null
+      && !Array.isArray(item)
+      && typeof (item as GitHubTreeItem).path === "string"
+      && typeof (item as GitHubTreeItem).type === "string"
+      && typeof (item as GitHubTreeItem).sha === "string"
+    ))
+    .filter((item) => shouldIngestGithubFile(item, config))
+    .sort((left, right) => left.path.localeCompare(right.path))
+    .slice(0, config.maxFiles)
+    .map((item) => ({ path: item.path, sha: item.sha, size: typeof item.size === "number" ? item.size : 0 }));
+}
+
+async function fetchGithubFile(
+  fetchFn: typeof fetch,
+  config: GitHubSourceConfig,
+  candidate: GitHubFileCandidate,
+  token?: string,
+): Promise<GitHubSyncFile> {
+  const blobUrl = githubApiUrl(`/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/git/blobs/${encodeURIComponent(candidate.sha)}`);
+  const payload = await fetchGithubJson(fetchFn, blobUrl, token);
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) throw new Error(`GitHub blob response is invalid for ${candidate.path}`);
+  const blob = payload as { content?: unknown; encoding?: unknown; size?: unknown };
+  if (blob.encoding !== "base64" || typeof blob.content !== "string") {
+    throw new Error(`GitHub blob response is unsupported for ${candidate.path}`);
+  }
+  const size = typeof blob.size === "number" ? blob.size : candidate.size;
+  if (size > config.maxFileBytes) throw new Error(`GitHub file exceeds maxFileBytes: ${candidate.path}`);
+  const content = Buffer.from(blob.content.replace(/\s/g, ""), "base64").toString("utf8");
+  if (content.trim().length === 0) throw new Error(`GitHub file is empty: ${candidate.path}`);
+  return { ...candidate, size, content };
+}
+
+function getSyncedGithubFiles(metadata: Record<string, unknown>): Record<string, string> {
+  const files = metadata.githubSyncedFiles;
+  if (typeof files !== "object" || files === null || Array.isArray(files)) return {};
+  const result: Record<string, string> = {};
+  for (const [path, sha] of Object.entries(files)) {
+    if (typeof sha === "string") result[path] = sha;
+  }
+  return result;
+}
+
+async function syncGithubContextSource(
+  db: Db,
+  tenantId: string | null,
+  sourceRow: typeof contextSources.$inferSelect,
+  collection: typeof contextCollections.$inferSelect,
+  options: ContextSourceSyncOptions,
+): Promise<{ source: ContextSource; collection: ContextCollection; document: ContextDocument | null; blocks: ContextBlock[]; synced: boolean }> {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  if (!fetchFn) throw new Error("fetch is unavailable");
+  const metadata = parseMetadata(sourceRow.metadata);
+  const config = parseGithubConfig(metadata);
+  const syncedFiles = getSyncedGithubFiles(metadata);
+  const candidates = await fetchGithubCandidates(fetchFn, config, options.githubToken);
+  const changedCandidates = candidates.filter((candidate) => syncedFiles[candidate.path] !== candidate.sha);
+  const now = new Date();
+
+  if (changedCandidates.length === 0 && sourceRow.syncStatus === "synced") {
+    await db.update(contextSources).set({
+      lastSyncedAt: now,
+      lastError: null,
+      updatedAt: now,
+      metadata: JSON.stringify({
+        ...metadata,
+        githubLastSync: {
+          checkedAt: now.toISOString(),
+          matchedFiles: candidates.length,
+          changedFiles: 0,
+        },
+      }),
+    }).where(eq(contextSources.id, sourceRow.id)).run();
+    const unchangedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+    return {
+      source: sourceFromRow(unchangedSource ?? sourceRow),
+      collection: collectionFromRow(collection),
+      document: null,
+      blocks: [],
+      synced: false,
+    };
+  }
+
+  const allBlocks: ContextBlock[] = [];
+  let lastDocument: ContextDocument | null = null;
+  let latestCollection: ContextCollection = collectionFromRow(collection);
+  const nextSyncedFiles = { ...syncedFiles };
+
+  for (const candidate of changedCandidates) {
+    const file = await fetchGithubFile(fetchFn, config, candidate, options.githubToken);
+    const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
+      title: file.path,
+      text: file.content,
+      source: `source:${sourceRow.type}`,
+      sourceUri: `https://github.com/${config.owner}/${config.repo}/blob/${encodeURIComponent(config.branch)}/${file.path.split("/").map(encodeURIComponent).join("/")}`,
+      metadata: {
+        ...metadata,
+        githubSyncedFiles: undefined,
+        contextSourceId: sourceRow.id,
+        contextSourceType: sourceRow.type,
+        externalId: sourceRow.externalId,
+        githubOwner: config.owner,
+        githubRepo: config.repo,
+        githubBranch: config.branch,
+        githubPath: file.path,
+        githubSha: file.sha,
+        githubSize: file.size,
+      },
+    });
+    nextSyncedFiles[file.path] = file.sha;
+    latestCollection = result.collection;
+    lastDocument = result.document;
+    allBlocks.push(...result.blocks);
+  }
+
+  await db.update(contextSources).set({
+    syncStatus: "synced",
+    lastSyncedAt: now,
+    lastDocumentId: lastDocument?.id ?? sourceRow.lastDocumentId,
+    documentCount: sourceRow.documentCount + changedCandidates.length,
+    lastError: null,
+    contentHash: hashContent(candidates.map((candidate) => `${candidate.path}:${candidate.sha}`).join("\n")),
+    metadata: JSON.stringify({
+      ...metadata,
+      githubSyncedFiles: nextSyncedFiles,
+      githubLastSync: {
+        checkedAt: now.toISOString(),
+        matchedFiles: candidates.length,
+        changedFiles: changedCandidates.length,
+      },
+    }),
+    updatedAt: now,
+  }).where(eq(contextSources.id, sourceRow.id)).run();
+
+  const syncedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+  if (!syncedSource) throw new Error("Failed to sync context source");
+  return {
+    source: sourceFromRow(syncedSource),
+    collection: latestCollection,
+    document: lastDocument,
+    blocks: allBlocks,
+    synced: changedCandidates.length > 0,
+  };
+}
+
 export async function syncContextSource(
   db: Db,
   tenantId: string | null,
   sourceId: string,
+  options: ContextSourceSyncOptions = {},
 ): Promise<{ source: ContextSource; collection: ContextCollection; document: ContextDocument | null; blocks: ContextBlock[]; synced: boolean }> {
   const sourceRow = await db.select().from(contextSources).where(eq(contextSources.id, sourceId)).get();
   if (!sourceRow) throw new Error("source not found");
   const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, sourceRow.collectionId));
   const collection = await db.select().from(contextCollections).where(collectionWhere).get();
   if (!collection) throw new Error("source not found");
+
+  if (sourceRow.type === "github_repository") {
+    const now = new Date();
+    try {
+      return await syncGithubContextSource(db, tenantId, sourceRow, collection, options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to sync context source";
+      await db.update(contextSources).set({
+        syncStatus: "failed",
+        lastError: message,
+        updatedAt: now,
+      }).where(eq(contextSources.id, sourceId)).run();
+      throw new Error(message);
+    }
+  }
 
   if (sourceRow.syncStatus === "synced" && sourceRow.lastDocumentId && sourceRow.documentCount > 0) {
     const document = await db.select().from(contextDocuments).where(eq(contextDocuments.id, sourceRow.lastDocumentId)).get();

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -397,6 +397,8 @@ async function applyRiskScan(
 export interface ContextRouteOptions {
   embeddings?: EmbeddingProvider | null;
   dbKeys?: Record<string, string>;
+  githubFetch?: typeof fetch;
+  githubToken?: string;
 }
 
 async function applyRequestedRanking(
@@ -752,7 +754,10 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
     const sourceId = c.req.param("id");
 
     try {
-      const result = await syncContextSource(db, tenantId, sourceId);
+      const result = await syncContextSource(db, tenantId, sourceId, {
+        fetch: routeOptions.githubFetch,
+        githubToken: routeOptions.githubToken,
+      });
       return c.json({
         source: result.source,
         collection: result.collection,

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -84,6 +84,13 @@ function fakeEmbeddings(vectors: Record<string, number[]>): EmbeddingProvider {
   };
 }
 
+function githubJson(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("context optimizer core", () => {
   it("drops exact duplicate chunks and reports token savings", () => {
     const result = optimizeContextChunks([
@@ -1816,6 +1823,137 @@ describe("managed context collections", () => {
     expect(rows).toEqual([
       expect.objectContaining({ syncStatus: "failed", lastError: "text is required", documentCount: 0 }),
     ]);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+  });
+
+  it("creates and idempotently syncs GitHub repository sources", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const githubFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/git/trees/main")) {
+        return githubJson({
+          tree: [
+            { path: "docs/readme.md", type: "blob", sha: "sha-readme", size: 61 },
+            { path: "docs/api.txt", type: "blob", sha: "sha-api", size: 42 },
+            { path: "src/private.ts", type: "blob", sha: "sha-private", size: 20 },
+          ],
+        });
+      }
+      if (url.includes("/git/blobs/sha-readme")) {
+        return githubJson({
+          encoding: "base64",
+          size: 61,
+          content: Buffer.from("Refunds are available within 30 days from GitHub docs.").toString("base64"),
+        });
+      }
+      if (url.includes("/git/blobs/sha-api")) {
+        return githubJson({
+          encoding: "base64",
+          size: 42,
+          content: Buffer.from("API clients should send account identifiers.").toString("base64"),
+        });
+      }
+      return githubJson({ message: "not found" }, 404);
+    });
+    const app = buildApp(db, undefined, { githubFetch });
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "GitHub KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Docs repository",
+        type: "github_repository",
+        github: {
+          owner: "acme",
+          repo: "docs",
+          branch: "main",
+          path: "docs",
+          extensions: [".md", ".txt"],
+          maxFiles: 10,
+          maxFileBytes: 1_000,
+        },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as { source: { id: string; type: string; metadata: Record<string, unknown> } };
+    expect(sourceBody.source.type).toBe("github_repository");
+    expect(sourceBody.source.metadata.github).toMatchObject({ owner: "acme", repo: "docs", branch: "main" });
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const syncBody = await syncRes.json() as {
+      synced: boolean;
+      source: { syncStatus: string; documentCount: number; metadata: Record<string, unknown> };
+      collection: { documentCount: number; blockCount: number };
+      document: { id: string; source: string; metadata: Record<string, unknown> };
+      blocks: Array<{ source: string; metadata: Record<string, unknown> }>;
+    };
+    expect(syncBody.synced).toBe(true);
+    expect(syncBody.source).toMatchObject({ syncStatus: "synced", documentCount: 2 });
+    expect(syncBody.collection).toMatchObject({ documentCount: 2, blockCount: 2 });
+    expect(syncBody.document.source).toBe("source:github_repository");
+    expect(syncBody.blocks).toHaveLength(2);
+    expect(syncBody.blocks[0]).toMatchObject({
+      source: "source:github_repository",
+      metadata: expect.objectContaining({ contextSourceId: sourceBody.source.id, githubOwner: "acme", githubRepo: "docs" }),
+    });
+    expect(syncBody.source.metadata.githubSyncedFiles).toMatchObject({
+      "docs/readme.md": "sha-readme",
+      "docs/api.txt": "sha-api",
+    });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+
+    const syncAgainRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncAgainRes.status).toBe(200);
+    const syncAgainBody = await syncAgainRes.json() as { synced: boolean; source: { documentCount: number }; document: unknown; blocks: unknown[] };
+    expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 2 }, document: null, blocks: [] });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+    expect(githubFetch.mock.calls.filter(([url]) => String(url).includes("/git/blobs/"))).toHaveLength(2);
+  });
+
+  it("persists failed GitHub source sync status without writing documents", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const githubFetch = vi.fn(async () => githubJson({ message: "rate limited" }, 403));
+    const app = buildApp(db, undefined, { githubFetch });
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "GitHub Failure KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Broken repository",
+        type: "github_repository",
+        github: { owner: "acme", repo: "docs", branch: "main" },
+      }),
+    });
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(500);
+    const rows = await db.select().from(contextSources).all();
+    expect(rows).toEqual([
+      expect.objectContaining({ type: "github_repository", syncStatus: "failed", documentCount: 0 }),
+    ]);
+    expect(rows[0]?.lastError).toContain("GitHub request failed (403)");
     expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
- Add `github_repository` context source config and validation.
- Sync GitHub repository trees/blobs into managed context documents and blocks with repo/path/SHA provenance.
- Skip unchanged files by blob SHA and persist failed sync status/errors.
- Surface GitHub source details in the Context Optimizer dashboard.
- Update OpenAPI, docs, changelog, and roadmap.

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/db/tsconfig.json`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- OpenAPI YAML parse check
- `git diff --check`
- `npm test --workspace @provara/gateway`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`

Closes #379

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
