### PR TITLE
feat(#383): add GitHub connector management UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable Provara changes are tracked here.
   - Connector ingestion foundation with tenant-scoped manual sources, idempotent source sync into managed documents and blocks, failed-sync status, and dashboard source visibility.
   - GitHub repository connector v1 with bounded tree/blob ingestion, path/extension/file-size filters, SHA-based idempotency, repo/path/SHA provenance, and dashboard source details.
   - Connector credential auth foundation with encrypted tenant-scoped GitHub tokens, credential-bound source sync, no secret echo in API responses, and dashboard auth status.
+  - Context dashboard connector management for creating GitHub credentials, creating GitHub repository sources, and manually syncing source rows without rendering secrets.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -48,7 +49,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, and connector credential auth foundation as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, and dashboard connector management as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -219,6 +219,17 @@ export interface ContextSource {
   updatedAt: string;
 }
 
+export interface ContextConnectorCredential {
+  id: string;
+  tenantId: string;
+  name: string;
+  type: "github_token";
+  hasSecret: boolean;
+  lastUsedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface BulkCanonicalResult {
   id: string;
   ok: boolean;
@@ -243,6 +254,7 @@ interface LoadState {
   retrievalEvents: ContextRetrievalEvent[];
   collections: ContextCollection[];
   sources: ContextSource[];
+  credentials: ContextConnectorCredential[];
   canonicalBlocks: ContextCanonicalBlock[];
   loading: boolean;
   error: string | null;
@@ -335,6 +347,10 @@ function contextSourceHasAuth(source: ContextSource): boolean {
     ? source.metadata.github as Record<string, unknown>
     : {};
   return typeof github.credentialId === "string" && github.credentialId.length > 0;
+}
+
+function parseCsv(value: string): string[] {
+  return value.split(",").map((part) => part.trim()).filter(Boolean);
 }
 
 function metricTone(value: number): string {
@@ -633,6 +649,24 @@ export function ContextOptimizerPanel() {
   const [selectedCanonicalIds, setSelectedCanonicalIds] = useState<string[]>([]);
   const [bulkAction, setBulkAction] = useState<"policy" | "approve" | "reject" | null>(null);
   const [bulkMessage, setBulkMessage] = useState<string | null>(null);
+  const [credentialDraft, setCredentialDraft] = useState({ name: "", value: "" });
+  const [credentialSubmitting, setCredentialSubmitting] = useState(false);
+  const [credentialMessage, setCredentialMessage] = useState<string | null>(null);
+  const [sourceDraft, setSourceDraft] = useState({
+    name: "",
+    owner: "",
+    repo: "",
+    branch: "main",
+    path: "",
+    extensions: ".md,.mdx,.txt,.rst,.adoc",
+    maxFiles: "100",
+    maxFileBytes: "250000",
+    credentialId: "",
+  });
+  const [sourceSubmitting, setSourceSubmitting] = useState(false);
+  const [sourceMessage, setSourceMessage] = useState<string | null>(null);
+  const [syncingSourceId, setSyncingSourceId] = useState<string | null>(null);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [state, setState] = useState<LoadState>({
     summary: null,
     events: [],
@@ -642,6 +676,7 @@ export function ContextOptimizerPanel() {
     retrievalEvents: [],
     collections: [],
     sources: [],
+    credentials: [],
     canonicalBlocks: [],
     loading: true,
     error: null,
@@ -663,6 +698,7 @@ export function ContextOptimizerPanel() {
           retrievalSummaryRes,
           retrievalEventsRes,
           collectionsRes,
+          credentialsRes,
         ] = await Promise.all([
           gatewayFetchRaw("/v1/context/summary"),
           gatewayFetchRaw("/v1/context/events?limit=25"),
@@ -671,6 +707,7 @@ export function ContextOptimizerPanel() {
           gatewayFetchRaw("/v1/context/retrieval/summary"),
           gatewayFetchRaw("/v1/context/retrieval/events?limit=10"),
           gatewayFetchRaw("/v1/context/collections"),
+          gatewayFetchRaw("/v1/context/credentials"),
         ]);
 
         const responses = [
@@ -681,6 +718,7 @@ export function ContextOptimizerPanel() {
           retrievalSummaryRes,
           retrievalEventsRes,
           collectionsRes,
+          credentialsRes,
         ];
         if (
           responses.some((res) => res.status === 402)
@@ -698,6 +736,7 @@ export function ContextOptimizerPanel() {
               retrievalEvents: [],
               collections: [],
               sources: [],
+              credentials: [],
               canonicalBlocks: [],
               loading: false,
               error: null,
@@ -721,6 +760,7 @@ export function ContextOptimizerPanel() {
         const retrievalSummaryBody = await retrievalSummaryRes.json() as { summary: ContextRetrievalSummary };
         const retrievalEventsBody = await retrievalEventsRes.json() as { events: ContextRetrievalEvent[] };
         const collectionsBody = await collectionsRes.json() as { collections: ContextCollection[] };
+        const credentialsBody = await credentialsRes.json() as { credentials?: ContextConnectorCredential[] };
         let canonicalBlocks: ContextCanonicalBlock[] = [];
         let sources: ContextSource[] = [];
         const firstCollection = collectionsBody.collections[0];
@@ -751,6 +791,7 @@ export function ContextOptimizerPanel() {
             retrievalEvents: retrievalEventsBody.events,
             collections: collectionsBody.collections,
             sources,
+            credentials: credentialsBody.credentials ?? [],
             canonicalBlocks,
             loading: false,
             error: null,
@@ -768,6 +809,7 @@ export function ContextOptimizerPanel() {
             retrievalEvents: [],
             collections: [],
             sources: [],
+            credentials: [],
             canonicalBlocks: [],
             loading: false,
             error: err instanceof Error ? err.message : "Failed to load Context Optimizer data",
@@ -791,7 +833,9 @@ export function ContextOptimizerPanel() {
   const retrievalRows = useMemo(() => state.retrievalEvents, [state.retrievalEvents]);
   const collectionRows = useMemo(() => state.collections, [state.collections]);
   const sourceRows = useMemo(() => state.sources, [state.sources]);
+  const credentialRows = useMemo(() => state.credentials, [state.credentials]);
   const canonicalRows = useMemo(() => state.canonicalBlocks, [state.canonicalBlocks]);
+  const firstCollection = collectionRows[0] ?? null;
   const visibleCanonicalRows = useMemo(() => canonicalRows.slice(0, 10), [canonicalRows]);
   const selectedCanonicalSet = useMemo(() => new Set(selectedCanonicalIds), [selectedCanonicalIds]);
   const selectedVisibleCount = visibleCanonicalRows.filter((block) => selectedCanonicalSet.has(block.id)).length;
@@ -822,6 +866,106 @@ export function ContextOptimizerPanel() {
       }
       return Array.from(next);
     });
+  }
+
+  async function createCredential() {
+    if (!credentialDraft.name.trim() || !credentialDraft.value.trim()) return;
+    setCredentialSubmitting(true);
+    setCredentialMessage(null);
+    try {
+      const res = await gatewayFetchRaw("/v1/context/credentials", {
+        method: "POST",
+        body: JSON.stringify({
+          name: credentialDraft.name.trim(),
+          type: "github_token",
+          value: credentialDraft.value,
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save credential");
+      const body = await res.json() as { credential: ContextConnectorCredential };
+      setState((prev) => ({
+        ...prev,
+        credentials: [
+          body.credential,
+          ...prev.credentials.filter((credential) => credential.id !== body.credential.id),
+        ],
+      }));
+      setCredentialDraft({ name: "", value: "" });
+      setSourceDraft((prev) => ({ ...prev, credentialId: body.credential.id }));
+      setCredentialMessage("Credential saved.");
+    } catch (err) {
+      setCredentialMessage(err instanceof Error ? err.message : "Failed to save credential");
+    } finally {
+      setCredentialSubmitting(false);
+    }
+  }
+
+  async function createGitHubSource() {
+    if (!firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()) return;
+    setSourceSubmitting(true);
+    setSourceMessage(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+        method: "POST",
+        body: JSON.stringify({
+          name: sourceDraft.name.trim(),
+          type: "github_repository",
+          github: {
+            owner: sourceDraft.owner.trim(),
+            repo: sourceDraft.repo.trim(),
+            branch: sourceDraft.branch.trim() || "main",
+            path: sourceDraft.path.trim() || undefined,
+            credentialId: sourceDraft.credentialId || undefined,
+            extensions: parseCsv(sourceDraft.extensions),
+            maxFiles: Number(sourceDraft.maxFiles) || 100,
+            maxFileBytes: Number(sourceDraft.maxFileBytes) || 250000,
+          },
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to create GitHub source");
+      const body = await res.json() as { source: ContextSource };
+      setState((prev) => ({
+        ...prev,
+        sources: [
+          body.source,
+          ...prev.sources.filter((source) => source.id !== body.source.id),
+        ],
+      }));
+      setSourceDraft((prev) => ({
+        ...prev,
+        name: "",
+        owner: "",
+        repo: "",
+        path: "",
+      }));
+      setSourceMessage("GitHub source created.");
+    } catch (err) {
+      setSourceMessage(err instanceof Error ? err.message : "Failed to create GitHub source");
+    } finally {
+      setSourceSubmitting(false);
+    }
+  }
+
+  async function syncSource(sourceId: string) {
+    setSyncingSourceId(sourceId);
+    setSyncMessage(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/sources/${sourceId}/sync`, { method: "POST" });
+      if (!res.ok) throw new Error("Failed to sync source");
+      const body = await res.json() as { source: ContextSource; collection?: ContextCollection; synced?: boolean };
+      setState((prev) => ({
+        ...prev,
+        sources: prev.sources.map((source) => source.id === body.source.id ? body.source : source),
+        collections: body.collection
+          ? prev.collections.map((collection) => collection.id === body.collection?.id ? body.collection as ContextCollection : collection)
+          : prev.collections,
+      }));
+      setSyncMessage(body.synced === false ? "Sync complete: no changes." : "Sync complete.");
+    } catch (err) {
+      setSyncMessage(err instanceof Error ? err.message : "Failed to sync source");
+    } finally {
+      setSyncingSourceId(null);
+    }
   }
 
   async function runBulkPolicyCheck() {
@@ -1017,8 +1161,204 @@ export function ContextOptimizerPanel() {
 
       <section>
         <div className="mb-3">
+          <h2 className="text-lg font-semibold text-zinc-100">Connector Management</h2>
+          <p className="mt-1 text-sm text-zinc-500">Credential metadata, GitHub repository sources, and manual source sync controls.</p>
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">GitHub Token Credentials</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-credential-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">
+                  Credential Name
+                </label>
+                <input
+                  id="context-credential-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={credentialDraft.name}
+                  onChange={(event) => setCredentialDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-credential-value" className="text-xs font-medium uppercase tracking-wider text-zinc-500">
+                  Token
+                </label>
+                <input
+                  id="context-credential-value"
+                  type="password"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={credentialDraft.value}
+                  onChange={(event) => setCredentialDraft((prev) => ({ ...prev, value: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={credentialSubmitting || !credentialDraft.name.trim() || !credentialDraft.value.trim()}
+                onClick={() => void createCredential()}
+              >
+                {credentialSubmitting ? "Saving..." : "Save Credential"}
+              </button>
+              {credentialMessage && <span className="text-xs text-zinc-400">{credentialMessage}</span>}
+            </div>
+
+            <div className="mt-4 overflow-hidden rounded-md border border-zinc-800">
+              {credentialRows.length === 0 ? (
+                <div className="p-4 text-sm text-zinc-500">No connector credentials yet.</div>
+              ) : (
+                <table className="min-w-full divide-y divide-zinc-800 text-sm">
+                  <thead className="bg-zinc-950/60 text-xs uppercase tracking-wider text-zinc-500">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-medium">Name</th>
+                      <th className="px-3 py-2 text-left font-medium">Secret</th>
+                      <th className="px-3 py-2 text-left font-medium">Last Used</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-zinc-800">
+                    {credentialRows.map((credential) => (
+                      <tr key={credential.id}>
+                        <td className="px-3 py-2">
+                          <div className="font-medium text-zinc-200">{credential.name}</div>
+                          <div className="mt-0.5 text-xs text-zinc-500">{credential.type}</div>
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2">
+                          <span className={`rounded border px-2 py-0.5 text-xs ${
+                            credential.hasSecret
+                              ? "border-emerald-900/70 bg-emerald-950/20 text-emerald-200"
+                              : "border-zinc-800 bg-zinc-950/50 text-zinc-400"
+                          }`}>
+                            {credential.hasSecret ? "Stored" : "Missing"}
+                          </span>
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 text-zinc-400">{formatTimestamp(credential.lastUsedAt)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">GitHub Source</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Source Name</label>
+                <input
+                  id="context-source-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.name}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-source-credential" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Credential</label>
+                <select
+                  id="context-source-credential"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.credentialId}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, credentialId: event.target.value }))}
+                >
+                  <option value="">No credential</option>
+                  {credentialRows.map((credential) => (
+                    <option key={credential.id} value={credential.id}>{credential.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="context-source-owner" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Owner</label>
+                <input
+                  id="context-source-owner"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.owner}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, owner: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-source-repo" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Repository</label>
+                <input
+                  id="context-source-repo"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.repo}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, repo: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-source-branch" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Branch</label>
+                <input
+                  id="context-source-branch"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.branch}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, branch: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-source-path" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Path</label>
+                <input
+                  id="context-source-path"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.path}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, path: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-source-extensions" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Extensions</label>
+                <input
+                  id="context-source-extensions"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={sourceDraft.extensions}
+                  onChange={(event) => setSourceDraft((prev) => ({ ...prev, extensions: event.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="context-source-max-files" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Max Files</label>
+                  <input
+                    id="context-source-max-files"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={sourceDraft.maxFiles}
+                    onChange={(event) => setSourceDraft((prev) => ({ ...prev, maxFiles: event.target.value }))}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="context-source-max-bytes" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Max Bytes</label>
+                  <input
+                    id="context-source-max-bytes"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={sourceDraft.maxFileBytes}
+                    onChange={(event) => setSourceDraft((prev) => ({ ...prev, maxFileBytes: event.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={sourceSubmitting || !firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()}
+                onClick={() => void createGitHubSource()}
+              >
+                {sourceSubmitting ? "Creating..." : "Create Source"}
+              </button>
+              {sourceMessage && <span className="text-xs text-zinc-400">{sourceMessage}</span>}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="mb-3">
           <h2 className="text-lg font-semibold text-zinc-100">Collection Sources</h2>
           <p className="mt-1 text-sm text-zinc-500">Manual connector sources and sync status for the first managed collection.</p>
+          {syncMessage && <p className="mt-1 text-xs text-zinc-400">{syncMessage}</p>}
         </div>
 
         {state.loading ? (
@@ -1040,6 +1380,7 @@ export function ContextOptimizerPanel() {
                     <th className="px-4 py-3 text-right font-medium">Documents</th>
                     <th className="px-4 py-3 text-left font-medium">Last Synced</th>
                     <th className="px-4 py-3 text-left font-medium">Updated</th>
+                    <th className="px-4 py-3 text-right font-medium">Action</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-zinc-800">
@@ -1081,6 +1422,16 @@ export function ContextOptimizerPanel() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
                         {formatTimestamp(source.updatedAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          className="rounded-md border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs font-medium text-zinc-200 hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={syncingSourceId !== null}
+                          onClick={() => void syncSource(source.id)}
+                        >
+                          {syncingSourceId === source.id ? "Syncing..." : "Sync"}
+                        </button>
                       </td>
                     </tr>
                   ))}

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -179,6 +179,22 @@ describe("ContextOptimizerPanel", () => {
           ],
         }));
       }
+      if (path === "/v1/context/credentials") {
+        return Promise.resolve(jsonResponse({
+          credentials: [
+            {
+              id: "cred-1",
+              tenantId: "tenant-pro",
+              name: "GitHub Docs",
+              type: "github_token",
+              hasSecret: true,
+              lastUsedAt: "2026-05-01T22:04:00.000Z",
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T22:04:00.000Z",
+            },
+          ],
+        }));
+      }
       if (path === "/v1/context/collections/collection-1/canonical-blocks?reviewStatus=draft") {
         return Promise.resolve(jsonResponse({
           canonicalBlocks: [
@@ -366,6 +382,11 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("Managed Collections")).toBeInTheDocument();
     expect(screen.getByText("Support KB")).toBeInTheDocument();
     expect(screen.getByText("Approved support context")).toBeInTheDocument();
+    expect(screen.getByText("Connector Management")).toBeInTheDocument();
+    expect(screen.getByText("GitHub Token Credentials")).toBeInTheDocument();
+    expect(screen.getByText("GitHub Source")).toBeInTheDocument();
+    expect(screen.getAllByText("GitHub Docs").length).toBeGreaterThan(0);
+    expect(screen.getByText("Stored")).toBeInTheDocument();
     expect(screen.getByText("Collection Sources")).toBeInTheDocument();
     expect(screen.getByText("Refund source")).toBeInTheDocument();
     expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
@@ -385,6 +406,224 @@ describe("ContextOptimizerPanel", () => {
     fireEvent.click(screen.getByText("Approve"));
     expect(await screen.findByText("Bulk approved: 1 updated, 0 failed.")).toBeInTheDocument();
     expect(screen.getByText("No draft canonical blocks in the first managed collection.")).toBeInTheDocument();
+  });
+
+  it("creates GitHub credentials, creates sources, and syncs source rows without rendering secrets", async () => {
+    mockedFetch.mockImplementation((path, init) => {
+      if (path === "/v1/context/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            inputChunks: 0,
+            outputChunks: 0,
+            droppedChunks: 0,
+            nearDuplicateChunks: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            savedTokens: 0,
+            reductionPct: 0,
+            avgRelevanceScore: null,
+            lowRelevanceChunks: 0,
+            rerankedChunks: 0,
+            avgFreshnessScore: null,
+            staleChunks: 0,
+            conflictChunks: 0,
+            conflictGroups: 0,
+            compressedChunks: 0,
+            compressionSavedTokens: 0,
+            compressionRatePct: 0,
+            flaggedChunks: 0,
+            quarantinedChunks: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/quality/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            regressedCount: 0,
+            avgRawScore: null,
+            avgOptimizedScore: null,
+            avgDelta: null,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/retrieval/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            retrievedChunks: 0,
+            usedChunks: 0,
+            unusedChunks: 0,
+            duplicateChunks: 0,
+            nearDuplicateChunks: 0,
+            riskyChunks: 0,
+            retrievedTokens: 0,
+            usedTokens: 0,
+            unusedTokens: 0,
+            avgRelevanceScore: null,
+            lowRelevanceChunks: 0,
+            rerankedChunks: 0,
+            avgFreshnessScore: null,
+            staleChunks: 0,
+            conflictChunks: 0,
+            conflictGroups: 0,
+            compressedChunks: 0,
+            compressionSavedTokens: 0,
+            compressionRatePct: 0,
+            efficiencyPct: 0,
+            duplicateRatePct: 0,
+            nearDuplicateRatePct: 0,
+            riskyRatePct: 0,
+            conflictRatePct: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/collections") {
+        return Promise.resolve(jsonResponse({
+          collections: [
+            {
+              id: "collection-1",
+              tenantId: "tenant-pro",
+              name: "Support KB",
+              description: "Approved support context",
+              status: "active",
+              documentCount: 0,
+              blockCount: 0,
+              canonicalBlockCount: 0,
+              approvedBlockCount: 0,
+              tokenCount: 0,
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T20:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (path === "/v1/context/credentials" && init?.method === "POST") {
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          name: "Docs token",
+          type: "github_token",
+          value: "ghp_secret_token_123",
+        });
+        return Promise.resolve(jsonResponse({
+          credential: {
+            id: "cred-new",
+            tenantId: "tenant-pro",
+            name: "Docs token",
+            type: "github_token",
+            hasSecret: true,
+            lastUsedAt: null,
+            createdAt: "2026-05-01T22:10:00.000Z",
+            updatedAt: "2026-05-01T22:10:00.000Z",
+          },
+        }));
+      }
+      if (path === "/v1/context/credentials") {
+        return Promise.resolve(jsonResponse({ credentials: [] }));
+      }
+      if (path === "/v1/context/collections/collection-1/sources" && init?.method === "POST") {
+        expect(JSON.parse(String(init.body))).toMatchObject({
+          name: "Docs repo",
+          type: "github_repository",
+          github: {
+            owner: "acme",
+            repo: "docs",
+            branch: "main",
+            path: "docs",
+            credentialId: "cred-new",
+            extensions: [".md", ".mdx"],
+            maxFiles: 50,
+            maxFileBytes: 125000,
+          },
+        });
+        return Promise.resolve(jsonResponse({
+          source: {
+            id: "source-new",
+            collectionId: "collection-1",
+            name: "Docs repo",
+            type: "github_repository",
+            externalId: "github:acme/docs:main:docs",
+            sourceUri: "https://github.com/acme/docs/tree/main",
+            syncStatus: "pending",
+            lastSyncedAt: null,
+            lastDocumentId: null,
+            documentCount: 0,
+            lastError: null,
+            metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs", credentialId: "cred-new" } },
+            updatedAt: "2026-05-01T22:11:00.000Z",
+          },
+        }));
+      }
+      if (path === "/v1/context/collections/collection-1/sources") {
+        return Promise.resolve(jsonResponse({ sources: [] }));
+      }
+      if (path === "/v1/context/sources/source-new/sync") {
+        return Promise.resolve(jsonResponse({
+          synced: true,
+          collection: {
+            id: "collection-1",
+            tenantId: "tenant-pro",
+            name: "Support KB",
+            description: "Approved support context",
+            status: "active",
+            documentCount: 1,
+            blockCount: 3,
+            canonicalBlockCount: 1,
+            approvedBlockCount: 0,
+            tokenCount: 250,
+            createdAt: "2026-05-01T20:00:00.000Z",
+            updatedAt: "2026-05-01T22:12:00.000Z",
+          },
+          source: {
+            id: "source-new",
+            collectionId: "collection-1",
+            name: "Docs repo",
+            type: "github_repository",
+            externalId: "github:acme/docs:main:docs",
+            sourceUri: "https://github.com/acme/docs/tree/main",
+            syncStatus: "synced",
+            lastSyncedAt: "2026-05-01T22:12:00.000Z",
+            lastDocumentId: "doc-new",
+            documentCount: 1,
+            lastError: null,
+            metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs", credentialId: "cred-new" } },
+            updatedAt: "2026-05-01T22:12:00.000Z",
+          },
+        }));
+      }
+      return Promise.resolve(jsonResponse({ events: [] }));
+    });
+
+    render(<ContextOptimizerPanel />);
+
+    expect(await screen.findByText("Connector Management")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Credential Name"), { target: { value: "Docs token" } });
+    fireEvent.change(screen.getByLabelText("Token"), { target: { value: "ghp_secret_token_123" } });
+    fireEvent.click(screen.getByText("Save Credential"));
+
+    expect(await screen.findByText("Credential saved.")).toBeInTheDocument();
+    expect(screen.getAllByText("Docs token").length).toBeGreaterThan(0);
+    expect(document.body.textContent).not.toContain("ghp_secret_token_123");
+
+    fireEvent.change(screen.getByLabelText("Source Name"), { target: { value: "Docs repo" } });
+    fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "acme" } });
+    fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "docs" } });
+    fireEvent.change(screen.getByLabelText("Path"), { target: { value: "docs" } });
+    fireEvent.change(screen.getByLabelText("Extensions"), { target: { value: ".md,.mdx" } });
+    fireEvent.change(screen.getByLabelText("Max Files"), { target: { value: "50" } });
+    fireEvent.change(screen.getByLabelText("Max Bytes"), { target: { value: "125000" } });
+    fireEvent.click(screen.getByText("Create Source"));
+
+    expect(await screen.findByText("GitHub source created.")).toBeInTheDocument();
+    expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sync" }));
+    expect(await screen.findByText("Sync complete.")).toBeInTheDocument();
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getByText("synced")).toBeInTheDocument();
   });
 
   it("updates and persists optimizer payload controls", async () => {

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -38,6 +38,7 @@ Implemented as of `0.2.0`:
 - Connector ingestion foundation with tenant-scoped manual sources, idempotent sync, failed-sync status, and dashboard source visibility.
 - GitHub repository connector v1 with bounded tree/blob ingestion, SHA-based idempotency, and dashboard source details.
 - Connector credential auth foundation with encrypted GitHub token storage and source binding.
+- Dashboard connector management for GitHub credential creation, GitHub source creation, and manual source sync.
 
 Next planned layer:
 - Additional external connector implementations.
@@ -136,6 +137,7 @@ Foundation shipped:
 - GitHub repo/path/SHA provenance on stored documents and blocks.
 - Encrypted tenant-scoped connector credentials for GitHub tokens.
 - Source-level credential binding without exposing secret values in API or dashboard responses.
+- Dashboard controls for creating GitHub credentials and repository sources, plus manual sync from source rows.
 
 Candidate connectors:
 - Confluence.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -27,6 +27,7 @@ The shipped V1 implementation is intentionally narrow:
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
+- Dashboard connector management for GitHub credentials, GitHub repository source creation, and manual source sync.
 
 It does not yet perform connector pulls from systems such as Confluence, Drive, or S3. Those belong to later roadmap phases.
 
@@ -205,7 +206,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Creation, source sync, ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, list credential metadata without secret values, create GitHub repository sources for the first managed collection, and bind a source to a stored credential. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 


### PR DESCRIPTION
## Summary

- Add `/dashboard/context` connector management for GitHub token credentials and GitHub repository source creation.
- Add per-source manual sync from the Collection Sources table with refreshed source and collection state.
- Document the dashboard connector management checkpoint in release notes and roadmap docs.

## Verification

- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #383

Authored-by: Codex/GPT-5 (codex)
Last-code-by: Codex/GPT-5 (codex)
