### PR TITLE
feat(#385): add file upload context connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable Provara changes are tracked here.
   - GitHub repository connector v1 with bounded tree/blob ingestion, path/extension/file-size filters, SHA-based idempotency, repo/path/SHA provenance, and dashboard source details.
   - Connector credential auth foundation with encrypted tenant-scoped GitHub tokens, credential-bound source sync, no secret echo in API responses, and dashboard auth status.
   - Context dashboard connector management for creating GitHub credentials, creating GitHub repository sources, and manually syncing source rows without rendering secrets.
+  - File upload connector v1 with bounded text upload validation, sanitized filename metadata, idempotent source sync, OpenAPI coverage, and dashboard creation controls.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -49,7 +50,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, and dashboard connector management as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, dashboard connector management, and file upload connector v1 as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -207,7 +207,7 @@ export interface ContextSource {
   id: string;
   collectionId: string;
   name: string;
-  type: "manual" | "github_repository";
+  type: "manual" | "github_repository" | "file_upload";
   externalId: string | null;
   sourceUri: string | null;
   syncStatus: "pending" | "synced" | "failed";
@@ -282,6 +282,7 @@ interface OptimizerDraftSettings {
 }
 
 const OPTIMIZER_SETTINGS_STORAGE_KEY = "provara:context-optimizer:settings";
+const MAX_FILE_UPLOAD_BYTES = 500_000;
 
 const DEFAULT_OPTIMIZER_SETTINGS: OptimizerDraftSettings = {
   dedupeMode: "semantic",
@@ -324,6 +325,7 @@ function formatTimestamp(value: string | null): string {
 
 function formatContextSourceType(type: ContextSource["type"]): string {
   if (type === "github_repository") return "GitHub";
+  if (type === "file_upload") return "File Upload";
   return "Manual";
 }
 
@@ -337,6 +339,15 @@ function formatContextSourceDetail(source: ContextSource): string {
     const branch = typeof github.branch === "string" ? github.branch : "main";
     const path = typeof github.path === "string" && github.path ? `/${github.path}` : "";
     if (owner && repo) return `${owner}/${repo}@${branch}${path}`;
+  }
+  if (source.type === "file_upload") {
+    const file = typeof source.metadata.file === "object" && source.metadata.file !== null && !Array.isArray(source.metadata.file)
+      ? source.metadata.file as Record<string, unknown>
+      : {};
+    const filename = typeof file.filename === "string" ? file.filename : "";
+    const contentType = typeof file.contentType === "string" ? file.contentType : "";
+    const sizeBytes = typeof file.sizeBytes === "number" ? file.sizeBytes : null;
+    if (filename) return `${filename}${contentType ? ` (${contentType}` : ""}${contentType && sizeBytes !== null ? `, ${formatInteger(sizeBytes)} bytes)` : contentType ? ")" : ""}`;
   }
   return source.sourceUri || source.externalId || source.id;
 }
@@ -665,6 +676,14 @@ export function ContextOptimizerPanel() {
   });
   const [sourceSubmitting, setSourceSubmitting] = useState(false);
   const [sourceMessage, setSourceMessage] = useState<string | null>(null);
+  const [fileDraft, setFileDraft] = useState({
+    name: "",
+    filename: "",
+    contentType: "text/plain",
+    content: "",
+  });
+  const [fileSubmitting, setFileSubmitting] = useState(false);
+  const [fileMessage, setFileMessage] = useState<string | null>(null);
   const [syncingSourceId, setSyncingSourceId] = useState<string | null>(null);
   const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const [state, setState] = useState<LoadState>({
@@ -946,6 +965,59 @@ export function ContextOptimizerPanel() {
     }
   }
 
+  async function loadUploadFile(file: File | undefined) {
+    setFileMessage(null);
+    if (!file) return;
+    if (file.size > MAX_FILE_UPLOAD_BYTES) {
+      setFileDraft({ name: "", filename: "", contentType: "text/plain", content: "" });
+      setFileMessage(`File must be at most ${formatInteger(MAX_FILE_UPLOAD_BYTES)} bytes.`);
+      return;
+    }
+    const content = await file.text();
+    setFileDraft({
+      name: file.name.replace(/\.[^.]+$/, "") || file.name,
+      filename: file.name,
+      contentType: file.type || "text/plain",
+      content,
+    });
+    setFileMessage("File loaded.");
+  }
+
+  async function createFileUploadSource() {
+    if (!firstCollection || !fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()) return;
+    setFileSubmitting(true);
+    setFileMessage(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+        method: "POST",
+        body: JSON.stringify({
+          name: fileDraft.name.trim(),
+          type: "file_upload",
+          content: fileDraft.content,
+          file: {
+            filename: fileDraft.filename,
+            contentType: fileDraft.contentType || "text/plain",
+          },
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to create file upload source");
+      const body = await res.json() as { source: ContextSource };
+      setState((prev) => ({
+        ...prev,
+        sources: [
+          body.source,
+          ...prev.sources.filter((source) => source.id !== body.source.id),
+        ],
+      }));
+      setFileDraft({ name: "", filename: "", contentType: "text/plain", content: "" });
+      setFileMessage("File source created.");
+    } catch (err) {
+      setFileMessage(err instanceof Error ? err.message : "Failed to create file upload source");
+    } finally {
+      setFileSubmitting(false);
+    }
+  }
+
   async function syncSource(sourceId: string) {
     setSyncingSourceId(sourceId);
     setSyncMessage(null);
@@ -1162,7 +1234,7 @@ export function ContextOptimizerPanel() {
       <section>
         <div className="mb-3">
           <h2 className="text-lg font-semibold text-zinc-100">Connector Management</h2>
-          <p className="mt-1 text-sm text-zinc-500">Credential metadata, GitHub repository sources, and manual source sync controls.</p>
+          <p className="mt-1 text-sm text-zinc-500">Credential metadata, GitHub repository sources, file upload sources, and manual source sync controls.</p>
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">
@@ -1244,10 +1316,53 @@ export function ContextOptimizerPanel() {
           </div>
 
           <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">File Upload Source</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-file-upload" className="text-xs font-medium uppercase tracking-wider text-zinc-500">File</label>
+                <input
+                  id="context-file-upload"
+                  type="file"
+                  accept=".txt,.md,.mdx,.rst,.adoc,.csv,.json,text/plain,text/markdown,application/json,text/csv"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 file:mr-3 file:rounded file:border-0 file:bg-zinc-800 file:px-2 file:py-1 file:text-xs file:text-zinc-100"
+                  onChange={(event) => void loadUploadFile(event.target.files?.[0])}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-file-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">File Source Name</label>
+                <input
+                  id="context-file-source-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={fileDraft.name}
+                  onChange={(event) => setFileDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+            </div>
+            {fileDraft.filename && (
+              <div className="mt-3 rounded-md border border-zinc-800 bg-zinc-950/60 px-3 py-2 text-xs text-zinc-400">
+                <span className="text-zinc-300">{fileDraft.filename}</span>
+                <span className="ml-2">{fileDraft.contentType}</span>
+                <span className="ml-2">{formatInteger(new Blob([fileDraft.content]).size)} bytes</span>
+              </div>
+            )}
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={fileSubmitting || !firstCollection || !fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()}
+                onClick={() => void createFileUploadSource()}
+              >
+                {fileSubmitting ? "Creating..." : "Create File Source"}
+              </button>
+              {fileMessage && <span className="text-xs text-zinc-400">{fileMessage}</span>}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
             <h3 className="text-sm font-semibold text-zinc-100">GitHub Source</h3>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               <div>
-                <label htmlFor="context-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Source Name</label>
+                <label htmlFor="context-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">GitHub Source Name</label>
                 <input
                   id="context-source-name"
                   className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -257,6 +257,21 @@ describe("ContextOptimizerPanel", () => {
               metadata: { github: { owner: "acme", repo: "docs", branch: "main", path: "docs", credentialId: "cred-1" } },
               updatedAt: "2026-05-01T22:04:00.000Z",
             },
+            {
+              id: "source-3",
+              collectionId: "collection-1",
+              name: "Uploaded handbook",
+              type: "file_upload",
+              externalId: "upload:handbook",
+              sourceUri: "upload://handbook.md",
+              syncStatus: "pending",
+              lastSyncedAt: null,
+              lastDocumentId: null,
+              documentCount: 0,
+              lastError: null,
+              metadata: { file: { filename: "handbook.md", contentType: "text/markdown", sizeBytes: 128 } },
+              updatedAt: "2026-05-01T22:05:00.000Z",
+            },
           ],
         }));
       }
@@ -392,6 +407,8 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
     expect(screen.getByText("Docs repository")).toBeInTheDocument();
     expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
+    expect(screen.getByText("Uploaded handbook")).toBeInTheDocument();
+    expect(screen.getByText("handbook.md (text/markdown, 128 bytes)")).toBeInTheDocument();
     expect(screen.getByText("Configured")).toBeInTheDocument();
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
@@ -525,7 +542,36 @@ describe("ContextOptimizerPanel", () => {
         return Promise.resolve(jsonResponse({ credentials: [] }));
       }
       if (path === "/v1/context/collections/collection-1/sources" && init?.method === "POST") {
-        expect(JSON.parse(String(init.body))).toMatchObject({
+        const parsed = JSON.parse(String(init.body)) as Record<string, unknown>;
+        if (parsed.type === "file_upload") {
+          expect(parsed).toMatchObject({
+            name: "Uploaded guide",
+            type: "file_upload",
+            content: "Uploaded guide content for context.",
+            file: {
+              filename: "guide.md",
+              contentType: "text/markdown",
+            },
+          });
+          return Promise.resolve(jsonResponse({
+            source: {
+              id: "source-file",
+              collectionId: "collection-1",
+              name: "Uploaded guide",
+              type: "file_upload",
+              externalId: "upload:guide",
+              sourceUri: "upload://guide.md",
+              syncStatus: "pending",
+              lastSyncedAt: null,
+              lastDocumentId: null,
+              documentCount: 0,
+              lastError: null,
+              metadata: { file: { filename: "guide.md", contentType: "text/markdown", sizeBytes: 35 } },
+              updatedAt: "2026-05-01T22:10:00.000Z",
+            },
+          }));
+        }
+        expect(parsed).toMatchObject({
           name: "Docs repo",
           type: "github_repository",
           github: {
@@ -594,6 +640,40 @@ describe("ContextOptimizerPanel", () => {
           },
         }));
       }
+      if (path === "/v1/context/sources/source-file/sync") {
+        return Promise.resolve(jsonResponse({
+          synced: true,
+          collection: {
+            id: "collection-1",
+            tenantId: "tenant-pro",
+            name: "Support KB",
+            description: "Approved support context",
+            status: "active",
+            documentCount: 2,
+            blockCount: 4,
+            canonicalBlockCount: 1,
+            approvedBlockCount: 0,
+            tokenCount: 300,
+            createdAt: "2026-05-01T20:00:00.000Z",
+            updatedAt: "2026-05-01T22:13:00.000Z",
+          },
+          source: {
+            id: "source-file",
+            collectionId: "collection-1",
+            name: "Uploaded guide",
+            type: "file_upload",
+            externalId: "upload:guide",
+            sourceUri: "upload://guide.md",
+            syncStatus: "synced",
+            lastSyncedAt: "2026-05-01T22:13:00.000Z",
+            lastDocumentId: "doc-file",
+            documentCount: 1,
+            lastError: null,
+            metadata: { file: { filename: "guide.md", contentType: "text/markdown", sizeBytes: 35 } },
+            updatedAt: "2026-05-01T22:13:00.000Z",
+          },
+        }));
+      }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
 
@@ -608,7 +688,19 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getAllByText("Docs token").length).toBeGreaterThan(0);
     expect(document.body.textContent).not.toContain("ghp_secret_token_123");
 
-    fireEvent.change(screen.getByLabelText("Source Name"), { target: { value: "Docs repo" } });
+    const upload = new File(["Uploaded guide content for context."], "guide.md", { type: "text/markdown" });
+    fireEvent.change(screen.getByLabelText("File"), { target: { files: [upload] } });
+    expect(await screen.findByText("File loaded.")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("guide")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("Uploaded guide content for context.");
+    fireEvent.change(screen.getByLabelText("File Source Name"), { target: { value: "Uploaded guide" } });
+    fireEvent.click(screen.getByText("Create File Source"));
+
+    expect(await screen.findByText("File source created.")).toBeInTheDocument();
+    expect(screen.getByText("guide.md (text/markdown, 35 bytes)")).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("Uploaded guide content for context.");
+
+    fireEvent.change(screen.getByLabelText("GitHub Source Name"), { target: { value: "Docs repo" } });
     fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "acme" } });
     fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "docs" } });
     fireEvent.change(screen.getByLabelText("Path"), { target: { value: "docs" } });
@@ -620,7 +712,7 @@ describe("ContextOptimizerPanel", () => {
     expect(await screen.findByText("GitHub source created.")).toBeInTheDocument();
     expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Sync" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Sync" })[0] as HTMLElement);
     expect(await screen.findByText("Sync complete.")).toBeInTheDocument();
     expect(screen.getAllByText("1").length).toBeGreaterThan(0);
     expect(screen.getByText("synced")).toBeInTheDocument();

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -39,6 +39,7 @@ Implemented as of `0.2.0`:
 - GitHub repository connector v1 with bounded tree/blob ingestion, SHA-based idempotency, and dashboard source details.
 - Connector credential auth foundation with encrypted GitHub token storage and source binding.
 - Dashboard connector management for GitHub credential creation, GitHub source creation, and manual source sync.
+- File upload connector v1 with bounded text upload validation, sanitized file metadata, idempotent source sync, and dashboard creation controls.
 
 Next planned layer:
 - Additional external connector implementations.
@@ -138,6 +139,7 @@ Foundation shipped:
 - Encrypted tenant-scoped connector credentials for GitHub tokens.
 - Source-level credential binding without exposing secret values in API or dashboard responses.
 - Dashboard controls for creating GitHub credentials and repository sources, plus manual sync from source rows.
+- Bounded file upload source creation for local text/markdown knowledge without external OAuth.
 
 Candidate connectors:
 - Confluence.
@@ -145,7 +147,7 @@ Candidate connectors:
 - SharePoint.
 - Notion.
 - Zendesk or Intercom help centers.
-- S3 and local file upload.
+- S3.
 
 ## V3: Retrieval Quality Layer
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,13 +21,13 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
-- Connector ingestion with tenant-scoped manual and GitHub repository sources plus encrypted connector credentials.
+- Connector ingestion with tenant-scoped manual, file upload, and GitHub repository sources plus encrypted connector credentials.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
-- Dashboard connector management for GitHub credentials, GitHub repository source creation, and manual source sync.
+- Dashboard connector management for GitHub credentials, file upload source creation, GitHub repository source creation, and manual source sync.
 
 It does not yet perform connector pulls from systems such as Confluence, Drive, or S3. Those belong to later roadmap phases.
 
@@ -134,6 +134,22 @@ Collections are tenant-scoped containers for reusable context. The document inge
 
 Manual sources are the connector foundation. `POST /v1/context/collections/{id}/sources` creates a tenant-scoped source with content, source URI, external ID, and metadata. `POST /v1/context/sources/{id}/sync` ingests that source into the existing `context_documents` and `context_blocks` pipeline, records `synced` or `failed` status on the source, persists the last error for failed syncs, and skips unchanged already-synced sources without duplicating documents.
 
+File upload sources use `type: "file_upload"` with text content and a `file` metadata object:
+
+```json
+{
+  "name": "Uploaded handbook",
+  "type": "file_upload",
+  "content": "# Refund policy\nRefunds require a receipt within 30 days.",
+  "file": {
+    "filename": "handbook.md",
+    "contentType": "text/markdown"
+  }
+}
+```
+
+Upload ingestion is text-only and bounded to 500,000 UTF-8 bytes. Provara sanitizes the filename, stores file metadata on the source, uses an `upload://` source URI, and syncs the content through the same document/block pipeline as manual sources.
+
 GitHub repository sources use `type: "github_repository"` with a `github` config object:
 
 ```json
@@ -206,7 +222,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, list credential metadata without secret values, create GitHub repository sources for the first managed collection, and bind a source to a stored credential. The Collection Sources section shows manual and GitHub sources for the first managed collection, including source URI or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, list credential metadata without secret values, create text file upload sources, create GitHub repository sources for the first managed collection, and bind a GitHub source to a stored credential. The Collection Sources section shows manual, file upload, and GitHub sources for the first managed collection, including source URI, filename metadata, or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -472,7 +472,7 @@ export const contextSources = sqliteTable("context_sources", {
     .notNull()
     .references(() => contextCollections.id),
   name: text("name").notNull(),
-  type: text("type", { enum: ["manual", "github_repository"] }).notNull().default("manual"),
+  type: text("type", { enum: ["manual", "github_repository", "file_upload"] }).notNull().default("manual"),
   externalId: text("external_id"),
   sourceUri: text("source_uri"),
   content: text("content").notNull().default(""),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -3075,7 +3075,7 @@ components:
           maxLength: 200
         type:
           type: string
-          enum: [manual, github_repository]
+          enum: [manual, github_repository, file_upload]
         externalId:
           type: string
           maxLength: 2000
@@ -3084,13 +3084,27 @@ components:
           maxLength: 2000
         content:
           type: string
-          description: Required for manual sources.
+          description: Required for manual and file_upload sources.
           maxLength: 500000
         github:
           $ref: "#/components/schemas/GitHubContextSourceConfig"
+        file:
+          $ref: "#/components/schemas/FileUploadContextSourceConfig"
         metadata:
           type: object
           additionalProperties: true
+
+    FileUploadContextSourceConfig:
+      type: object
+      required: [filename]
+      properties:
+        filename:
+          type: string
+          minLength: 1
+          maxLength: 240
+        contentType:
+          type: string
+          maxLength: 120
 
     CreateContextConnectorCredentialRequest:
       type: object
@@ -3259,7 +3273,7 @@ components:
           type: string
         type:
           type: string
-          enum: [manual, github_repository]
+          enum: [manual, github_repository, file_upload]
         externalId:
           type: string
           nullable: true

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -33,11 +33,14 @@ const MAX_GITHUB_FILE_BYTES = 250_000;
 const MAX_GITHUB_FILES = 100;
 const MAX_CREDENTIAL_NAME_CHARS = 120;
 const MAX_CREDENTIAL_VALUE_CHARS = 20_000;
+const MAX_UPLOAD_FILENAME_CHARS = 240;
+const MAX_UPLOAD_CONTENT_TYPE_CHARS = 120;
+const MAX_UPLOAD_BYTES = 500_000;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
 const BLOCK_INSERT_BATCH_SIZE = 50;
 
-type ContextSourceType = "manual" | "github_repository";
+type ContextSourceType = "manual" | "github_repository" | "file_upload";
 
 export interface GitHubSourceConfig {
   owner: string;
@@ -48,6 +51,12 @@ export interface GitHubSourceConfig {
   maxFileBytes: number;
   maxFiles: number;
   credentialId?: string;
+}
+
+export interface FileUploadSourceConfig {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
 }
 
 export interface ContextConnectorCredential {
@@ -181,6 +190,7 @@ export interface CreateContextSourceInput {
   content?: string;
   metadata?: Record<string, unknown>;
   github?: GitHubSourceConfig;
+  file?: FileUploadSourceConfig;
 }
 
 export interface CreateContextConnectorCredentialInput {
@@ -234,6 +244,35 @@ function normalizeGithubExtension(value: string): string {
   const trimmed = value.trim().toLowerCase();
   if (!trimmed) return "";
   return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function sanitizeUploadFilename(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, "/")
+    .split("/")
+    .filter(Boolean)
+    .at(-1)
+    ?.replace(/[^\w .@()+,-]/g, "_")
+    .replace(/\s+/g, " ")
+    .slice(0, MAX_UPLOAD_FILENAME_CHARS)
+    .trim() ?? "";
+}
+
+function isSafeUploadedText(value: string): boolean {
+  if (value.includes("\0")) return false;
+  let controlCount = 0;
+  const limit = Math.min(value.length, 8_192);
+  for (let index = 0; index < limit; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 32 && code !== 9 && code !== 10 && code !== 13) controlCount += 1;
+  }
+  return controlCount <= Math.max(4, Math.floor(limit * 0.01));
+}
+
+function normalizeUploadContentType(value: string | undefined): string {
+  const trimmed = value?.trim().toLowerCase() || "text/plain";
+  return trimmed.slice(0, MAX_UPLOAD_CONTENT_TYPE_CHARS);
 }
 
 function parseGithubConfig(metadata: Record<string, unknown>): GitHubSourceConfig {
@@ -518,15 +557,22 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
   const type = body.type === undefined ? "manual" : body.type;
-  if (type !== "manual" && type !== "github_repository") return { error: "type must be manual or github_repository" };
+  if (type !== "manual" && type !== "github_repository" && type !== "file_upload") {
+    return { error: "type must be manual, github_repository, or file_upload" };
+  }
   const externalId = trimOptional(body.externalId, "externalId", MAX_SOURCE_URI_CHARS);
   if (externalId.error) return { error: externalId.error };
   const sourceUri = trimOptional(body.sourceUri, "sourceUri", MAX_SOURCE_URI_CHARS);
   if (sourceUri.error) return { error: sourceUri.error };
-  if (type === "manual" && typeof body.content !== "string") return { error: "content is required" };
+  if ((type === "manual" || type === "file_upload") && typeof body.content !== "string") return { error: "content is required" };
   if (body.content !== undefined && typeof body.content !== "string") return { error: "content must be a string" };
   if (typeof body.content === "string" && body.content.length > MAX_INGEST_TEXT_CHARS) {
     return { error: `content must be at most ${MAX_INGEST_TEXT_CHARS} characters` };
+  }
+  if (type === "file_upload" && typeof body.content === "string") {
+    const byteLength = Buffer.byteLength(body.content, "utf8");
+    if (byteLength > MAX_UPLOAD_BYTES) return { error: `file content must be at most ${MAX_UPLOAD_BYTES} bytes` };
+    if (!isSafeUploadedText(body.content)) return { error: "file content must be text" };
   }
 
   let metadata: Record<string, unknown> | undefined;
@@ -597,6 +643,21 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
     };
   }
 
+  let file: FileUploadSourceConfig | undefined;
+  if (type === "file_upload") {
+    if (typeof body.file !== "object" || body.file === null || Array.isArray(body.file)) {
+      return { error: "file config is required" };
+    }
+    const raw = body.file as Record<string, unknown>;
+    if (typeof raw.filename !== "string") return { error: "file.filename is required" };
+    const filename = sanitizeUploadFilename(raw.filename);
+    if (!filename) return { error: "file.filename is required" };
+    if (filename === "." || filename === "..") return { error: "file.filename is invalid" };
+    const contentType = typeof raw.contentType === "string" ? normalizeUploadContentType(raw.contentType) : "text/plain";
+    const sizeBytes = typeof body.content === "string" ? Buffer.byteLength(body.content, "utf8") : 0;
+    file = { filename, contentType, sizeBytes };
+  }
+
   return {
     value: {
       name: name.value,
@@ -606,6 +667,7 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
       content: typeof body.content === "string" ? body.content : undefined,
       metadata,
       github,
+      file,
     },
   };
 }
@@ -819,11 +881,21 @@ export async function createContextSource(
   const id = nanoid();
   const metadata = input.github
     ? { ...(input.metadata ?? {}), github: input.github, githubSyncedFiles: {} }
-    : input.metadata ?? {};
+    : input.file
+      ? { ...(input.metadata ?? {}), file: input.file }
+      : input.metadata ?? {};
   const sourceUri = input.sourceUri
-    ?? (input.github ? `https://github.com/${input.github.owner}/${input.github.repo}/tree/${encodeURIComponent(input.github.branch)}` : null);
+    ?? (input.github
+      ? `https://github.com/${input.github.owner}/${input.github.repo}/tree/${encodeURIComponent(input.github.branch)}`
+      : input.file
+        ? `upload://${encodeURIComponent(input.file.filename)}`
+        : null);
   const externalId = input.externalId
-    ?? (input.github ? `github:${input.github.owner}/${input.github.repo}:${input.github.branch}:${input.github.path ?? ""}` : id);
+    ?? (input.github
+      ? `github:${input.github.owner}/${input.github.repo}:${input.github.branch}:${input.github.path ?? ""}`
+      : input.file
+        ? `upload:${hashContent(`${input.file.filename}:${input.content ?? ""}`).slice(0, 32)}`
+        : id);
   const content = input.content ?? "";
   await db.insert(contextSources).values({
     id,
@@ -1209,13 +1281,18 @@ export async function syncContextSource(
 
   const now = new Date();
   try {
+    const metadata = parseMetadata(sourceRow.metadata);
+    const file = sourceRow.type === "file_upload" && typeof metadata.file === "object" && metadata.file !== null && !Array.isArray(metadata.file)
+      ? metadata.file as Record<string, unknown>
+      : null;
+    const title = typeof file?.filename === "string" && file.filename.trim() ? file.filename.trim() : sourceRow.name;
     const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
-      title: sourceRow.name,
+      title,
       text: sourceRow.content,
       source: `source:${sourceRow.type}`,
       sourceUri: sourceRow.sourceUri ?? undefined,
       metadata: {
-        ...parseMetadata(sourceRow.metadata),
+        ...metadata,
         contextSourceId: sourceRow.id,
         contextSourceType: sourceRow.type,
         externalId: sourceRow.externalId,

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1804,6 +1804,116 @@ describe("managed context collections", () => {
     expect(await db.select().from(contextBlocks).all()).toHaveLength(1);
   });
 
+  it("creates and idempotently syncs file upload context sources", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Upload KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Uploaded refunds",
+        type: "file_upload",
+        content: "Uploaded refunds require a receipt within 30 days.",
+        file: {
+          filename: "../refunds.md",
+          contentType: "text/markdown",
+        },
+        metadata: { owner: "support" },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as {
+      source: { id: string; type: string; sourceUri: string; metadata: Record<string, unknown> };
+    };
+    expect(sourceBody.source).toMatchObject({
+      type: "file_upload",
+      sourceUri: "upload://refunds.md",
+      metadata: {
+        owner: "support",
+        file: { filename: "refunds.md", contentType: "text/markdown" },
+      },
+    });
+    expect(JSON.stringify(sourceBody)).not.toContain("Uploaded refunds require");
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const syncBody = await syncRes.json() as {
+      synced: boolean;
+      source: { syncStatus: string; documentCount: number };
+      document: { title: string; source: string; sourceUri: string; metadata: Record<string, unknown> };
+      blocks: Array<{ source: string; metadata: Record<string, unknown> }>;
+    };
+    expect(syncBody.synced).toBe(true);
+    expect(syncBody.source).toMatchObject({ syncStatus: "synced", documentCount: 1 });
+    expect(syncBody.document).toMatchObject({
+      title: "refunds.md",
+      source: "source:file_upload",
+      sourceUri: "upload://refunds.md",
+      metadata: expect.objectContaining({
+        contextSourceId: sourceBody.source.id,
+        contextSourceType: "file_upload",
+        file: expect.objectContaining({ filename: "refunds.md" }),
+      }),
+    });
+    expect(syncBody.blocks[0]).toMatchObject({
+      source: "source:file_upload",
+      metadata: expect.objectContaining({ contextSourceType: "file_upload" }),
+    });
+
+    const syncAgainRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncAgainRes.status).toBe(200);
+    const syncAgainBody = await syncAgainRes.json() as { synced: boolean; source: { documentCount: number } };
+    expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 1 } });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(1);
+    expect(await db.select().from(contextBlocks).all()).toHaveLength(1);
+  });
+
+  it("rejects unsafe file upload source payloads", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Unsafe Upload KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const missingFileRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Missing file", type: "file_upload", content: "Some text." }),
+    });
+    expect(missingFileRes.status).toBe(400);
+    expect(await missingFileRes.json()).toMatchObject({ error: { message: "file config is required" } });
+
+    const binaryRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Binary file",
+        type: "file_upload",
+        content: "valid text\0with null",
+        file: { filename: "binary.dat", contentType: "application/octet-stream" },
+      }),
+    });
+    expect(binaryRes.status).toBe(400);
+    expect(await binaryRes.json()).toMatchObject({ error: { message: "file content must be text" } });
+    expect(await db.select().from(contextSources).all()).toHaveLength(0);
+  });
+
   it("persists failed source sync status without writing documents", async () => {
     await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
     const app = buildApp(db);


### PR DESCRIPTION
## Summary

- Add `file_upload` context sources with text-only validation, filename sanitization, and bounded upload size.
- Reuse the existing source sync path to ingest uploaded files into context documents and blocks idempotently.
- Add dashboard file upload source creation and source-row rendering without exposing raw file content.
- Update OpenAPI, changelog, docs, and roadmap.

## Verification

- `npm test --workspace @provara/gateway -- context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npm test --workspace @provara/gateway` (initial run hit the known refusal-fallback flake; `refusal-fallback.test.ts` and the full rerun passed)
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #385

Authored-by: Codex/GPT-5 (codex)
Last-code-by: Codex/GPT-5 (codex)
