### PR TITLE
feat(#387): add S3 context connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable Provara changes are tracked here.
   - Connector credential auth foundation with encrypted tenant-scoped GitHub tokens, credential-bound source sync, no secret echo in API responses, and dashboard auth status.
   - Context dashboard connector management for creating GitHub credentials, creating GitHub repository sources, and manually syncing source rows without rendering secrets.
   - File upload connector v1 with bounded text upload validation, sanitized filename metadata, idempotent source sync, OpenAPI coverage, and dashboard creation controls.
+  - S3 connector v1 with encrypted AWS access-key credentials, SigV4 ListObjectsV2/GetObject sync, prefix/extension/file-size/file-count bounds, ETag idempotency, OpenAPI coverage, and dashboard creation controls.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -50,7 +51,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, dashboard connector management, and file upload connector v1 as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, dashboard connector management, file upload connector v1, and S3 connector v1 as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -207,7 +207,7 @@ export interface ContextSource {
   id: string;
   collectionId: string;
   name: string;
-  type: "manual" | "github_repository" | "file_upload";
+  type: "manual" | "github_repository" | "file_upload" | "s3_bucket";
   externalId: string | null;
   sourceUri: string | null;
   syncStatus: "pending" | "synced" | "failed";
@@ -223,7 +223,7 @@ export interface ContextConnectorCredential {
   id: string;
   tenantId: string;
   name: string;
-  type: "github_token";
+  type: "github_token" | "aws_access_key";
   hasSecret: boolean;
   lastUsedAt: string | null;
   createdAt: string;
@@ -326,6 +326,7 @@ function formatTimestamp(value: string | null): string {
 function formatContextSourceType(type: ContextSource["type"]): string {
   if (type === "github_repository") return "GitHub";
   if (type === "file_upload") return "File Upload";
+  if (type === "s3_bucket") return "S3";
   return "Manual";
 }
 
@@ -349,15 +350,25 @@ function formatContextSourceDetail(source: ContextSource): string {
     const sizeBytes = typeof file.sizeBytes === "number" ? file.sizeBytes : null;
     if (filename) return `${filename}${contentType ? ` (${contentType}` : ""}${contentType && sizeBytes !== null ? `, ${formatInteger(sizeBytes)} bytes)` : contentType ? ")" : ""}`;
   }
+  if (source.type === "s3_bucket") {
+    const s3 = typeof source.metadata.s3 === "object" && source.metadata.s3 !== null && !Array.isArray(source.metadata.s3)
+      ? source.metadata.s3 as Record<string, unknown>
+      : {};
+    const bucket = typeof s3.bucket === "string" ? s3.bucket : "";
+    const region = typeof s3.region === "string" ? s3.region : "";
+    const prefix = typeof s3.prefix === "string" && s3.prefix ? `/${s3.prefix}` : "";
+    if (bucket) return `s3://${bucket}${prefix}${region ? ` (${region})` : ""}`;
+  }
   return source.sourceUri || source.externalId || source.id;
 }
 
 function contextSourceHasAuth(source: ContextSource): boolean {
-  if (source.type !== "github_repository") return false;
-  const github = typeof source.metadata.github === "object" && source.metadata.github !== null && !Array.isArray(source.metadata.github)
-    ? source.metadata.github as Record<string, unknown>
+  if (source.type !== "github_repository" && source.type !== "s3_bucket") return false;
+  const credentialMetadata = source.type === "github_repository" ? source.metadata.github : source.metadata.s3;
+  const connector = typeof credentialMetadata === "object" && credentialMetadata !== null && !Array.isArray(credentialMetadata)
+    ? credentialMetadata as Record<string, unknown>
     : {};
-  return typeof github.credentialId === "string" && github.credentialId.length > 0;
+  return typeof connector.credentialId === "string" && connector.credentialId.length > 0;
 }
 
 function parseCsv(value: string): string[] {
@@ -663,6 +674,9 @@ export function ContextOptimizerPanel() {
   const [credentialDraft, setCredentialDraft] = useState({ name: "", value: "" });
   const [credentialSubmitting, setCredentialSubmitting] = useState(false);
   const [credentialMessage, setCredentialMessage] = useState<string | null>(null);
+  const [awsCredentialDraft, setAwsCredentialDraft] = useState({ name: "", accessKeyId: "", secretAccessKey: "", sessionToken: "" });
+  const [awsCredentialSubmitting, setAwsCredentialSubmitting] = useState(false);
+  const [awsCredentialMessage, setAwsCredentialMessage] = useState<string | null>(null);
   const [sourceDraft, setSourceDraft] = useState({
     name: "",
     owner: "",
@@ -676,6 +690,18 @@ export function ContextOptimizerPanel() {
   });
   const [sourceSubmitting, setSourceSubmitting] = useState(false);
   const [sourceMessage, setSourceMessage] = useState<string | null>(null);
+  const [s3Draft, setS3Draft] = useState({
+    name: "",
+    bucket: "",
+    region: "us-east-1",
+    prefix: "",
+    extensions: ".md,.mdx,.txt,.rst,.adoc,.csv,.json",
+    maxFiles: "100",
+    maxFileBytes: "250000",
+    credentialId: "",
+  });
+  const [s3Submitting, setS3Submitting] = useState(false);
+  const [s3Message, setS3Message] = useState<string | null>(null);
   const [fileDraft, setFileDraft] = useState({
     name: "",
     filename: "",
@@ -853,6 +879,8 @@ export function ContextOptimizerPanel() {
   const collectionRows = useMemo(() => state.collections, [state.collections]);
   const sourceRows = useMemo(() => state.sources, [state.sources]);
   const credentialRows = useMemo(() => state.credentials, [state.credentials]);
+  const githubCredentialRows = useMemo(() => credentialRows.filter((credential) => credential.type === "github_token"), [credentialRows]);
+  const awsCredentialRows = useMemo(() => credentialRows.filter((credential) => credential.type === "aws_access_key"), [credentialRows]);
   const canonicalRows = useMemo(() => state.canonicalBlocks, [state.canonicalBlocks]);
   const firstCollection = collectionRows[0] ?? null;
   const visibleCanonicalRows = useMemo(() => canonicalRows.slice(0, 10), [canonicalRows]);
@@ -919,6 +947,42 @@ export function ContextOptimizerPanel() {
     }
   }
 
+  async function createAwsCredential() {
+    if (!awsCredentialDraft.name.trim() || !awsCredentialDraft.accessKeyId.trim() || !awsCredentialDraft.secretAccessKey.trim()) return;
+    setAwsCredentialSubmitting(true);
+    setAwsCredentialMessage(null);
+    try {
+      const res = await gatewayFetchRaw("/v1/context/credentials", {
+        method: "POST",
+        body: JSON.stringify({
+          name: awsCredentialDraft.name.trim(),
+          type: "aws_access_key",
+          value: JSON.stringify({
+            accessKeyId: awsCredentialDraft.accessKeyId.trim(),
+            secretAccessKey: awsCredentialDraft.secretAccessKey,
+            sessionToken: awsCredentialDraft.sessionToken.trim() || undefined,
+          }),
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save AWS credential");
+      const body = await res.json() as { credential: ContextConnectorCredential };
+      setState((prev) => ({
+        ...prev,
+        credentials: [
+          body.credential,
+          ...prev.credentials.filter((credential) => credential.id !== body.credential.id),
+        ],
+      }));
+      setAwsCredentialDraft({ name: "", accessKeyId: "", secretAccessKey: "", sessionToken: "" });
+      setS3Draft((prev) => ({ ...prev, credentialId: body.credential.id }));
+      setAwsCredentialMessage("AWS credential saved.");
+    } catch (err) {
+      setAwsCredentialMessage(err instanceof Error ? err.message : "Failed to save AWS credential");
+    } finally {
+      setAwsCredentialSubmitting(false);
+    }
+  }
+
   async function createGitHubSource() {
     if (!firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()) return;
     setSourceSubmitting(true);
@@ -962,6 +1026,45 @@ export function ContextOptimizerPanel() {
       setSourceMessage(err instanceof Error ? err.message : "Failed to create GitHub source");
     } finally {
       setSourceSubmitting(false);
+    }
+  }
+
+  async function createS3Source() {
+    if (!firstCollection || !s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId) return;
+    setS3Submitting(true);
+    setS3Message(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+        method: "POST",
+        body: JSON.stringify({
+          name: s3Draft.name.trim(),
+          type: "s3_bucket",
+          s3: {
+            bucket: s3Draft.bucket.trim(),
+            region: s3Draft.region.trim(),
+            prefix: s3Draft.prefix.trim() || undefined,
+            credentialId: s3Draft.credentialId,
+            extensions: parseCsv(s3Draft.extensions),
+            maxFiles: Number(s3Draft.maxFiles) || 100,
+            maxFileBytes: Number(s3Draft.maxFileBytes) || 250000,
+          },
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to create S3 source");
+      const body = await res.json() as { source: ContextSource };
+      setState((prev) => ({
+        ...prev,
+        sources: [
+          body.source,
+          ...prev.sources.filter((source) => source.id !== body.source.id),
+        ],
+      }));
+      setS3Draft((prev) => ({ ...prev, name: "", bucket: "", prefix: "" }));
+      setS3Message("S3 source created.");
+    } catch (err) {
+      setS3Message(err instanceof Error ? err.message : "Failed to create S3 source");
+    } finally {
+      setS3Submitting(false);
     }
   }
 
@@ -1234,7 +1337,7 @@ export function ContextOptimizerPanel() {
       <section>
         <div className="mb-3">
           <h2 className="text-lg font-semibold text-zinc-100">Connector Management</h2>
-          <p className="mt-1 text-sm text-zinc-500">Credential metadata, GitHub repository sources, file upload sources, and manual source sync controls.</p>
+          <p className="mt-1 text-sm text-zinc-500">Credential metadata, S3 buckets, GitHub repository sources, file upload sources, and manual source sync controls.</p>
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">
@@ -1316,6 +1419,64 @@ export function ContextOptimizerPanel() {
           </div>
 
           <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">AWS Access Key Credential</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-aws-credential-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">AWS Credential Name</label>
+                <input
+                  id="context-aws-credential-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={awsCredentialDraft.name}
+                  onChange={(event) => setAwsCredentialDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-aws-access-key-id" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Access Key ID</label>
+                <input
+                  id="context-aws-access-key-id"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={awsCredentialDraft.accessKeyId}
+                  onChange={(event) => setAwsCredentialDraft((prev) => ({ ...prev, accessKeyId: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-aws-secret-access-key" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Secret Access Key</label>
+                <input
+                  id="context-aws-secret-access-key"
+                  type="password"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={awsCredentialDraft.secretAccessKey}
+                  onChange={(event) => setAwsCredentialDraft((prev) => ({ ...prev, secretAccessKey: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-aws-session-token" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Session Token</label>
+                <input
+                  id="context-aws-session-token"
+                  type="password"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={awsCredentialDraft.sessionToken}
+                  onChange={(event) => setAwsCredentialDraft((prev) => ({ ...prev, sessionToken: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={awsCredentialSubmitting || !awsCredentialDraft.name.trim() || !awsCredentialDraft.accessKeyId.trim() || !awsCredentialDraft.secretAccessKey.trim()}
+                onClick={() => void createAwsCredential()}
+              >
+                {awsCredentialSubmitting ? "Saving..." : "Save AWS Credential"}
+              </button>
+              {awsCredentialMessage && <span className="text-xs text-zinc-400">{awsCredentialMessage}</span>}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
             <h3 className="text-sm font-semibold text-zinc-100">File Upload Source</h3>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               <div>
@@ -1359,6 +1520,106 @@ export function ContextOptimizerPanel() {
           </div>
 
           <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">S3 Source</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-s3-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">S3 Source Name</label>
+                <input
+                  id="context-s3-source-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.name}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-s3-credential" className="text-xs font-medium uppercase tracking-wider text-zinc-500">AWS Credential</label>
+                <select
+                  id="context-s3-credential"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.credentialId}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, credentialId: event.target.value }))}
+                >
+                  <option value="">Select credential</option>
+                  {awsCredentialRows.map((credential) => (
+                    <option key={credential.id} value={credential.id}>{credential.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="context-s3-bucket" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Bucket</label>
+                <input
+                  id="context-s3-bucket"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.bucket}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, bucket: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-s3-region" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Region</label>
+                <input
+                  id="context-s3-region"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.region}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, region: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-s3-prefix" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Prefix</label>
+                <input
+                  id="context-s3-prefix"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.prefix}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, prefix: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-s3-extensions" className="text-xs font-medium uppercase tracking-wider text-zinc-500">S3 Extensions</label>
+                <input
+                  id="context-s3-extensions"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={s3Draft.extensions}
+                  onChange={(event) => setS3Draft((prev) => ({ ...prev, extensions: event.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="context-s3-max-files" className="text-xs font-medium uppercase tracking-wider text-zinc-500">S3 Max Files</label>
+                  <input
+                    id="context-s3-max-files"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={s3Draft.maxFiles}
+                    onChange={(event) => setS3Draft((prev) => ({ ...prev, maxFiles: event.target.value }))}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="context-s3-max-bytes" className="text-xs font-medium uppercase tracking-wider text-zinc-500">S3 Max Bytes</label>
+                  <input
+                    id="context-s3-max-bytes"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={s3Draft.maxFileBytes}
+                    onChange={(event) => setS3Draft((prev) => ({ ...prev, maxFileBytes: event.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={s3Submitting || !firstCollection || !s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId}
+                onClick={() => void createS3Source()}
+              >
+                {s3Submitting ? "Creating..." : "Create S3 Source"}
+              </button>
+              {s3Message && <span className="text-xs text-zinc-400">{s3Message}</span>}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
             <h3 className="text-sm font-semibold text-zinc-100">GitHub Source</h3>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               <div>
@@ -1379,7 +1640,7 @@ export function ContextOptimizerPanel() {
                   onChange={(event) => setSourceDraft((prev) => ({ ...prev, credentialId: event.target.value }))}
                 >
                   <option value="">No credential</option>
-                  {credentialRows.map((credential) => (
+                  {githubCredentialRows.map((credential) => (
                     <option key={credential.id} value={credential.id}>{credential.name}</option>
                   ))}
                 </select>

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -192,6 +192,16 @@ describe("ContextOptimizerPanel", () => {
               createdAt: "2026-05-01T20:00:00.000Z",
               updatedAt: "2026-05-01T22:04:00.000Z",
             },
+            {
+              id: "cred-aws",
+              tenantId: "tenant-pro",
+              name: "AWS Docs",
+              type: "aws_access_key",
+              hasSecret: true,
+              lastUsedAt: null,
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T22:04:00.000Z",
+            },
           ],
         }));
       }
@@ -271,6 +281,21 @@ describe("ContextOptimizerPanel", () => {
               lastError: null,
               metadata: { file: { filename: "handbook.md", contentType: "text/markdown", sizeBytes: 128 } },
               updatedAt: "2026-05-01T22:05:00.000Z",
+            },
+            {
+              id: "source-4",
+              collectionId: "collection-1",
+              name: "Docs bucket",
+              type: "s3_bucket",
+              externalId: "s3:acme-docs:us-east-1:docs",
+              sourceUri: "s3://acme-docs/docs",
+              syncStatus: "synced",
+              lastSyncedAt: "2026-05-01T22:06:00.000Z",
+              lastDocumentId: "doc-s3",
+              documentCount: 2,
+              lastError: null,
+              metadata: { s3: { bucket: "acme-docs", region: "us-east-1", prefix: "docs", credentialId: "cred-aws" } },
+              updatedAt: "2026-05-01T22:06:00.000Z",
             },
           ],
         }));
@@ -401,7 +426,8 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("GitHub Token Credentials")).toBeInTheDocument();
     expect(screen.getByText("GitHub Source")).toBeInTheDocument();
     expect(screen.getAllByText("GitHub Docs").length).toBeGreaterThan(0);
-    expect(screen.getByText("Stored")).toBeInTheDocument();
+    expect(screen.getAllByText("AWS Docs").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Stored").length).toBeGreaterThan(0);
     expect(screen.getByText("Collection Sources")).toBeInTheDocument();
     expect(screen.getByText("Refund source")).toBeInTheDocument();
     expect(screen.getByText("file://refunds.md")).toBeInTheDocument();
@@ -409,7 +435,9 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getByText("acme/docs@main/docs")).toBeInTheDocument();
     expect(screen.getByText("Uploaded handbook")).toBeInTheDocument();
     expect(screen.getByText("handbook.md (text/markdown, 128 bytes)")).toBeInTheDocument();
-    expect(screen.getByText("Configured")).toBeInTheDocument();
+    expect(screen.getByText("Docs bucket")).toBeInTheDocument();
+    expect(screen.getByText("s3://acme-docs/docs (us-east-1)")).toBeInTheDocument();
+    expect(screen.getAllByText("Configured").length).toBeGreaterThan(0);
     expect(screen.getByText("Canonical")).toBeInTheDocument();
     expect(screen.getByText("Approved")).toBeInTheDocument();
     expect(screen.getByText("Canonical Review Queue")).toBeInTheDocument();
@@ -520,7 +548,31 @@ describe("ContextOptimizerPanel", () => {
         }));
       }
       if (path === "/v1/context/credentials" && init?.method === "POST") {
-        expect(JSON.parse(String(init.body))).toMatchObject({
+        const parsed = JSON.parse(String(init.body)) as Record<string, unknown>;
+        if (parsed.type === "aws_access_key") {
+          const value = JSON.parse(String(parsed.value)) as Record<string, unknown>;
+          expect(parsed).toMatchObject({
+            name: "AWS token",
+            type: "aws_access_key",
+          });
+          expect(value).toMatchObject({
+            accessKeyId: "AKIA_TEST",
+            secretAccessKey: "aws_secret_123",
+          });
+          return Promise.resolve(jsonResponse({
+            credential: {
+              id: "cred-aws-new",
+              tenantId: "tenant-pro",
+              name: "AWS token",
+              type: "aws_access_key",
+              hasSecret: true,
+              lastUsedAt: null,
+              createdAt: "2026-05-01T22:10:00.000Z",
+              updatedAt: "2026-05-01T22:10:00.000Z",
+            },
+          }));
+        }
+        expect(parsed).toMatchObject({
           name: "Docs token",
           type: "github_token",
           value: "ghp_secret_token_123",
@@ -567,6 +619,38 @@ describe("ContextOptimizerPanel", () => {
               documentCount: 0,
               lastError: null,
               metadata: { file: { filename: "guide.md", contentType: "text/markdown", sizeBytes: 35 } },
+              updatedAt: "2026-05-01T22:10:00.000Z",
+            },
+          }));
+        }
+        if (parsed.type === "s3_bucket") {
+          expect(parsed).toMatchObject({
+            name: "Docs bucket",
+            type: "s3_bucket",
+            s3: {
+              bucket: "acme-docs",
+              region: "us-east-1",
+              prefix: "docs",
+              credentialId: "cred-aws-new",
+              extensions: [".md", ".txt"],
+              maxFiles: 25,
+              maxFileBytes: 125000,
+            },
+          });
+          return Promise.resolve(jsonResponse({
+            source: {
+              id: "source-s3",
+              collectionId: "collection-1",
+              name: "Docs bucket",
+              type: "s3_bucket",
+              externalId: "s3:acme-docs:us-east-1:docs",
+              sourceUri: "s3://acme-docs/docs",
+              syncStatus: "pending",
+              lastSyncedAt: null,
+              lastDocumentId: null,
+              documentCount: 0,
+              lastError: null,
+              metadata: { s3: { bucket: "acme-docs", region: "us-east-1", prefix: "docs", credentialId: "cred-aws-new" } },
               updatedAt: "2026-05-01T22:10:00.000Z",
             },
           }));
@@ -674,6 +758,40 @@ describe("ContextOptimizerPanel", () => {
           },
         }));
       }
+      if (path === "/v1/context/sources/source-s3/sync") {
+        return Promise.resolve(jsonResponse({
+          synced: true,
+          collection: {
+            id: "collection-1",
+            tenantId: "tenant-pro",
+            name: "Support KB",
+            description: "Approved support context",
+            status: "active",
+            documentCount: 3,
+            blockCount: 6,
+            canonicalBlockCount: 1,
+            approvedBlockCount: 0,
+            tokenCount: 400,
+            createdAt: "2026-05-01T20:00:00.000Z",
+            updatedAt: "2026-05-01T22:14:00.000Z",
+          },
+          source: {
+            id: "source-s3",
+            collectionId: "collection-1",
+            name: "Docs bucket",
+            type: "s3_bucket",
+            externalId: "s3:acme-docs:us-east-1:docs",
+            sourceUri: "s3://acme-docs/docs",
+            syncStatus: "synced",
+            lastSyncedAt: "2026-05-01T22:14:00.000Z",
+            lastDocumentId: "doc-s3",
+            documentCount: 2,
+            lastError: null,
+            metadata: { s3: { bucket: "acme-docs", region: "us-east-1", prefix: "docs", credentialId: "cred-aws-new" } },
+            updatedAt: "2026-05-01T22:14:00.000Z",
+          },
+        }));
+      }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
 
@@ -688,6 +806,15 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getAllByText("Docs token").length).toBeGreaterThan(0);
     expect(document.body.textContent).not.toContain("ghp_secret_token_123");
 
+    fireEvent.change(screen.getByLabelText("AWS Credential Name"), { target: { value: "AWS token" } });
+    fireEvent.change(screen.getByLabelText("Access Key ID"), { target: { value: "AKIA_TEST" } });
+    fireEvent.change(screen.getByLabelText("Secret Access Key"), { target: { value: "aws_secret_123" } });
+    fireEvent.click(screen.getByText("Save AWS Credential"));
+
+    expect(await screen.findByText("AWS credential saved.")).toBeInTheDocument();
+    expect(screen.getAllByText("AWS token").length).toBeGreaterThan(0);
+    expect(document.body.textContent).not.toContain("aws_secret_123");
+
     const upload = new File(["Uploaded guide content for context."], "guide.md", { type: "text/markdown" });
     fireEvent.change(screen.getByLabelText("File"), { target: { files: [upload] } });
     expect(await screen.findByText("File loaded.")).toBeInTheDocument();
@@ -699,6 +826,17 @@ describe("ContextOptimizerPanel", () => {
     expect(await screen.findByText("File source created.")).toBeInTheDocument();
     expect(screen.getByText("guide.md (text/markdown, 35 bytes)")).toBeInTheDocument();
     expect(document.body.textContent).not.toContain("Uploaded guide content for context.");
+
+    fireEvent.change(screen.getByLabelText("S3 Source Name"), { target: { value: "Docs bucket" } });
+    fireEvent.change(screen.getByLabelText("Bucket"), { target: { value: "acme-docs" } });
+    fireEvent.change(screen.getByLabelText("Prefix"), { target: { value: "docs" } });
+    fireEvent.change(screen.getByLabelText("S3 Extensions"), { target: { value: ".md,.txt" } });
+    fireEvent.change(screen.getByLabelText("S3 Max Files"), { target: { value: "25" } });
+    fireEvent.change(screen.getByLabelText("S3 Max Bytes"), { target: { value: "125000" } });
+    fireEvent.click(screen.getByText("Create S3 Source"));
+
+    expect(await screen.findByText("S3 source created.")).toBeInTheDocument();
+    expect(screen.getAllByText("s3://acme-docs/docs (us-east-1)").length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByLabelText("GitHub Source Name"), { target: { value: "Docs repo" } });
     fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "acme" } });

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -40,6 +40,7 @@ Implemented as of `0.2.0`:
 - Connector credential auth foundation with encrypted GitHub token storage and source binding.
 - Dashboard connector management for GitHub credential creation, GitHub source creation, and manual source sync.
 - File upload connector v1 with bounded text upload validation, sanitized file metadata, idempotent source sync, and dashboard creation controls.
+- S3 connector v1 with encrypted AWS access-key credentials, bounded object selection, ETag idempotency, and dashboard creation controls.
 
 Next planned layer:
 - Additional external connector implementations.
@@ -140,6 +141,7 @@ Foundation shipped:
 - Source-level credential binding without exposing secret values in API or dashboard responses.
 - Dashboard controls for creating GitHub credentials and repository sources, plus manual sync from source rows.
 - Bounded file upload source creation for local text/markdown knowledge without external OAuth.
+- S3 bucket source creation and listing with AWS SigV4 sync, prefix/extension/file-size/file-count bounds, and ETag-based idempotency.
 
 Candidate connectors:
 - Confluence.
@@ -147,7 +149,6 @@ Candidate connectors:
 - SharePoint.
 - Notion.
 - Zendesk or Intercom help centers.
-- S3.
 
 ## V3: Retrieval Quality Layer
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,15 +21,15 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
-- Connector ingestion with tenant-scoped manual, file upload, and GitHub repository sources plus encrypted connector credentials.
+- Connector ingestion with tenant-scoped manual, file upload, GitHub repository, and S3 bucket sources plus encrypted connector credentials.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
-- Dashboard connector management for GitHub credentials, file upload source creation, GitHub repository source creation, and manual source sync.
+- Dashboard connector management for GitHub credentials, AWS credentials, file upload source creation, S3 bucket source creation, GitHub repository source creation, and manual source sync.
 
-It does not yet perform connector pulls from systems such as Confluence, Drive, or S3. Those belong to later roadmap phases.
+It does not yet perform connector pulls from systems such as Confluence or Drive. Those belong to later roadmap phases.
 
 ## API
 
@@ -171,7 +171,27 @@ GitHub repository sources use `type: "github_repository"` with a `github` config
 
 GitHub sync fetches the repository tree and selected blobs through GitHub's JSON API, bounds files by extension/count/size, stores repo/path/SHA metadata on ingested documents and blocks, and skips files whose blob SHA has already synced.
 
-Connector credentials are tenant-scoped encrypted secrets. `POST /v1/context/credentials` accepts `type: "github_token"` and a token `value`, stores it with the same AES-GCM master-key encryption used for provider API keys, and returns only metadata plus `hasSecret: true`. `GET /v1/context/credentials` never returns raw token values. GitHub sources can set `github.credentialId`; sync decrypts that credential server-side, sends it as the GitHub bearer token, and records missing or undecryptable credentials as failed source syncs.
+S3 bucket sources use `type: "s3_bucket"` with an `s3` config object:
+
+```json
+{
+  "name": "Docs bucket",
+  "type": "s3_bucket",
+  "s3": {
+    "bucket": "acme-docs",
+    "region": "us-east-1",
+    "prefix": "docs",
+    "credentialId": "credential-id",
+    "extensions": [".md", ".txt"],
+    "maxFiles": 100,
+    "maxFileBytes": 250000
+  }
+}
+```
+
+S3 sync uses AWS Signature Version 4 against S3 ListObjectsV2 and GetObject, bounds objects by extension/count/size, stores bucket/key/ETag metadata on ingested documents and blocks, and skips objects whose ETag has already synced.
+
+Connector credentials are tenant-scoped encrypted secrets. `POST /v1/context/credentials` accepts `type: "github_token"` and a token `value`, or `type: "aws_access_key"` with a JSON string containing `accessKeyId`, `secretAccessKey`, and optional `sessionToken`. Values are stored with the same AES-GCM master-key encryption used for provider API keys, and responses return only metadata plus `hasSecret: true`. `GET /v1/context/credentials` never returns raw secret values. GitHub sources can set `github.credentialId`; S3 sources must set `s3.credentialId`; sync decrypts the credential server-side and records missing or undecryptable credentials as failed source syncs.
 
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
@@ -222,7 +242,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, list credential metadata without secret values, create text file upload sources, create GitHub repository sources for the first managed collection, and bind a GitHub source to a stored credential. The Collection Sources section shows manual, file upload, and GitHub sources for the first managed collection, including source URI, filename metadata, or repo/branch/path, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, create AWS access-key credentials, list credential metadata without secret values, create text file upload sources, create S3 bucket sources, create GitHub repository sources for the first managed collection, and bind external sources to stored credentials. The Collection Sources section shows manual, file upload, GitHub, and S3 sources for the first managed collection, including source URI, filename metadata, repo/branch/path, or bucket/prefix/region, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -263,6 +283,6 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 The next behavior layer is additional external connector ingestion:
 
-- Confluence, Google Drive, SharePoint, Notion, Zendesk/Intercom, and S3/file upload connectors.
+- Confluence, Google Drive, SharePoint, Notion, and Zendesk/Intercom connectors.
 - Source provenance and sync metadata for managed collections.
 - Connector-level review and policy defaults.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -472,7 +472,7 @@ export const contextSources = sqliteTable("context_sources", {
     .notNull()
     .references(() => contextCollections.id),
   name: text("name").notNull(),
-  type: text("type", { enum: ["manual", "github_repository", "file_upload"] }).notNull().default("manual"),
+  type: text("type", { enum: ["manual", "github_repository", "file_upload", "s3_bucket"] }).notNull().default("manual"),
   externalId: text("external_id"),
   sourceUri: text("source_uri"),
   content: text("content").notNull().default(""),
@@ -499,7 +499,7 @@ export const contextConnectorCredentials = sqliteTable("context_connector_creden
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),
   name: text("name").notNull(),
-  type: text("type", { enum: ["github_token"] }).notNull(),
+  type: text("type", { enum: ["github_token", "aws_access_key"] }).notNull(),
   encryptedValue: text("encrypted_value").notNull(),
   iv: text("iv").notNull(),
   authTag: text("auth_tag").notNull(),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -3075,7 +3075,7 @@ components:
           maxLength: 200
         type:
           type: string
-          enum: [manual, github_repository, file_upload]
+          enum: [manual, github_repository, file_upload, s3_bucket]
         externalId:
           type: string
           maxLength: 2000
@@ -3090,6 +3090,8 @@ components:
           $ref: "#/components/schemas/GitHubContextSourceConfig"
         file:
           $ref: "#/components/schemas/FileUploadContextSourceConfig"
+        s3:
+          $ref: "#/components/schemas/S3ContextSourceConfig"
         metadata:
           type: object
           additionalProperties: true
@@ -3106,6 +3108,43 @@ components:
           type: string
           maxLength: 120
 
+    S3ContextSourceConfig:
+      type: object
+      required: [bucket, region, credentialId]
+      properties:
+        bucket:
+          type: string
+          minLength: 3
+          maxLength: 63
+        region:
+          type: string
+          minLength: 1
+          maxLength: 64
+        prefix:
+          type: string
+          maxLength: 1000
+        credentialId:
+          type: string
+          description: Tenant-scoped aws_access_key connector credential id.
+        extensions:
+          type: array
+          description: Object key extensions to ingest. Defaults to documentation/text extensions.
+          minItems: 1
+          maxItems: 20
+          items:
+            type: string
+            maxLength: 24
+        maxFileBytes:
+          type: integer
+          minimum: 1
+          maximum: 250000
+          default: 250000
+        maxFiles:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 100
+
     CreateContextConnectorCredentialRequest:
       type: object
       required: [name, value]
@@ -3116,12 +3155,12 @@ components:
           maxLength: 120
         type:
           type: string
-          enum: [github_token]
+          enum: [github_token, aws_access_key]
         value:
           type: string
           minLength: 1
           maxLength: 20000
-          description: Secret token value. Only accepted on write and never returned.
+          description: Secret token value. For aws_access_key, pass a JSON string with accessKeyId, secretAccessKey, and optional sessionToken. Only accepted on write and never returned.
 
     ContextConnectorCredential:
       type: object
@@ -3136,7 +3175,7 @@ components:
           type: string
         type:
           type: string
-          enum: [github_token]
+          enum: [github_token, aws_access_key]
         hasSecret:
           type: boolean
         lastUsedAt:
@@ -3273,7 +3312,7 @@ components:
           type: string
         type:
           type: string
-          enum: [manual, github_repository, file_upload]
+          enum: [manual, github_repository, file_upload, s3_bucket]
         externalId:
           type: string
           nullable: true

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import type { Db } from "@provara/db";
 import {
   contextBlocks,
@@ -36,11 +36,18 @@ const MAX_CREDENTIAL_VALUE_CHARS = 20_000;
 const MAX_UPLOAD_FILENAME_CHARS = 240;
 const MAX_UPLOAD_CONTENT_TYPE_CHARS = 120;
 const MAX_UPLOAD_BYTES = 500_000;
+const MAX_S3_BUCKET_CHARS = 63;
+const MAX_S3_REGION_CHARS = 64;
+const MAX_S3_PREFIX_CHARS = 1_000;
+const MAX_S3_EXTENSION_CHARS = 24;
+const MAX_S3_FILE_BYTES = 250_000;
+const MAX_S3_FILES = 100;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
 const BLOCK_INSERT_BATCH_SIZE = 50;
 
-type ContextSourceType = "manual" | "github_repository" | "file_upload";
+type ContextSourceType = "manual" | "github_repository" | "file_upload" | "s3_bucket";
+type ContextConnectorCredentialType = "github_token" | "aws_access_key";
 
 export interface GitHubSourceConfig {
   owner: string;
@@ -59,11 +66,27 @@ export interface FileUploadSourceConfig {
   sizeBytes: number;
 }
 
+export interface S3SourceConfig {
+  bucket: string;
+  region: string;
+  prefix?: string;
+  extensions: string[];
+  maxFileBytes: number;
+  maxFiles: number;
+  credentialId: string;
+}
+
+interface AwsAccessKeyCredential {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
 export interface ContextConnectorCredential {
   id: string;
   tenantId: string | null;
   name: string;
-  type: "github_token";
+  type: ContextConnectorCredentialType;
   hasSecret: boolean;
   lastUsedAt: Date | null;
   createdAt: Date;
@@ -191,11 +214,12 @@ export interface CreateContextSourceInput {
   metadata?: Record<string, unknown>;
   github?: GitHubSourceConfig;
   file?: FileUploadSourceConfig;
+  s3?: S3SourceConfig;
 }
 
 export interface CreateContextConnectorCredentialInput {
   name: string;
-  type: "github_token";
+  type: ContextConnectorCredentialType;
   value: string;
 }
 
@@ -218,6 +242,17 @@ interface GitHubFileCandidate {
 }
 
 interface GitHubSyncFile extends GitHubFileCandidate {
+  content: string;
+}
+
+interface S3ObjectCandidate {
+  key: string;
+  etag: string;
+  size: number;
+  lastModified?: string;
+}
+
+interface S3SyncFile extends S3ObjectCandidate {
   content: string;
 }
 
@@ -244,6 +279,32 @@ function normalizeGithubExtension(value: string): string {
   const trimmed = value.trim().toLowerCase();
   if (!trimmed) return "";
   return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function normalizeConnectorExtension(value: string): string {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) return "";
+  return trimmed.startsWith(".") ? trimmed : `.${trimmed}`;
+}
+
+function normalizeS3Prefix(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/^\/+/, "") ?? "";
+  return trimmed || undefined;
+}
+
+function parseAwsCredentialValue(value: string): AwsAccessKeyCredential | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const raw = parsed as Record<string, unknown>;
+    const accessKeyId = typeof raw.accessKeyId === "string" ? raw.accessKeyId.trim() : "";
+    const secretAccessKey = typeof raw.secretAccessKey === "string" ? raw.secretAccessKey.trim() : "";
+    const sessionToken = typeof raw.sessionToken === "string" && raw.sessionToken.trim() ? raw.sessionToken.trim() : undefined;
+    if (!accessKeyId || !secretAccessKey) return null;
+    return { accessKeyId, secretAccessKey, sessionToken };
+  } catch {
+    return null;
+  }
 }
 
 function sanitizeUploadFilename(value: string): string {
@@ -298,6 +359,30 @@ function parseGithubConfig(metadata: Record<string, unknown>): GitHubSourceConfi
 
   if (!owner || !repo || !branch) throw new Error("github owner, repo, and branch are required");
   return { owner, repo, branch, path, extensions, maxFileBytes, maxFiles, credentialId };
+}
+
+function parseS3Config(metadata: Record<string, unknown>): S3SourceConfig {
+  const s3 = metadata.s3;
+  if (typeof s3 !== "object" || s3 === null || Array.isArray(s3)) {
+    throw new Error("s3 source config is required");
+  }
+  const raw = s3 as Record<string, unknown>;
+  const bucket = typeof raw.bucket === "string" ? raw.bucket : "";
+  const region = typeof raw.region === "string" ? raw.region : "";
+  const prefix = typeof raw.prefix === "string" ? normalizeS3Prefix(raw.prefix) : undefined;
+  const extensions = Array.isArray(raw.extensions)
+    ? raw.extensions.filter((value): value is string => typeof value === "string").map(normalizeConnectorExtension).filter(Boolean)
+    : [".md", ".mdx", ".txt", ".rst", ".adoc", ".csv", ".json"];
+  const maxFileBytes = typeof raw.maxFileBytes === "number" && Number.isFinite(raw.maxFileBytes)
+    ? Math.min(Math.max(Math.trunc(raw.maxFileBytes), 1), MAX_S3_FILE_BYTES)
+    : MAX_S3_FILE_BYTES;
+  const maxFiles = typeof raw.maxFiles === "number" && Number.isFinite(raw.maxFiles)
+    ? Math.min(Math.max(Math.trunc(raw.maxFiles), 1), MAX_S3_FILES)
+    : MAX_S3_FILES;
+  const credentialId = typeof raw.credentialId === "string" ? raw.credentialId.trim() : "";
+
+  if (!bucket || !region || !credentialId) throw new Error("s3 bucket, region, and credentialId are required");
+  return { bucket, region, prefix, extensions, maxFileBytes, maxFiles, credentialId };
 }
 
 function credentialFromRow(row: typeof contextConnectorCredentials.$inferSelect): ContextConnectorCredential {
@@ -557,8 +642,8 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
   const type = body.type === undefined ? "manual" : body.type;
-  if (type !== "manual" && type !== "github_repository" && type !== "file_upload") {
-    return { error: "type must be manual, github_repository, or file_upload" };
+  if (type !== "manual" && type !== "github_repository" && type !== "file_upload" && type !== "s3_bucket") {
+    return { error: "type must be manual, github_repository, file_upload, or s3_bucket" };
   }
   const externalId = trimOptional(body.externalId, "externalId", MAX_SOURCE_URI_CHARS);
   if (externalId.error) return { error: externalId.error };
@@ -658,6 +743,66 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
     file = { filename, contentType, sizeBytes };
   }
 
+  let s3: S3SourceConfig | undefined;
+  if (type === "s3_bucket") {
+    if (typeof body.s3 !== "object" || body.s3 === null || Array.isArray(body.s3)) {
+      return { error: "s3 config is required" };
+    }
+    const raw = body.s3 as Record<string, unknown>;
+    const bucket = trimOptional(raw.bucket, "s3.bucket", MAX_S3_BUCKET_CHARS);
+    if (bucket.error) return { error: bucket.error };
+    if (!bucket.value) return { error: "s3.bucket is required" };
+    if (!/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(bucket.value) || bucket.value.includes("..")) {
+      return { error: "s3.bucket is invalid" };
+    }
+    const region = trimOptional(raw.region, "s3.region", MAX_S3_REGION_CHARS);
+    if (region.error) return { error: region.error };
+    if (!region.value) return { error: "s3.region is required" };
+    if (!/^[a-z0-9-]+$/.test(region.value)) return { error: "s3.region is invalid" };
+    const prefix = trimOptional(raw.prefix, "s3.prefix", MAX_S3_PREFIX_CHARS);
+    if (prefix.error) return { error: prefix.error };
+    const credentialId = trimOptional(raw.credentialId, "s3.credentialId", MAX_SOURCE_URI_CHARS);
+    if (credentialId.error) return { error: credentialId.error };
+    if (!credentialId.value) return { error: "s3.credentialId is required" };
+
+    let extensions = [".md", ".mdx", ".txt", ".rst", ".adoc", ".csv", ".json"];
+    if (raw.extensions !== undefined) {
+      if (!Array.isArray(raw.extensions)) return { error: "s3.extensions must be an array" };
+      if (raw.extensions.length === 0 || raw.extensions.length > 20) return { error: "s3.extensions must contain 1 to 20 entries" };
+      extensions = [];
+      for (const [index, entry] of raw.extensions.entries()) {
+        if (typeof entry !== "string") return { error: `s3.extensions[${index}] must be a string` };
+        const normalized = normalizeConnectorExtension(entry);
+        if (!normalized) return { error: `s3.extensions[${index}] is required` };
+        if (normalized.length > MAX_S3_EXTENSION_CHARS) {
+          return { error: `s3.extensions[${index}] must be at most ${MAX_S3_EXTENSION_CHARS} characters` };
+        }
+        if (!extensions.includes(normalized)) extensions.push(normalized);
+      }
+    }
+
+    const maxFileBytes = raw.maxFileBytes === undefined ? MAX_S3_FILE_BYTES : raw.maxFileBytes;
+    if (typeof maxFileBytes !== "number" || !Number.isFinite(maxFileBytes)) return { error: "s3.maxFileBytes must be a number" };
+    if (maxFileBytes < 1 || maxFileBytes > MAX_S3_FILE_BYTES) {
+      return { error: `s3.maxFileBytes must be between 1 and ${MAX_S3_FILE_BYTES}` };
+    }
+    const maxFiles = raw.maxFiles === undefined ? MAX_S3_FILES : raw.maxFiles;
+    if (typeof maxFiles !== "number" || !Number.isFinite(maxFiles)) return { error: "s3.maxFiles must be a number" };
+    if (maxFiles < 1 || maxFiles > MAX_S3_FILES) {
+      return { error: `s3.maxFiles must be between 1 and ${MAX_S3_FILES}` };
+    }
+
+    s3 = {
+      bucket: bucket.value,
+      region: region.value,
+      prefix: normalizeS3Prefix(prefix.value),
+      extensions,
+      maxFileBytes: Math.trunc(maxFileBytes),
+      maxFiles: Math.trunc(maxFiles),
+      credentialId: credentialId.value,
+    };
+  }
+
   return {
     value: {
       name: name.value,
@@ -668,6 +813,7 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
       metadata,
       github,
       file,
+      s3,
     },
   };
 }
@@ -681,11 +827,14 @@ export function validateCreateContextConnectorCredentialBody(value: unknown): Va
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
   const type = body.type === undefined ? "github_token" : body.type;
-  if (type !== "github_token") return { error: "type must be github_token" };
+  if (type !== "github_token" && type !== "aws_access_key") return { error: "type must be github_token or aws_access_key" };
   if (typeof body.value !== "string") return { error: "value is required" };
   const credentialValue = body.value.trim();
   if (!credentialValue) return { error: "value cannot be empty or whitespace-only" };
   if (credentialValue.length > MAX_CREDENTIAL_VALUE_CHARS) return { error: `value must be at most ${MAX_CREDENTIAL_VALUE_CHARS} characters` };
+  if (type === "aws_access_key" && !parseAwsCredentialValue(credentialValue)) {
+    return { error: "value must be a JSON object with accessKeyId and secretAccessKey" };
+  }
   return { value: { name: name.value, type, value: credentialValue } };
 }
 
@@ -876,23 +1025,35 @@ export async function createContextSource(
     const credential = await db.select({ id: contextConnectorCredentials.id }).from(contextConnectorCredentials).where(credentialWhere).get();
     if (!credential) throw new Error("connector credential not found");
   }
+  if (input.s3?.credentialId) {
+    const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, input.s3.credentialId));
+    const credential = await db.select({ id: contextConnectorCredentials.id, type: contextConnectorCredentials.type }).from(contextConnectorCredentials).where(credentialWhere).get();
+    if (!credential) throw new Error("connector credential not found");
+    if (credential.type !== "aws_access_key") throw new Error("connector credential must be aws_access_key");
+  }
 
   const now = new Date();
   const id = nanoid();
   const metadata = input.github
     ? { ...(input.metadata ?? {}), github: input.github, githubSyncedFiles: {} }
+    : input.s3
+      ? { ...(input.metadata ?? {}), s3: input.s3, s3SyncedObjects: {} }
     : input.file
       ? { ...(input.metadata ?? {}), file: input.file }
       : input.metadata ?? {};
   const sourceUri = input.sourceUri
     ?? (input.github
       ? `https://github.com/${input.github.owner}/${input.github.repo}/tree/${encodeURIComponent(input.github.branch)}`
+      : input.s3
+        ? `s3://${input.s3.bucket}/${input.s3.prefix ?? ""}`
       : input.file
         ? `upload://${encodeURIComponent(input.file.filename)}`
         : null);
   const externalId = input.externalId
     ?? (input.github
       ? `github:${input.github.owner}/${input.github.repo}:${input.github.branch}:${input.github.path ?? ""}`
+      : input.s3
+        ? `s3:${input.s3.bucket}:${input.s3.region}:${input.s3.prefix ?? ""}`
       : input.file
         ? `upload:${hashContent(`${input.file.filename}:${input.content ?? ""}`).slice(0, 32)}`
         : id);
@@ -906,7 +1067,7 @@ export async function createContextSource(
     externalId,
     sourceUri,
     content,
-    contentHash: hashContent(input.github ? JSON.stringify(input.github) : content),
+    contentHash: hashContent(input.github ? JSON.stringify(input.github) : input.s3 ? JSON.stringify(input.s3) : content),
     syncStatus: "pending",
     documentCount: 0,
     metadata: JSON.stringify(metadata),
@@ -1106,6 +1267,16 @@ function getSyncedGithubFiles(metadata: Record<string, unknown>): Record<string,
   return result;
 }
 
+function getSyncedS3Objects(metadata: Record<string, unknown>): Record<string, string> {
+  const objects = metadata.s3SyncedObjects;
+  if (typeof objects !== "object" || objects === null || Array.isArray(objects)) return {};
+  const result: Record<string, string> = {};
+  for (const [key, etag] of Object.entries(objects)) {
+    if (typeof etag === "string") result[key] = etag;
+  }
+  return result;
+}
+
 async function resolveGithubToken(
   db: Db,
   tenantId: string | null,
@@ -1133,6 +1304,171 @@ async function resolveGithubToken(
     if (err instanceof Error && err.message === "connector credential is empty") throw err;
     throw new Error("connector credential could not be decrypted");
   }
+}
+
+async function resolveAwsCredential(
+  db: Db,
+  tenantId: string | null,
+  credentialId: string,
+): Promise<AwsAccessKeyCredential> {
+  if (!hasMasterKey()) throw new Error("PROVARA_MASTER_KEY not set");
+  const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, credentialId));
+  const credential = await db.select().from(contextConnectorCredentials).where(credentialWhere).get();
+  if (!credential) throw new Error("connector credential not found");
+  if (credential.type !== "aws_access_key") throw new Error("connector credential must be aws_access_key");
+  try {
+    const raw = decrypt({
+      encrypted: credential.encryptedValue,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }).replace(/[^\x20-\x7E\t\r\n]/g, "").trim();
+    const parsed = parseAwsCredentialValue(raw);
+    if (!parsed) throw new Error("connector credential is invalid");
+    await db.update(contextConnectorCredentials).set({
+      lastUsedAt: new Date(),
+    }).where(eq(contextConnectorCredentials.id, credential.id)).run();
+    return parsed;
+  } catch (err) {
+    if (err instanceof Error && err.message === "connector credential is invalid") throw err;
+    throw new Error("connector credential could not be decrypted");
+  }
+}
+
+function hmac(key: Buffer | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function encodeS3KeyPath(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function s3Host(config: S3SourceConfig): string {
+  return `${config.bucket}.s3.${config.region}.amazonaws.com`;
+}
+
+function signS3Request(
+  method: "GET",
+  url: URL,
+  config: S3SourceConfig,
+  credential: AwsAccessKeyCredential,
+  now = new Date(),
+): HeadersInit {
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = sha256Hex("");
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+  if (credential.sessionToken) headers["x-amz-security-token"] = credential.sessionToken;
+  const signedHeaders = Object.keys(headers).sort().join(";");
+  const canonicalHeaders = Object.keys(headers).sort().map((name) => `${name}:${headers[name]}\n`).join("");
+  const canonicalQuery = Array.from(url.searchParams.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join("&");
+  const canonicalRequest = [
+    method,
+    url.pathname || "/",
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${credential.secretAccessKey}`, dateStamp), config.region), "s3"), "aws4_request");
+  const signature = createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+  return {
+    Host: headers.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+    ...(credential.sessionToken ? { "x-amz-security-token": credential.sessionToken } : {}),
+    Authorization: `AWS4-HMAC-SHA256 Credential=${credential.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, "\"")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function xmlText(block: string, tag: string): string | undefined {
+  const match = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(block);
+  return match ? decodeXml(match[1] ?? "") : undefined;
+}
+
+function shouldIngestS3Object(candidate: S3ObjectCandidate, config: S3SourceConfig): boolean {
+  if (candidate.size <= 0 || candidate.size > config.maxFileBytes) return false;
+  const lowerKey = candidate.key.toLowerCase();
+  return config.extensions.some((extension) => lowerKey.endsWith(extension));
+}
+
+async function fetchS3Text(fetchFn: typeof fetch, url: URL, config: S3SourceConfig, credential: AwsAccessKeyCredential): Promise<string> {
+  const response = await fetchFn(url, { headers: signS3Request("GET", url, config, credential) });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const detail = text ? `: ${text.slice(0, 200)}` : "";
+    throw new Error(`S3 request failed (${response.status})${detail}`);
+  }
+  return response.text();
+}
+
+async function fetchS3Candidates(
+  fetchFn: typeof fetch,
+  config: S3SourceConfig,
+  credential: AwsAccessKeyCredential,
+): Promise<S3ObjectCandidate[]> {
+  const url = new URL(`https://${s3Host(config)}/`);
+  url.searchParams.set("list-type", "2");
+  url.searchParams.set("max-keys", String(config.maxFiles));
+  if (config.prefix) url.searchParams.set("prefix", config.prefix);
+  const xml = await fetchS3Text(fetchFn, url, config, credential);
+  const objects: S3ObjectCandidate[] = [];
+  const matches = xml.matchAll(/<Contents>([\s\S]*?)<\/Contents>/g);
+  for (const match of matches) {
+    const block = match[1] ?? "";
+    const key = xmlText(block, "Key");
+    const etag = xmlText(block, "ETag")?.replace(/^"|"$/g, "");
+    const size = Number(xmlText(block, "Size") ?? "0");
+    const lastModified = xmlText(block, "LastModified");
+    if (!key || !etag || !Number.isFinite(size)) continue;
+    objects.push({ key, etag, size, lastModified });
+    if (objects.length >= config.maxFiles) break;
+  }
+  return objects
+    .filter((candidate) => shouldIngestS3Object(candidate, config))
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .slice(0, config.maxFiles);
+}
+
+async function fetchS3File(
+  fetchFn: typeof fetch,
+  config: S3SourceConfig,
+  credential: AwsAccessKeyCredential,
+  candidate: S3ObjectCandidate,
+): Promise<S3SyncFile> {
+  if (candidate.size > config.maxFileBytes) throw new Error(`S3 object exceeds maxFileBytes: ${candidate.key}`);
+  const url = new URL(`https://${s3Host(config)}/${encodeS3KeyPath(candidate.key)}`);
+  const content = await fetchS3Text(fetchFn, url, config, credential);
+  if (Buffer.byteLength(content, "utf8") > config.maxFileBytes) throw new Error(`S3 object exceeds maxFileBytes: ${candidate.key}`);
+  if (!isSafeUploadedText(content)) throw new Error(`S3 object must be text: ${candidate.key}`);
+  if (content.trim().length === 0) throw new Error(`S3 object is empty: ${candidate.key}`);
+  return { ...candidate, content };
 }
 
 async function syncGithubContextSource(
@@ -1238,6 +1574,110 @@ async function syncGithubContextSource(
   };
 }
 
+async function syncS3ContextSource(
+  db: Db,
+  tenantId: string | null,
+  sourceRow: typeof contextSources.$inferSelect,
+  collection: typeof contextCollections.$inferSelect,
+  options: ContextSourceSyncOptions,
+): Promise<{ source: ContextSource; collection: ContextCollection; document: ContextDocument | null; blocks: ContextBlock[]; synced: boolean }> {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  if (!fetchFn) throw new Error("fetch is unavailable");
+  const metadata = parseMetadata(sourceRow.metadata);
+  const config = parseS3Config(metadata);
+  const credential = await resolveAwsCredential(db, tenantId, config.credentialId);
+  const syncedObjects = getSyncedS3Objects(metadata);
+  const candidates = await fetchS3Candidates(fetchFn, config, credential);
+  const changedCandidates = candidates.filter((candidate) => syncedObjects[candidate.key] !== candidate.etag);
+  const now = new Date();
+
+  if (changedCandidates.length === 0 && sourceRow.syncStatus === "synced") {
+    await db.update(contextSources).set({
+      lastSyncedAt: now,
+      lastError: null,
+      updatedAt: now,
+      metadata: JSON.stringify({
+        ...metadata,
+        s3LastSync: {
+          checkedAt: now.toISOString(),
+          matchedObjects: candidates.length,
+          changedObjects: 0,
+        },
+      }),
+    }).where(eq(contextSources.id, sourceRow.id)).run();
+    const unchangedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+    return {
+      source: sourceFromRow(unchangedSource ?? sourceRow),
+      collection: collectionFromRow(collection),
+      document: null,
+      blocks: [],
+      synced: false,
+    };
+  }
+
+  const allBlocks: ContextBlock[] = [];
+  let lastDocument: ContextDocument | null = null;
+  let latestCollection: ContextCollection = collectionFromRow(collection);
+  const nextSyncedObjects = { ...syncedObjects };
+
+  for (const candidate of changedCandidates) {
+    const file = await fetchS3File(fetchFn, config, credential, candidate);
+    const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
+      title: file.key,
+      text: file.content,
+      source: `source:${sourceRow.type}`,
+      sourceUri: `s3://${config.bucket}/${file.key}`,
+      metadata: {
+        ...metadata,
+        s3SyncedObjects: undefined,
+        contextSourceId: sourceRow.id,
+        contextSourceType: sourceRow.type,
+        externalId: sourceRow.externalId,
+        s3Bucket: config.bucket,
+        s3Region: config.region,
+        s3Prefix: config.prefix ?? null,
+        s3Key: file.key,
+        s3Etag: file.etag,
+        s3Size: file.size,
+        s3LastModified: file.lastModified ?? null,
+      },
+    });
+    nextSyncedObjects[file.key] = file.etag;
+    latestCollection = result.collection;
+    lastDocument = result.document;
+    allBlocks.push(...result.blocks);
+  }
+
+  await db.update(contextSources).set({
+    syncStatus: "synced",
+    lastSyncedAt: now,
+    lastDocumentId: lastDocument?.id ?? sourceRow.lastDocumentId,
+    documentCount: sourceRow.documentCount + changedCandidates.length,
+    lastError: null,
+    contentHash: hashContent(candidates.map((candidate) => `${candidate.key}:${candidate.etag}`).join("\n")),
+    metadata: JSON.stringify({
+      ...metadata,
+      s3SyncedObjects: nextSyncedObjects,
+      s3LastSync: {
+        checkedAt: now.toISOString(),
+        matchedObjects: candidates.length,
+        changedObjects: changedCandidates.length,
+      },
+    }),
+    updatedAt: now,
+  }).where(eq(contextSources.id, sourceRow.id)).run();
+
+  const syncedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+  if (!syncedSource) throw new Error("Failed to sync context source");
+  return {
+    source: sourceFromRow(syncedSource),
+    collection: latestCollection,
+    document: lastDocument,
+    blocks: allBlocks,
+    synced: changedCandidates.length > 0,
+  };
+}
+
 export async function syncContextSource(
   db: Db,
   tenantId: string | null,
@@ -1254,6 +1694,21 @@ export async function syncContextSource(
     const now = new Date();
     try {
       return await syncGithubContextSource(db, tenantId, sourceRow, collection, options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to sync context source";
+      await db.update(contextSources).set({
+        syncStatus: "failed",
+        lastError: message,
+        updatedAt: now,
+      }).where(eq(contextSources.id, sourceId)).run();
+      throw new Error(message);
+    }
+  }
+
+  if (sourceRow.type === "s3_bucket") {
+    const now = new Date();
+    try {
+      return await syncS3ContextSource(db, tenantId, sourceRow, collection, options);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to sync context source";
       await db.update(contextSources).set({

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -93,6 +93,13 @@ function githubJson(value: unknown, status = 200): Response {
   });
 }
 
+function s3Xml(value: string, status = 200): Response {
+  return new Response(value, {
+    status,
+    headers: { "Content-Type": "application/xml" },
+  });
+}
+
 describe("context optimizer core", () => {
   it("drops exact duplicate chunks and reports token savings", () => {
     const result = optimizeContextChunks([
@@ -1983,6 +1990,190 @@ describe("managed context collections", () => {
       body: JSON.stringify({ name: "GitHub Docs", type: "github_token", value: "ghp_secret_token_123" }),
     });
     expect(createRes.status).toBe(503);
+  });
+
+  it("creates and idempotently syncs S3 bucket sources with AWS credentials", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const s3Fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toContain("AWS4-HMAC-SHA256");
+      if (url.includes("list-type=2")) {
+        return s3Xml(`<?xml version="1.0" encoding="UTF-8"?>
+          <ListBucketResult>
+            <Contents><Key>docs/readme.md</Key><LastModified>2026-05-01T00:00:00.000Z</LastModified><ETag>"etag-readme"</ETag><Size>54</Size></Contents>
+            <Contents><Key>docs/api.txt</Key><LastModified>2026-05-01T00:00:00.000Z</LastModified><ETag>"etag-api"</ETag><Size>40</Size></Contents>
+            <Contents><Key>docs/image.png</Key><ETag>"etag-image"</ETag><Size>10</Size></Contents>
+          </ListBucketResult>`);
+      }
+      if (url.endsWith("/docs/readme.md")) {
+        return new Response("Refunds are available within 30 days from S3 docs.");
+      }
+      if (url.endsWith("/docs/api.txt")) {
+        return new Response("API clients should send account identifiers.");
+      }
+      return s3Xml("<Error>not found</Error>", 404);
+    });
+    const app = buildApp(db, undefined, { githubFetch: s3Fetch });
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "AWS Docs",
+        type: "aws_access_key",
+        value: JSON.stringify({ accessKeyId: "AKIA_TEST", secretAccessKey: "secret-test" }),
+      }),
+    });
+    expect(credentialRes.status).toBe(201);
+    const credentialBody = await credentialRes.json() as { credential: { id: string; type: string; hasSecret: boolean; value?: string } };
+    expect(credentialBody.credential).toMatchObject({ type: "aws_access_key", hasSecret: true });
+    expect(credentialBody.credential.value).toBeUndefined();
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "S3 KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Docs bucket",
+        type: "s3_bucket",
+        s3: {
+          bucket: "acme-docs",
+          region: "us-east-1",
+          prefix: "docs",
+          credentialId: credentialBody.credential.id,
+          extensions: [".md", ".txt"],
+          maxFiles: 10,
+          maxFileBytes: 1_000,
+        },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as { source: { id: string; type: string; metadata: Record<string, unknown> } };
+    expect(sourceBody.source.type).toBe("s3_bucket");
+    expect(sourceBody.source.metadata.s3).toMatchObject({ bucket: "acme-docs", region: "us-east-1", prefix: "docs" });
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const syncBody = await syncRes.json() as {
+      synced: boolean;
+      source: { syncStatus: string; documentCount: number; metadata: Record<string, unknown> };
+      collection: { documentCount: number; blockCount: number };
+      document: { source: string };
+      blocks: Array<{ source: string; metadata: Record<string, unknown> }>;
+    };
+    expect(syncBody.synced).toBe(true);
+    expect(syncBody.source).toMatchObject({ syncStatus: "synced", documentCount: 2 });
+    expect(syncBody.collection).toMatchObject({ documentCount: 2, blockCount: 2 });
+    expect(syncBody.document.source).toBe("source:s3_bucket");
+    expect(syncBody.blocks).toHaveLength(2);
+    expect(syncBody.blocks[0]).toMatchObject({
+      source: "source:s3_bucket",
+      metadata: expect.objectContaining({ contextSourceId: sourceBody.source.id, s3Bucket: "acme-docs", s3Region: "us-east-1" }),
+    });
+    expect(syncBody.source.metadata.s3SyncedObjects).toMatchObject({
+      "docs/readme.md": "etag-readme",
+      "docs/api.txt": "etag-api",
+    });
+    const credentialRow = await db.select().from(contextConnectorCredentials).where(eq(contextConnectorCredentials.id, credentialBody.credential.id)).get();
+    expect(credentialRow?.lastUsedAt).toBeInstanceOf(Date);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+
+    const syncAgainRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncAgainRes.status).toBe(200);
+    const syncAgainBody = await syncAgainRes.json() as { synced: boolean; source: { documentCount: number }; document: unknown; blocks: unknown[] };
+    expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 2 }, document: null, blocks: [] });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+    expect(s3Fetch.mock.calls.filter(([url]) => !String(url).includes("list-type=2"))).toHaveLength(2);
+  });
+
+  it("does not allow an S3 source to bind another tenant's AWS credential", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({
+        name: "Other AWS",
+        type: "aws_access_key",
+        value: JSON.stringify({ accessKeyId: "AKIA_OTHER", secretAccessKey: "other-secret" }),
+      }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "S3 Tenant Guard KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Blocked bucket",
+        type: "s3_bucket",
+        s3: { bucket: "acme-docs", region: "us-east-1", credentialId: credentialBody.credential.id },
+      }),
+    });
+    expect(sourceRes.status).toBe(404);
+  });
+
+  it("persists failed S3 source sync status without writing documents", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const s3Fetch = vi.fn(async () => s3Xml("<Error>access denied</Error>", 403));
+    const app = buildApp(db, undefined, { githubFetch: s3Fetch });
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "AWS Docs",
+        type: "aws_access_key",
+        value: JSON.stringify({ accessKeyId: "AKIA_TEST", secretAccessKey: "secret-test" }),
+      }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "S3 Failure KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Broken bucket",
+        type: "s3_bucket",
+        s3: { bucket: "acme-docs", region: "us-east-1", credentialId: credentialBody.credential.id },
+      }),
+    });
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(500);
+    const rows = await db.select().from(contextSources).all();
+    expect(rows).toEqual([
+      expect.objectContaining({ type: "s3_bucket", syncStatus: "failed", documentCount: 0 }),
+    ]);
+    expect(rows[0]?.lastError).toContain("S3 request failed (403)");
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
   });
 
   it("creates and idempotently syncs GitHub repository sources", async () => {


### PR DESCRIPTION
## Summary
- Add `s3_bucket` context sources with bounded validation.
- Add encrypted `aws_access_key` connector credentials scoped by tenant.
- Add SigV4 S3 ListObjectsV2/GetObject sync with ETag idempotency and provenance metadata.
- Add dashboard AWS credential and S3 source setup flows.
- Update OpenAPI, docs, roadmap, changelog, and test coverage.

## Verification
- `npm test --workspace @provara/gateway -- context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npm test --workspace @provara/gateway`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #387

Last-code-by: Codex/GPT-5 (codex)