### PR TITLE
feat(#381): add connector credential auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable Provara changes are tracked here.
   - Context governance alerts for policy-check failures, stale canonical review queues, and approved-export delta thresholds in the existing Alerts workflow.
   - Connector ingestion foundation with tenant-scoped manual sources, idempotent source sync into managed documents and blocks, failed-sync status, and dashboard source visibility.
   - GitHub repository connector v1 with bounded tree/blob ingestion, path/extension/file-size filters, SHA-based idempotency, repo/path/SHA provenance, and dashboard source details.
+  - Connector credential auth foundation with encrypted tenant-scoped GitHub tokens, credential-bound source sync, no secret echo in API responses, and dashboard auth status.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -47,7 +48,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, and GitHub repository connector v1 as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, and connector credential auth foundation as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.
@@ -62,7 +63,7 @@ All notable Provara changes are tracked here.
 ### Upgrade Notes
 
 - Run database migrations through `0044_firewall_settings`.
-- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, canonical blocks, review audit events, canonical policy checks, and connector ingestion foundation, run database migrations through `0058_context_sources`.
+- For Context Optimizer visibility, risk reporting, quality scoring, retrieval analytics, semantic near-duplicate metrics, relevance metrics, freshness metrics, conflict metrics, compression metrics, managed collections, canonical blocks, review audit events, canonical policy checks, connector ingestion foundation, and connector credentials, run database migrations through `0059_context_connector_credentials`.
 - New tables:
   - `firewall_events`
   - `firewall_settings`
@@ -72,6 +73,7 @@ All notable Provara changes are tracked here.
   - `context_collections`
   - `context_documents`
   - `context_sources`
+  - `context_connector_credentials`
   - `context_blocks`
   - `context_canonical_blocks`
   - `context_canonical_review_events`

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -329,6 +329,14 @@ function formatContextSourceDetail(source: ContextSource): string {
   return source.sourceUri || source.externalId || source.id;
 }
 
+function contextSourceHasAuth(source: ContextSource): boolean {
+  if (source.type !== "github_repository") return false;
+  const github = typeof source.metadata.github === "object" && source.metadata.github !== null && !Array.isArray(source.metadata.github)
+    ? source.metadata.github as Record<string, unknown>
+    : {};
+  return typeof github.credentialId === "string" && github.credentialId.length > 0;
+}
+
 function metricTone(value: number): string {
   if (value > 0) return "text-emerald-300";
   return "text-zinc-200";
@@ -1027,6 +1035,7 @@ export function ContextOptimizerPanel() {
                   <tr>
                     <th className="px-4 py-3 text-left font-medium">Source</th>
                     <th className="px-4 py-3 text-left font-medium">Type</th>
+                    <th className="px-4 py-3 text-left font-medium">Auth</th>
                     <th className="px-4 py-3 text-left font-medium">Sync</th>
                     <th className="px-4 py-3 text-right font-medium">Documents</th>
                     <th className="px-4 py-3 text-left font-medium">Last Synced</th>
@@ -1044,6 +1053,15 @@ export function ContextOptimizerPanel() {
                         {source.lastError && <div className="mt-1 text-xs text-red-300">{source.lastError}</div>}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-zinc-300">{formatContextSourceType(source.type)}</td>
+                      <td className="whitespace-nowrap px-4 py-3">
+                        <span className={`rounded border px-2 py-0.5 text-xs ${
+                          contextSourceHasAuth(source)
+                            ? "border-emerald-900/70 bg-emerald-950/20 text-emerald-200"
+                            : "border-zinc-800 bg-zinc-950/50 text-zinc-400"
+                        }`}>
+                          {contextSourceHasAuth(source) ? "Configured" : "None"}
+                        </span>
+                      </td>
                       <td className="whitespace-nowrap px-4 py-3">
                         <span className={`rounded border px-2 py-0.5 text-xs capitalize ${
                           source.syncStatus === "synced"

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -238,7 +238,7 @@ describe("ContextOptimizerPanel", () => {
               lastDocumentId: "doc-2",
               documentCount: 2,
               lastError: null,
-              metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs" } },
+              metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs", credentialId: "cred-1" } },
               updatedAt: "2026-05-01T22:04:00.000Z",
             },
           ],
@@ -371,6 +371,7 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
     expect(screen.getByText("Docs repository")).toBeInTheDocument();
     expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
+    expect(screen.getByText("Configured")).toBeInTheDocument();
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Canonical Review Queue")).toBeInTheDocument();

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -37,6 +37,7 @@ Implemented as of `0.2.0`:
 - Context governance alerts for policy-check failures, stale draft queues, and approved-export delta thresholds.
 - Connector ingestion foundation with tenant-scoped manual sources, idempotent sync, failed-sync status, and dashboard source visibility.
 - GitHub repository connector v1 with bounded tree/blob ingestion, SHA-based idempotency, and dashboard source details.
+- Connector credential auth foundation with encrypted GitHub token storage and source binding.
 
 Next planned layer:
 - Additional external connector implementations.
@@ -133,6 +134,8 @@ Foundation shipped:
 - Bounded GitHub file selection by path, extension, file size, and file count.
 - GitHub blob SHA idempotency for incremental sync.
 - GitHub repo/path/SHA provenance on stored documents and blocks.
+- Encrypted tenant-scoped connector credentials for GitHub tokens.
+- Source-level credential binding without exposing secret values in API or dashboard responses.
 
 Candidate connectors:
 - Confluence.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,7 +21,7 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
-- Connector ingestion with tenant-scoped manual and GitHub repository sources.
+- Connector ingestion with tenant-scoped manual and GitHub repository sources plus encrypted connector credentials.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
@@ -116,6 +116,8 @@ POST /v1/context/collections
 POST /v1/context/collections/{id}/documents
 GET /v1/context/collections/{id}/sources
 POST /v1/context/collections/{id}/sources
+GET /v1/context/credentials
+POST /v1/context/credentials
 POST /v1/context/sources/{id}/sync
 POST /v1/context/collections/{id}/distill
 GET /v1/context/collections/{id}/canonical-blocks
@@ -142,6 +144,7 @@ GitHub repository sources use `type: "github_repository"` with a `github` config
     "repo": "docs",
     "branch": "main",
     "path": "docs",
+    "credentialId": "credential-id",
     "extensions": [".md", ".txt"],
     "maxFiles": 100,
     "maxFileBytes": 250000
@@ -150,6 +153,8 @@ GitHub repository sources use `type: "github_repository"` with a `github` config
 ```
 
 GitHub sync fetches the repository tree and selected blobs through GitHub's JSON API, bounds files by extension/count/size, stores repo/path/SHA metadata on ingested documents and blocks, and skips files whose blob SHA has already synced.
+
+Connector credentials are tenant-scoped encrypted secrets. `POST /v1/context/credentials` accepts `type: "github_token"` and a token `value`, stores it with the same AES-GCM master-key encryption used for provider API keys, and returns only metadata plus `hasSecret: true`. `GET /v1/context/credentials` never returns raw token values. GitHub sources can set `github.credentialId`; sync decrypts that credential server-side, sends it as the GitHub bearer token, and records missing or undecryptable credentials as failed source syncs.
 
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
@@ -200,7 +205,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 

--- a/packages/db/drizzle/0059_context_connector_credentials.sql
+++ b/packages/db/drizzle/0059_context_connector_credentials.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `context_connector_credentials` (
+  `id` text PRIMARY KEY NOT NULL,
+  `tenant_id` text,
+  `name` text NOT NULL,
+  `type` text NOT NULL,
+  `encrypted_value` text NOT NULL,
+  `iv` text NOT NULL,
+  `auth_tag` text NOT NULL,
+  `last_used_at` integer,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `context_connector_credentials_tenant_idx` ON `context_connector_credentials` (`tenant_id`,`updated_at`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `context_connector_credentials_tenant_name_idx` ON `context_connector_credentials` (`tenant_id`,`name`);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1777679100000,
       "tag": "0058_context_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "6",
+      "when": 1777681200000,
+      "tag": "0059_context_connector_credentials",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -495,6 +495,26 @@ export const contextSources = sqliteTable("context_sources", {
   uniqueIndex("context_sources_collection_external_idx").on(table.collectionId, table.externalId),
 ]);
 
+export const contextConnectorCredentials = sqliteTable("context_connector_credentials", {
+  id: text("id").primaryKey(),
+  tenantId: text("tenant_id"),
+  name: text("name").notNull(),
+  type: text("type", { enum: ["github_token"] }).notNull(),
+  encryptedValue: text("encrypted_value").notNull(),
+  iv: text("iv").notNull(),
+  authTag: text("auth_tag").notNull(),
+  lastUsedAt: integer("last_used_at", { mode: "timestamp" }),
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer("updated_at", { mode: "timestamp" })
+    .notNull()
+    .$defaultFn(() => new Date()),
+}, (table) => [
+  index("context_connector_credentials_tenant_idx").on(table.tenantId, table.updatedAt),
+  uniqueIndex("context_connector_credentials_tenant_name_idx").on(table.tenantId, table.name),
+]);
+
 export const contextBlocks = sqliteTable("context_blocks", {
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -622,6 +622,56 @@ paths:
         "404":
           description: Collection not found.
 
+  /v1/context/credentials:
+    get:
+      tags: [Context Optimizer]
+      summary: List connector credentials
+      description: Lists tenant-scoped connector credentials without returning secret values.
+      operationId: listContextConnectorCredentials
+      responses:
+        "200":
+          description: Connector credentials
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [credentials]
+                properties:
+                  credentials:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ContextConnectorCredential"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+    post:
+      tags: [Context Optimizer]
+      summary: Create or update a connector credential
+      description: Stores the credential encrypted and never returns the raw value.
+      operationId: createContextConnectorCredential
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateContextConnectorCredentialRequest"
+      responses:
+        "201":
+          description: Created or updated connector credential
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [credential]
+                properties:
+                  credential:
+                    $ref: "#/components/schemas/ContextConnectorCredential"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "503":
+          description: Encryption master key is not configured.
+
   /v1/context/sources/{id}/sync:
     post:
       tags: [Context Optimizer]
@@ -3042,6 +3092,50 @@ components:
           type: object
           additionalProperties: true
 
+    CreateContextConnectorCredentialRequest:
+      type: object
+      required: [name, value]
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 120
+        type:
+          type: string
+          enum: [github_token]
+        value:
+          type: string
+          minLength: 1
+          maxLength: 20000
+          description: Secret token value. Only accepted on write and never returned.
+
+    ContextConnectorCredential:
+      type: object
+      required: [id, tenantId, name, type, hasSecret, lastUsedAt, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+        tenantId:
+          type: string
+          nullable: true
+        name:
+          type: string
+        type:
+          type: string
+          enum: [github_token]
+        hasSecret:
+          type: boolean
+        lastUsedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
     GitHubContextSourceConfig:
       type: object
       required: [owner, repo]
@@ -3062,6 +3156,9 @@ components:
           type: string
           description: Optional repository path prefix to ingest.
           maxLength: 1000
+        credentialId:
+          type: string
+          description: Optional tenant-scoped connector credential id. When set, sync uses that encrypted GitHub token.
         extensions:
           type: array
           description: File extensions to ingest. Defaults to markdown/text documentation extensions.

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -5,12 +5,14 @@ import {
   contextCanonicalBlocks,
   contextCanonicalReviewEvents,
   contextCollections,
+  contextConnectorCredentials,
   contextDocuments,
   contextSources,
 } from "@provara/db";
 import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { tenantFilter, tenantScoped } from "../auth/tenant.js";
+import { decrypt, encrypt, hasMasterKey } from "../crypto/index.js";
 import { estimateContextTokens } from "./optimizer.js";
 
 const MAX_COLLECTION_NAME_CHARS = 120;
@@ -29,6 +31,8 @@ const MAX_GITHUB_PATH_CHARS = 1_000;
 const MAX_GITHUB_EXTENSION_CHARS = 24;
 const MAX_GITHUB_FILE_BYTES = 250_000;
 const MAX_GITHUB_FILES = 100;
+const MAX_CREDENTIAL_NAME_CHARS = 120;
+const MAX_CREDENTIAL_VALUE_CHARS = 20_000;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
 const BLOCK_INSERT_BATCH_SIZE = 50;
@@ -43,6 +47,18 @@ export interface GitHubSourceConfig {
   extensions: string[];
   maxFileBytes: number;
   maxFiles: number;
+  credentialId?: string;
+}
+
+export interface ContextConnectorCredential {
+  id: string;
+  tenantId: string | null;
+  name: string;
+  type: "github_token";
+  hasSecret: boolean;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface ContextCollection {
@@ -167,6 +183,12 @@ export interface CreateContextSourceInput {
   github?: GitHubSourceConfig;
 }
 
+export interface CreateContextConnectorCredentialInput {
+  name: string;
+  type: "github_token";
+  value: string;
+}
+
 export interface ValidationResult<T> {
   value?: T;
   error?: string;
@@ -233,9 +255,23 @@ function parseGithubConfig(metadata: Record<string, unknown>): GitHubSourceConfi
   const maxFiles = typeof raw.maxFiles === "number" && Number.isFinite(raw.maxFiles)
     ? Math.min(Math.max(Math.trunc(raw.maxFiles), 1), MAX_GITHUB_FILES)
     : MAX_GITHUB_FILES;
+  const credentialId = typeof raw.credentialId === "string" && raw.credentialId.trim() ? raw.credentialId.trim() : undefined;
 
   if (!owner || !repo || !branch) throw new Error("github owner, repo, and branch are required");
-  return { owner, repo, branch, path, extensions, maxFileBytes, maxFiles };
+  return { owner, repo, branch, path, extensions, maxFileBytes, maxFiles, credentialId };
+}
+
+function credentialFromRow(row: typeof contextConnectorCredentials.$inferSelect): ContextConnectorCredential {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    name: row.name,
+    type: row.type,
+    hasSecret: true,
+    lastUsedAt: row.lastUsedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
 }
 
 function collectionFromRow(row: typeof contextCollections.$inferSelect): ContextCollection {
@@ -519,6 +555,8 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
     if (branch.error) return { error: branch.error };
     const path = trimOptional(raw.path, "github.path", MAX_GITHUB_PATH_CHARS);
     if (path.error) return { error: path.error };
+    const credentialId = trimOptional(raw.credentialId, "github.credentialId", MAX_SOURCE_URI_CHARS);
+    if (credentialId.error) return { error: credentialId.error };
 
     let extensions = [".md", ".mdx", ".txt", ".rst", ".adoc"];
     if (raw.extensions !== undefined) {
@@ -555,6 +593,7 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
       extensions,
       maxFileBytes: Math.trunc(maxFileBytes),
       maxFiles: Math.trunc(maxFiles),
+      credentialId: credentialId.value,
     };
   }
 
@@ -569,6 +608,23 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
       github,
     },
   };
+}
+
+export function validateCreateContextConnectorCredentialBody(value: unknown): ValidationResult<CreateContextConnectorCredentialInput> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { error: "body must be an object" };
+  }
+  const body = value as Record<string, unknown>;
+  const name = trimOptional(body.name, "name", MAX_CREDENTIAL_NAME_CHARS);
+  if (name.error) return { error: name.error };
+  if (!name.value) return { error: "name is required" };
+  const type = body.type === undefined ? "github_token" : body.type;
+  if (type !== "github_token") return { error: "type must be github_token" };
+  if (typeof body.value !== "string") return { error: "value is required" };
+  const credentialValue = body.value.trim();
+  if (!credentialValue) return { error: "value cannot be empty or whitespace-only" };
+  if (credentialValue.length > MAX_CREDENTIAL_VALUE_CHARS) return { error: `value must be at most ${MAX_CREDENTIAL_VALUE_CHARS} characters` };
+  return { value: { name: name.value, type, value: credentialValue } };
 }
 
 export function validateReviewStatusBody(value: unknown): ValidationResult<{ reviewStatus: ContextCanonicalBlock["reviewStatus"]; note?: string }> {
@@ -693,6 +749,56 @@ export async function listContextCollections(db: Db, tenantId: string | null): P
   return rows.map(collectionFromRow);
 }
 
+export async function createContextConnectorCredential(
+  db: Db,
+  tenantId: string | null,
+  input: CreateContextConnectorCredentialInput,
+): Promise<ContextConnectorCredential> {
+  if (!hasMasterKey()) throw new Error("PROVARA_MASTER_KEY not set");
+  const now = new Date();
+  const encrypted = encrypt(input.value);
+  const existingWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.name, input.name));
+  const existing = await db.select().from(contextConnectorCredentials).where(existingWhere).get();
+  if (existing) {
+    await db.update(contextConnectorCredentials).set({
+      type: input.type,
+      encryptedValue: encrypted.encrypted,
+      iv: encrypted.iv,
+      authTag: encrypted.authTag,
+      updatedAt: now,
+    }).where(eq(contextConnectorCredentials.id, existing.id)).run();
+    const row = await db.select().from(contextConnectorCredentials).where(eq(contextConnectorCredentials.id, existing.id)).get();
+    if (!row) throw new Error("Failed to update connector credential");
+    return credentialFromRow(row);
+  }
+
+  const id = nanoid();
+  await db.insert(contextConnectorCredentials).values({
+    id,
+    tenantId,
+    name: input.name,
+    type: input.type,
+    encryptedValue: encrypted.encrypted,
+    iv: encrypted.iv,
+    authTag: encrypted.authTag,
+    createdAt: now,
+    updatedAt: now,
+  }).run();
+  const row = await db.select().from(contextConnectorCredentials).where(eq(contextConnectorCredentials.id, id)).get();
+  if (!row) throw new Error("Failed to create connector credential");
+  return credentialFromRow(row);
+}
+
+export async function listContextConnectorCredentials(db: Db, tenantId: string | null): Promise<ContextConnectorCredential[]> {
+  const rows = await db
+    .select()
+    .from(contextConnectorCredentials)
+    .where(tenantFilter(contextConnectorCredentials.tenantId, tenantId))
+    .orderBy(desc(contextConnectorCredentials.updatedAt), asc(contextConnectorCredentials.id))
+    .all();
+  return rows.map(credentialFromRow);
+}
+
 export async function createContextSource(
   db: Db,
   tenantId: string | null,
@@ -703,6 +809,11 @@ export async function createContextSource(
   const collection = await db.select().from(contextCollections).where(collectionWhere).get();
   if (!collection) throw new Error("collection not found");
   if (collection.status !== "active") throw new Error("collection is archived");
+  if (input.github?.credentialId) {
+    const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, input.github.credentialId));
+    const credential = await db.select({ id: contextConnectorCredentials.id }).from(contextConnectorCredentials).where(credentialWhere).get();
+    if (!credential) throw new Error("connector credential not found");
+  }
 
   const now = new Date();
   const id = nanoid();
@@ -923,6 +1034,35 @@ function getSyncedGithubFiles(metadata: Record<string, unknown>): Record<string,
   return result;
 }
 
+async function resolveGithubToken(
+  db: Db,
+  tenantId: string | null,
+  credentialId: string | undefined,
+  fallbackToken: string | undefined,
+): Promise<string | undefined> {
+  if (!credentialId) return fallbackToken;
+  if (!hasMasterKey()) throw new Error("PROVARA_MASTER_KEY not set");
+  const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, credentialId));
+  const credential = await db.select().from(contextConnectorCredentials).where(credentialWhere).get();
+  if (!credential) throw new Error("connector credential not found");
+  if (credential.type !== "github_token") throw new Error("connector credential must be github_token");
+  try {
+    const token = decrypt({
+      encrypted: credential.encryptedValue,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }).replace(/[^\x20-\x7E\t]/g, "").trim();
+    if (!token) throw new Error("connector credential is empty");
+    await db.update(contextConnectorCredentials).set({
+      lastUsedAt: new Date(),
+    }).where(eq(contextConnectorCredentials.id, credential.id)).run();
+    return token;
+  } catch (err) {
+    if (err instanceof Error && err.message === "connector credential is empty") throw err;
+    throw new Error("connector credential could not be decrypted");
+  }
+}
+
 async function syncGithubContextSource(
   db: Db,
   tenantId: string | null,
@@ -934,8 +1074,9 @@ async function syncGithubContextSource(
   if (!fetchFn) throw new Error("fetch is unavailable");
   const metadata = parseMetadata(sourceRow.metadata);
   const config = parseGithubConfig(metadata);
+  const githubToken = await resolveGithubToken(db, tenantId, config.credentialId, options.githubToken);
   const syncedFiles = getSyncedGithubFiles(metadata);
-  const candidates = await fetchGithubCandidates(fetchFn, config, options.githubToken);
+  const candidates = await fetchGithubCandidates(fetchFn, config, githubToken);
   const changedCandidates = candidates.filter((candidate) => syncedFiles[candidate.path] !== candidate.sha);
   const now = new Date();
 
@@ -969,7 +1110,7 @@ async function syncGithubContextSource(
   const nextSyncedFiles = { ...syncedFiles };
 
   for (const candidate of changedCandidates) {
-    const file = await fetchGithubFile(fetchFn, config, candidate, options.githubToken);
+    const file = await fetchGithubFile(fetchFn, config, candidate, githubToken);
     const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
       title: file.path,
       text: file.content,

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -30,6 +30,7 @@ import {
 } from "../context/retrieval.js";
 import {
   createContextCollection,
+  createContextConnectorCredential,
   createContextSource,
   distillContextCollection,
   exportApprovedContextBlocks,
@@ -38,6 +39,7 @@ import {
   listContextCanonicalBlocks,
   listContextCanonicalReviewEvents,
   listContextCollections,
+  listContextConnectorCredentials,
   listContextSources,
   recordContextCanonicalPolicyCheck,
   syncContextSource,
@@ -45,6 +47,7 @@ import {
   validateBulkPolicyCheckBody,
   validateBulkReviewBody,
   validateCreateCollectionBody,
+  validateCreateContextConnectorCredentialBody,
   validateCreateContextSourceBody,
   validateIngestDocumentBody,
   validateReviewStatusBody,
@@ -703,6 +706,41 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       return c.json(
         { error: { message, type: notFound ? "not_found" : "store_error" } },
         notFound ? 404 : 500,
+      );
+    }
+  });
+
+  app.get("/credentials", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    try {
+      const credentials = await listContextConnectorCredentials(db, tenantId);
+      return c.json({ credentials });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to list connector credentials";
+      return c.json({ error: { message, type: "store_error" } }, 500);
+    }
+  });
+
+  app.post("/credentials", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const body = await c.req.json<unknown>().catch(() => null);
+    const parsed = validateCreateContextConnectorCredentialBody(body);
+    if (!parsed.value) {
+      return c.json(
+        { error: { message: parsed.error || "invalid credential body", type: "validation_error" } },
+        400,
+      );
+    }
+
+    try {
+      const credential = await createContextConnectorCredential(db, tenantId, parsed.value);
+      return c.json({ credential }, 201);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to create connector credential";
+      const configError = message.includes("PROVARA_MASTER_KEY");
+      return c.json(
+        { error: { message, type: configError ? "configuration_error" : "store_error" } },
+        configError ? 503 : 500,
       );
     }
   });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
+import { eq } from "drizzle-orm";
 import type { Db } from "@provara/db";
 import {
   alertLogs,
@@ -8,6 +9,7 @@ import {
   contextCanonicalBlocks,
   contextCanonicalReviewEvents,
   contextCollections,
+  contextConnectorCredentials,
   contextDocuments,
   contextOptimizationEvents,
   contextQualityEvents,
@@ -1568,15 +1570,19 @@ describe("POST /v1/context/optimize", () => {
 
 describe("managed context collections", () => {
   let db: Db;
+  let originalMasterKey: string | undefined;
 
   beforeEach(async () => {
     db = await makeTestDb();
     resetTierEnv();
     process.env.PROVARA_CLOUD = "true";
+    originalMasterKey = process.env.PROVARA_MASTER_KEY;
   });
 
   afterEach(() => {
     resetTierEnv();
+    if (originalMasterKey === undefined) delete process.env.PROVARA_MASTER_KEY;
+    else process.env.PROVARA_MASTER_KEY = originalMasterKey;
   });
 
   it("creates and lists tenant-scoped collections", async () => {
@@ -1826,6 +1832,49 @@ describe("managed context collections", () => {
     expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
   });
 
+  it("creates and lists encrypted connector credentials without exposing secret values", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+
+    const createRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "GitHub Docs", type: "github_token", value: "ghp_secret_token_123" }),
+    });
+    expect(createRes.status).toBe(201);
+    const createBody = await createRes.json() as { credential: { id: string; name: string; type: string; hasSecret: boolean; value?: string } };
+    expect(createBody.credential).toMatchObject({ name: "GitHub Docs", type: "github_token", hasSecret: true });
+    expect(createBody.credential.value).toBeUndefined();
+
+    const rows = await db.select().from(contextConnectorCredentials).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.encryptedValue).not.toContain("ghp_secret_token_123");
+
+    const listRes = await app.request("/v1/context/credentials", {
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json() as { credentials: Array<{ id: string; name: string; hasSecret: boolean; value?: string }> };
+    expect(listBody.credentials).toEqual([
+      expect.objectContaining({ id: createBody.credential.id, name: "GitHub Docs", hasSecret: true }),
+    ]);
+    expect(listBody.credentials[0]?.value).toBeUndefined();
+  });
+
+  it("rejects connector credentials when encryption is not configured", async () => {
+    delete process.env.PROVARA_MASTER_KEY;
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+
+    const createRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "GitHub Docs", type: "github_token", value: "ghp_secret_token_123" }),
+    });
+    expect(createRes.status).toBe(503);
+  });
+
   it("creates and idempotently syncs GitHub repository sources", async () => {
     await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
     const githubFetch = vi.fn(async (input: RequestInfo | URL) => {
@@ -1921,6 +1970,90 @@ describe("managed context collections", () => {
     expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 2 }, document: null, blocks: [] });
     expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
     expect(githubFetch.mock.calls.filter(([url]) => String(url).includes("/git/blobs/"))).toHaveLength(2);
+  });
+
+  it("syncs GitHub repository sources with a tenant-scoped connector credential", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const githubFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBe("Bearer ghp_secret_token_123");
+      const url = String(input);
+      if (url.includes("/git/trees/main")) {
+        return githubJson({ tree: [{ path: "docs/readme.md", type: "blob", sha: "sha-readme", size: 61 }] });
+      }
+      if (url.includes("/git/blobs/sha-readme")) {
+        return githubJson({
+          encoding: "base64",
+          size: 61,
+          content: Buffer.from("Credential-backed GitHub docs.").toString("base64"),
+        });
+      }
+      return githubJson({ message: "not found" }, 404);
+    });
+    const app = buildApp(db, undefined, { githubFetch });
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "GitHub Docs", type: "github_token", value: "ghp_secret_token_123" }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Credential GitHub KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Credential repository",
+        type: "github_repository",
+        github: { owner: "acme", repo: "docs", branch: "main", path: "docs", credentialId: credentialBody.credential.id },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as { source: { id: string; metadata: Record<string, unknown> } };
+    expect(sourceBody.source.metadata.github).toMatchObject({ credentialId: credentialBody.credential.id });
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const credentialRow = await db.select().from(contextConnectorCredentials).where(eq(contextConnectorCredentials.id, credentialBody.credential.id)).get();
+    expect(credentialRow?.lastUsedAt).toBeInstanceOf(Date);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(1);
+  });
+
+  it("does not allow a GitHub source to bind another tenant's credential", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({ name: "Other GitHub", type: "github_token", value: "ghp_other_token" }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Tenant Guard KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Blocked repository",
+        type: "github_repository",
+        github: { owner: "acme", repo: "docs", branch: "main", credentialId: credentialBody.credential.id },
+      }),
+    });
+    expect(sourceRes.status).toBe(404);
   });
 
   it("persists failed GitHub source sync status without writing documents", async () => {


### PR DESCRIPTION
## Summary
- Add encrypted tenant-scoped connector credentials for GitHub tokens.
- Add `GET/POST /v1/context/credentials` without returning secret values.
- Allow `github_repository` sources to bind `github.credentialId` and use it during sync.
- Persist failed sync status for missing/invalid credentials and show source auth status in the dashboard.
- Update OpenAPI, docs, changelog, and roadmap.

## Verification
- `npm test --workspace @provara/gateway -- tests/context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/db/tsconfig.json`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- OpenAPI YAML parse check
- `git diff --check`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `npm test --workspace @provara/gateway` (first run hit unrelated refusal-fallback transient; `tests/refusal-fallback.test.ts` passed on rerun; full gateway rerun passed 670/670)

Closes #381

Authored-by: codex/gpt-5 (codex)
Last-code-by: codex/gpt-5 (codex)
