### PR TITLE
feat(#389): add Confluence context connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable Provara changes are tracked here.
   - Context dashboard connector management for creating GitHub credentials, creating GitHub repository sources, and manually syncing source rows without rendering secrets.
   - File upload connector v1 with bounded text upload validation, sanitized filename metadata, idempotent source sync, OpenAPI coverage, and dashboard creation controls.
   - S3 connector v1 with encrypted AWS access-key credentials, SigV4 ListObjectsV2/GetObject sync, prefix/extension/file-size/file-count bounds, ETag idempotency, OpenAPI coverage, and dashboard creation controls.
+  - Confluence connector v1 with encrypted API-token credentials, bounded Confluence Cloud page search, storage-body text extraction, page-version idempotency, OpenAPI coverage, and dashboard creation controls.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.
@@ -51,7 +52,7 @@ All notable Provara changes are tracked here.
 
 ### Changed
 
-- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, dashboard connector management, file upload connector v1, and S3 connector v1 as shipped checkpoints.
+- Context Optimizer roadmap now marks V1 runtime optimization, V1.1 dashboard visibility, risk-aware optimization, V1.2 quality scoring, retrieval analytics, semantic near-duplicate detection, lexical relevance reranking, embedding relevance reranking, stale-context detection, conflicting-context detection, scored contradiction bands, extractive and abstractive compression, dashboard configuration controls, managed context collections, canonical block distillation, canonical review audit trails, canonical policy checks, bulk review actions, context governance alerts, connector ingestion foundation, GitHub repository connector v1, connector credential auth foundation, dashboard connector management, file upload connector v1, S3 connector v1, and Confluence connector v1 as shipped checkpoints.
 - Guardrails documentation now treats Prompt Injection Firewalling as a first-class guardrails capability.
 - The Guardrails dashboard custom-rule creation button now lives beside the Custom Rules table.
 - Streaming tool-call responses can buffer tool-call deltas until alignment checks pass.

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -207,7 +207,7 @@ export interface ContextSource {
   id: string;
   collectionId: string;
   name: string;
-  type: "manual" | "github_repository" | "file_upload" | "s3_bucket";
+  type: "manual" | "github_repository" | "file_upload" | "s3_bucket" | "confluence_space";
   externalId: string | null;
   sourceUri: string | null;
   syncStatus: "pending" | "synced" | "failed";
@@ -223,7 +223,7 @@ export interface ContextConnectorCredential {
   id: string;
   tenantId: string;
   name: string;
-  type: "github_token" | "aws_access_key";
+  type: "github_token" | "aws_access_key" | "confluence_api_token";
   hasSecret: boolean;
   lastUsedAt: string | null;
   createdAt: string;
@@ -327,6 +327,7 @@ function formatContextSourceType(type: ContextSource["type"]): string {
   if (type === "github_repository") return "GitHub";
   if (type === "file_upload") return "File Upload";
   if (type === "s3_bucket") return "S3";
+  if (type === "confluence_space") return "Confluence";
   return "Manual";
 }
 
@@ -359,12 +360,25 @@ function formatContextSourceDetail(source: ContextSource): string {
     const prefix = typeof s3.prefix === "string" && s3.prefix ? `/${s3.prefix}` : "";
     if (bucket) return `s3://${bucket}${prefix}${region ? ` (${region})` : ""}`;
   }
+  if (source.type === "confluence_space") {
+    const confluence = typeof source.metadata.confluence === "object" && source.metadata.confluence !== null && !Array.isArray(source.metadata.confluence)
+      ? source.metadata.confluence as Record<string, unknown>
+      : {};
+    const baseUrl = typeof confluence.baseUrl === "string" ? confluence.baseUrl : "";
+    const spaceKey = typeof confluence.spaceKey === "string" ? confluence.spaceKey : "";
+    const labels = Array.isArray(confluence.labels) ? confluence.labels.filter((label): label is string => typeof label === "string") : [];
+    if (baseUrl && spaceKey) return `${baseUrl}/wiki/spaces/${spaceKey}${labels.length > 0 ? ` (${labels.join(", ")})` : ""}`;
+  }
   return source.sourceUri || source.externalId || source.id;
 }
 
 function contextSourceHasAuth(source: ContextSource): boolean {
-  if (source.type !== "github_repository" && source.type !== "s3_bucket") return false;
-  const credentialMetadata = source.type === "github_repository" ? source.metadata.github : source.metadata.s3;
+  if (source.type !== "github_repository" && source.type !== "s3_bucket" && source.type !== "confluence_space") return false;
+  const credentialMetadata = source.type === "github_repository"
+    ? source.metadata.github
+    : source.type === "s3_bucket"
+      ? source.metadata.s3
+      : source.metadata.confluence;
   const connector = typeof credentialMetadata === "object" && credentialMetadata !== null && !Array.isArray(credentialMetadata)
     ? credentialMetadata as Record<string, unknown>
     : {};
@@ -677,6 +691,9 @@ export function ContextOptimizerPanel() {
   const [awsCredentialDraft, setAwsCredentialDraft] = useState({ name: "", accessKeyId: "", secretAccessKey: "", sessionToken: "" });
   const [awsCredentialSubmitting, setAwsCredentialSubmitting] = useState(false);
   const [awsCredentialMessage, setAwsCredentialMessage] = useState<string | null>(null);
+  const [confluenceCredentialDraft, setConfluenceCredentialDraft] = useState({ name: "", email: "", apiToken: "" });
+  const [confluenceCredentialSubmitting, setConfluenceCredentialSubmitting] = useState(false);
+  const [confluenceCredentialMessage, setConfluenceCredentialMessage] = useState<string | null>(null);
   const [sourceDraft, setSourceDraft] = useState({
     name: "",
     owner: "",
@@ -702,6 +719,18 @@ export function ContextOptimizerPanel() {
   });
   const [s3Submitting, setS3Submitting] = useState(false);
   const [s3Message, setS3Message] = useState<string | null>(null);
+  const [confluenceDraft, setConfluenceDraft] = useState({
+    name: "",
+    baseUrl: "",
+    spaceKey: "",
+    labels: "",
+    titleContains: "",
+    maxPages: "100",
+    maxPageBytes: "250000",
+    credentialId: "",
+  });
+  const [confluenceSubmitting, setConfluenceSubmitting] = useState(false);
+  const [confluenceMessage, setConfluenceMessage] = useState<string | null>(null);
   const [fileDraft, setFileDraft] = useState({
     name: "",
     filename: "",
@@ -881,6 +910,7 @@ export function ContextOptimizerPanel() {
   const credentialRows = useMemo(() => state.credentials, [state.credentials]);
   const githubCredentialRows = useMemo(() => credentialRows.filter((credential) => credential.type === "github_token"), [credentialRows]);
   const awsCredentialRows = useMemo(() => credentialRows.filter((credential) => credential.type === "aws_access_key"), [credentialRows]);
+  const confluenceCredentialRows = useMemo(() => credentialRows.filter((credential) => credential.type === "confluence_api_token"), [credentialRows]);
   const canonicalRows = useMemo(() => state.canonicalBlocks, [state.canonicalBlocks]);
   const firstCollection = collectionRows[0] ?? null;
   const visibleCanonicalRows = useMemo(() => canonicalRows.slice(0, 10), [canonicalRows]);
@@ -983,6 +1013,41 @@ export function ContextOptimizerPanel() {
     }
   }
 
+  async function createConfluenceCredential() {
+    if (!confluenceCredentialDraft.name.trim() || !confluenceCredentialDraft.email.trim() || !confluenceCredentialDraft.apiToken.trim()) return;
+    setConfluenceCredentialSubmitting(true);
+    setConfluenceCredentialMessage(null);
+    try {
+      const res = await gatewayFetchRaw("/v1/context/credentials", {
+        method: "POST",
+        body: JSON.stringify({
+          name: confluenceCredentialDraft.name.trim(),
+          type: "confluence_api_token",
+          value: JSON.stringify({
+            email: confluenceCredentialDraft.email.trim(),
+            apiToken: confluenceCredentialDraft.apiToken,
+          }),
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to save Confluence credential");
+      const body = await res.json() as { credential: ContextConnectorCredential };
+      setState((prev) => ({
+        ...prev,
+        credentials: [
+          body.credential,
+          ...prev.credentials.filter((credential) => credential.id !== body.credential.id),
+        ],
+      }));
+      setConfluenceCredentialDraft({ name: "", email: "", apiToken: "" });
+      setConfluenceDraft((prev) => ({ ...prev, credentialId: body.credential.id }));
+      setConfluenceCredentialMessage("Confluence credential saved.");
+    } catch (err) {
+      setConfluenceCredentialMessage(err instanceof Error ? err.message : "Failed to save Confluence credential");
+    } finally {
+      setConfluenceCredentialSubmitting(false);
+    }
+  }
+
   async function createGitHubSource() {
     if (!firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()) return;
     setSourceSubmitting(true);
@@ -1065,6 +1130,45 @@ export function ContextOptimizerPanel() {
       setS3Message(err instanceof Error ? err.message : "Failed to create S3 source");
     } finally {
       setS3Submitting(false);
+    }
+  }
+
+  async function createConfluenceSource() {
+    if (!firstCollection || !confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId) return;
+    setConfluenceSubmitting(true);
+    setConfluenceMessage(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+        method: "POST",
+        body: JSON.stringify({
+          name: confluenceDraft.name.trim(),
+          type: "confluence_space",
+          confluence: {
+            baseUrl: confluenceDraft.baseUrl.trim(),
+            spaceKey: confluenceDraft.spaceKey.trim(),
+            labels: parseCsv(confluenceDraft.labels),
+            titleContains: confluenceDraft.titleContains.trim() || undefined,
+            credentialId: confluenceDraft.credentialId,
+            maxPages: Number(confluenceDraft.maxPages) || 100,
+            maxPageBytes: Number(confluenceDraft.maxPageBytes) || 250000,
+          },
+        }),
+      });
+      if (!res.ok) throw new Error("Failed to create Confluence source");
+      const body = await res.json() as { source: ContextSource };
+      setState((prev) => ({
+        ...prev,
+        sources: [
+          body.source,
+          ...prev.sources.filter((source) => source.id !== body.source.id),
+        ],
+      }));
+      setConfluenceDraft((prev) => ({ ...prev, name: "", spaceKey: "", labels: "", titleContains: "" }));
+      setConfluenceMessage("Confluence source created.");
+    } catch (err) {
+      setConfluenceMessage(err instanceof Error ? err.message : "Failed to create Confluence source");
+    } finally {
+      setConfluenceSubmitting(false);
     }
   }
 
@@ -1337,7 +1441,7 @@ export function ContextOptimizerPanel() {
       <section>
         <div className="mb-3">
           <h2 className="text-lg font-semibold text-zinc-100">Connector Management</h2>
-          <p className="mt-1 text-sm text-zinc-500">Credential metadata, S3 buckets, GitHub repository sources, file upload sources, and manual source sync controls.</p>
+          <p className="mt-1 text-sm text-zinc-500">Credential metadata, Confluence spaces, S3 buckets, GitHub repository sources, file upload sources, and manual source sync controls.</p>
         </div>
 
         <div className="grid gap-4 lg:grid-cols-2">
@@ -1473,6 +1577,53 @@ export function ContextOptimizerPanel() {
                 {awsCredentialSubmitting ? "Saving..." : "Save AWS Credential"}
               </button>
               {awsCredentialMessage && <span className="text-xs text-zinc-400">{awsCredentialMessage}</span>}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">Confluence API Token Credential</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-confluence-credential-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Confluence Credential Name</label>
+                <input
+                  id="context-confluence-credential-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceCredentialDraft.name}
+                  onChange={(event) => setConfluenceCredentialDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-confluence-email" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Email</label>
+                <input
+                  id="context-confluence-email"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceCredentialDraft.email}
+                  onChange={(event) => setConfluenceCredentialDraft((prev) => ({ ...prev, email: event.target.value }))}
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <label htmlFor="context-confluence-api-token" className="text-xs font-medium uppercase tracking-wider text-zinc-500">API Token</label>
+                <input
+                  id="context-confluence-api-token"
+                  type="password"
+                  autoComplete="off"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceCredentialDraft.apiToken}
+                  onChange={(event) => setConfluenceCredentialDraft((prev) => ({ ...prev, apiToken: event.target.value }))}
+                />
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={confluenceCredentialSubmitting || !confluenceCredentialDraft.name.trim() || !confluenceCredentialDraft.email.trim() || !confluenceCredentialDraft.apiToken.trim()}
+                onClick={() => void createConfluenceCredential()}
+              >
+                {confluenceCredentialSubmitting ? "Saving..." : "Save Confluence Credential"}
+              </button>
+              {confluenceCredentialMessage && <span className="text-xs text-zinc-400">{confluenceCredentialMessage}</span>}
             </div>
           </div>
 
@@ -1616,6 +1767,106 @@ export function ContextOptimizerPanel() {
                 {s3Submitting ? "Creating..." : "Create S3 Source"}
               </button>
               {s3Message && <span className="text-xs text-zinc-400">{s3Message}</span>}
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+            <h3 className="text-sm font-semibold text-zinc-100">Confluence Source</h3>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div>
+                <label htmlFor="context-confluence-source-name" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Confluence Source Name</label>
+                <input
+                  id="context-confluence-source-name"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.name}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, name: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-confluence-credential" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Confluence Credential</label>
+                <select
+                  id="context-confluence-credential"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.credentialId}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, credentialId: event.target.value }))}
+                >
+                  <option value="">Select credential</option>
+                  {confluenceCredentialRows.map((credential) => (
+                    <option key={credential.id} value={credential.id}>{credential.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="context-confluence-base-url" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Base URL</label>
+                <input
+                  id="context-confluence-base-url"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.baseUrl}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, baseUrl: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-confluence-space-key" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Space Key</label>
+                <input
+                  id="context-confluence-space-key"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.spaceKey}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, spaceKey: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-confluence-labels" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Labels</label>
+                <input
+                  id="context-confluence-labels"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.labels}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, labels: event.target.value }))}
+                />
+              </div>
+              <div>
+                <label htmlFor="context-confluence-title-filter" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Title Filter</label>
+                <input
+                  id="context-confluence-title-filter"
+                  className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                  value={confluenceDraft.titleContains}
+                  onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, titleContains: event.target.value }))}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label htmlFor="context-confluence-max-pages" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Max Pages</label>
+                  <input
+                    id="context-confluence-max-pages"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={confluenceDraft.maxPages}
+                    onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, maxPages: event.target.value }))}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="context-confluence-max-bytes" className="text-xs font-medium uppercase tracking-wider text-zinc-500">Confluence Max Bytes</label>
+                  <input
+                    id="context-confluence-max-bytes"
+                    type="number"
+                    min="1"
+                    className="mt-1 w-full rounded-md border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-blue-600"
+                    value={confluenceDraft.maxPageBytes}
+                    onChange={(event) => setConfluenceDraft((prev) => ({ ...prev, maxPageBytes: event.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="mt-3 flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={confluenceSubmitting || !firstCollection || !confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId}
+                onClick={() => void createConfluenceSource()}
+              >
+                {confluenceSubmitting ? "Creating..." : "Create Confluence Source"}
+              </button>
+              {confluenceMessage && <span className="text-xs text-zinc-400">{confluenceMessage}</span>}
             </div>
           </div>
 

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -202,6 +202,16 @@ describe("ContextOptimizerPanel", () => {
               createdAt: "2026-05-01T20:00:00.000Z",
               updatedAt: "2026-05-01T22:04:00.000Z",
             },
+            {
+              id: "cred-confluence",
+              tenantId: "tenant-pro",
+              name: "Confluence Docs",
+              type: "confluence_api_token",
+              hasSecret: true,
+              lastUsedAt: null,
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T22:04:00.000Z",
+            },
           ],
         }));
       }
@@ -296,6 +306,21 @@ describe("ContextOptimizerPanel", () => {
               lastError: null,
               metadata: { s3: { bucket: "acme-docs", region: "us-east-1", prefix: "docs", credentialId: "cred-aws" } },
               updatedAt: "2026-05-01T22:06:00.000Z",
+            },
+            {
+              id: "source-5",
+              collectionId: "collection-1",
+              name: "Support space",
+              type: "confluence_space",
+              externalId: "confluence:https://acme.atlassian.net:SUP:policy:",
+              sourceUri: "https://acme.atlassian.net/wiki/spaces/SUP",
+              syncStatus: "synced",
+              lastSyncedAt: "2026-05-01T22:07:00.000Z",
+              lastDocumentId: "doc-confluence",
+              documentCount: 2,
+              lastError: null,
+              metadata: { confluence: { baseUrl: "https://acme.atlassian.net", spaceKey: "SUP", labels: ["policy"], credentialId: "cred-confluence" } },
+              updatedAt: "2026-05-01T22:07:00.000Z",
             },
           ],
         }));
@@ -572,6 +597,29 @@ describe("ContextOptimizerPanel", () => {
             },
           }));
         }
+        if (parsed.type === "confluence_api_token") {
+          const value = JSON.parse(String(parsed.value)) as Record<string, unknown>;
+          expect(parsed).toMatchObject({
+            name: "Confluence token",
+            type: "confluence_api_token",
+          });
+          expect(value).toMatchObject({
+            email: "docs@example.com",
+            apiToken: "conf_secret_123",
+          });
+          return Promise.resolve(jsonResponse({
+            credential: {
+              id: "cred-confluence-new",
+              tenantId: "tenant-pro",
+              name: "Confluence token",
+              type: "confluence_api_token",
+              hasSecret: true,
+              lastUsedAt: null,
+              createdAt: "2026-05-01T22:10:00.000Z",
+              updatedAt: "2026-05-01T22:10:00.000Z",
+            },
+          }));
+        }
         expect(parsed).toMatchObject({
           name: "Docs token",
           type: "github_token",
@@ -651,6 +699,38 @@ describe("ContextOptimizerPanel", () => {
               documentCount: 0,
               lastError: null,
               metadata: { s3: { bucket: "acme-docs", region: "us-east-1", prefix: "docs", credentialId: "cred-aws-new" } },
+              updatedAt: "2026-05-01T22:10:00.000Z",
+            },
+          }));
+        }
+        if (parsed.type === "confluence_space") {
+          expect(parsed).toMatchObject({
+            name: "Support space",
+            type: "confluence_space",
+            confluence: {
+              baseUrl: "https://acme.atlassian.net",
+              spaceKey: "SUP",
+              labels: ["policy"],
+              titleContains: "Refund",
+              credentialId: "cred-confluence-new",
+              maxPages: 25,
+              maxPageBytes: 125000,
+            },
+          });
+          return Promise.resolve(jsonResponse({
+            source: {
+              id: "source-confluence",
+              collectionId: "collection-1",
+              name: "Support space",
+              type: "confluence_space",
+              externalId: "confluence:https://acme.atlassian.net:SUP:policy:Refund",
+              sourceUri: "https://acme.atlassian.net/wiki/spaces/SUP",
+              syncStatus: "pending",
+              lastSyncedAt: null,
+              lastDocumentId: null,
+              documentCount: 0,
+              lastError: null,
+              metadata: { confluence: { baseUrl: "https://acme.atlassian.net", spaceKey: "SUP", labels: ["policy"], titleContains: "Refund", credentialId: "cred-confluence-new" } },
               updatedAt: "2026-05-01T22:10:00.000Z",
             },
           }));
@@ -815,6 +895,15 @@ describe("ContextOptimizerPanel", () => {
     expect(screen.getAllByText("AWS token").length).toBeGreaterThan(0);
     expect(document.body.textContent).not.toContain("aws_secret_123");
 
+    fireEvent.change(screen.getByLabelText("Confluence Credential Name"), { target: { value: "Confluence token" } });
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "docs@example.com" } });
+    fireEvent.change(screen.getByLabelText("API Token"), { target: { value: "conf_secret_123" } });
+    fireEvent.click(screen.getByText("Save Confluence Credential"));
+
+    expect(await screen.findByText("Confluence credential saved.")).toBeInTheDocument();
+    expect(screen.getAllByText("Confluence token").length).toBeGreaterThan(0);
+    expect(document.body.textContent).not.toContain("conf_secret_123");
+
     const upload = new File(["Uploaded guide content for context."], "guide.md", { type: "text/markdown" });
     fireEvent.change(screen.getByLabelText("File"), { target: { files: [upload] } });
     expect(await screen.findByText("File loaded.")).toBeInTheDocument();
@@ -837,6 +926,18 @@ describe("ContextOptimizerPanel", () => {
 
     expect(await screen.findByText("S3 source created.")).toBeInTheDocument();
     expect(screen.getAllByText("s3://acme-docs/docs (us-east-1)").length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText("Confluence Source Name"), { target: { value: "Support space" } });
+    fireEvent.change(screen.getByLabelText("Base URL"), { target: { value: "https://acme.atlassian.net" } });
+    fireEvent.change(screen.getByLabelText("Space Key"), { target: { value: "SUP" } });
+    fireEvent.change(screen.getByLabelText("Labels"), { target: { value: "policy" } });
+    fireEvent.change(screen.getByLabelText("Title Filter"), { target: { value: "Refund" } });
+    fireEvent.change(screen.getByLabelText("Max Pages"), { target: { value: "25" } });
+    fireEvent.change(screen.getByLabelText("Confluence Max Bytes"), { target: { value: "125000" } });
+    fireEvent.click(screen.getByText("Create Confluence Source"));
+
+    expect(await screen.findByText("Confluence source created.")).toBeInTheDocument();
+    expect(screen.getAllByText("https://acme.atlassian.net/wiki/spaces/SUP (policy)").length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByLabelText("GitHub Source Name"), { target: { value: "Docs repo" } });
     fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "acme" } });

--- a/docs/context-optimizer-roadmap.md
+++ b/docs/context-optimizer-roadmap.md
@@ -41,6 +41,7 @@ Implemented as of `0.2.0`:
 - Dashboard connector management for GitHub credential creation, GitHub source creation, and manual source sync.
 - File upload connector v1 with bounded text upload validation, sanitized file metadata, idempotent source sync, and dashboard creation controls.
 - S3 connector v1 with encrypted AWS access-key credentials, bounded object selection, ETag idempotency, and dashboard creation controls.
+- Confluence connector v1 with encrypted API-token credentials, bounded page search, storage-body text extraction, page-version idempotency, and dashboard creation controls.
 
 Next planned layer:
 - Additional external connector implementations.
@@ -142,9 +143,9 @@ Foundation shipped:
 - Dashboard controls for creating GitHub credentials and repository sources, plus manual sync from source rows.
 - Bounded file upload source creation for local text/markdown knowledge without external OAuth.
 - S3 bucket source creation and listing with AWS SigV4 sync, prefix/extension/file-size/file-count bounds, and ETag-based idempotency.
+- Confluence space source creation and listing with Confluence Cloud content search, label/title filters, page-size/page-count bounds, storage-body text extraction, and page-version idempotency.
 
 Candidate connectors:
-- Confluence.
 - Google Drive.
 - SharePoint.
 - Notion.

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -21,15 +21,15 @@ The shipped V1 implementation is intentionally narrow:
 - Raw-context vs optimized-context quality scoring with the configured judge model.
 - Retrieval analytics for used, unused, duplicate, and risky retrieved chunks.
 - Managed context collections with plain-text ingestion into reusable blocks.
-- Connector ingestion with tenant-scoped manual, file upload, GitHub repository, and S3 bucket sources plus encrypted connector credentials.
+- Connector ingestion with tenant-scoped manual, file upload, GitHub repository, S3 bucket, and Confluence space sources plus encrypted connector credentials.
 - Canonical context block distillation with review status and approved-only export.
 - Canonical review audit events with reviewer notes and actor attribution when available.
 - Tenant-scoped optimization events for reporting.
 - Dashboard visibility at `/dashboard/context`.
 - Dashboard configuration controls for composing and copying an optimization request payload.
-- Dashboard connector management for GitHub credentials, AWS credentials, file upload source creation, S3 bucket source creation, GitHub repository source creation, and manual source sync.
+- Dashboard connector management for GitHub credentials, AWS credentials, Confluence credentials, file upload source creation, S3 bucket source creation, Confluence space source creation, GitHub repository source creation, and manual source sync.
 
-It does not yet perform connector pulls from systems such as Confluence or Drive. Those belong to later roadmap phases.
+It does not yet perform connector pulls from systems such as Drive, SharePoint, Notion, or help centers. Those belong to later roadmap phases.
 
 ## API
 
@@ -191,7 +191,27 @@ S3 bucket sources use `type: "s3_bucket"` with an `s3` config object:
 
 S3 sync uses AWS Signature Version 4 against S3 ListObjectsV2 and GetObject, bounds objects by extension/count/size, stores bucket/key/ETag metadata on ingested documents and blocks, and skips objects whose ETag has already synced.
 
-Connector credentials are tenant-scoped encrypted secrets. `POST /v1/context/credentials` accepts `type: "github_token"` and a token `value`, or `type: "aws_access_key"` with a JSON string containing `accessKeyId`, `secretAccessKey`, and optional `sessionToken`. Values are stored with the same AES-GCM master-key encryption used for provider API keys, and responses return only metadata plus `hasSecret: true`. `GET /v1/context/credentials` never returns raw secret values. GitHub sources can set `github.credentialId`; S3 sources must set `s3.credentialId`; sync decrypts the credential server-side and records missing or undecryptable credentials as failed source syncs.
+Confluence space sources use `type: "confluence_space"` with a `confluence` config object:
+
+```json
+{
+  "name": "Support space",
+  "type": "confluence_space",
+  "confluence": {
+    "baseUrl": "https://acme.atlassian.net",
+    "spaceKey": "SUP",
+    "credentialId": "credential-id",
+    "labels": ["policy"],
+    "titleContains": "Refund",
+    "maxPages": 100,
+    "maxPageBytes": 250000
+  }
+}
+```
+
+Confluence sync uses the Confluence Cloud content search API, bounds pages by count and storage-body byte size, extracts text from storage HTML, stores space/page/version metadata on ingested documents and blocks, and skips pages whose version number has already synced.
+
+Connector credentials are tenant-scoped encrypted secrets. `POST /v1/context/credentials` accepts `type: "github_token"` and a token `value`, `type: "aws_access_key"` with a JSON string containing `accessKeyId`, `secretAccessKey`, and optional `sessionToken`, or `type: "confluence_api_token"` with a JSON string containing `email` and `apiToken`. Values are stored with the same AES-GCM master-key encryption used for provider API keys, and responses return only metadata plus `hasSecret: true`. `GET /v1/context/credentials` never returns raw secret values. GitHub sources can set `github.credentialId`; S3 sources must set `s3.credentialId`; Confluence sources must set `confluence.credentialId`; sync decrypts the credential server-side and records missing or undecryptable credentials as failed source syncs.
 
 Distillation converts stored blocks into canonical blocks through local normalization and hash-based coalescing. Duplicate stored blocks collapse into a single canonical block with multiple `sourceBlockIds` and `sourceDocumentIds`. Canonical blocks start in `draft`, can be marked `approved` or `rejected`, and the export endpoint returns only approved blocks for downstream retrieval/vector workflows.
 
@@ -242,7 +262,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, create AWS access-key credentials, list credential metadata without secret values, create text file upload sources, create S3 bucket sources, create GitHub repository sources for the first managed collection, and bind external sources to stored credentials. The Collection Sources section shows manual, file upload, GitHub, and S3 sources for the first managed collection, including source URI, filename metadata, repo/branch/path, or bucket/prefix/region, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section lists persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, AWS access-key credentials, Confluence API-token credentials, list credential metadata without secret values, create text file upload sources, create S3 bucket sources, create Confluence space sources, create GitHub repository sources for the first managed collection, and bind external sources to stored credentials. The Collection Sources section shows manual, file upload, GitHub, S3, and Confluence sources for the first managed collection, including source URI, filename metadata, repo/branch/path, bucket/prefix/region, or Confluence base URL/space/labels, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Collection creation, manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
 
 The Recent Events table shows:
 
@@ -283,6 +303,5 @@ The public demo tenant (`t_demo`) seeds recent Context Optimizer events. This ke
 
 The next behavior layer is additional external connector ingestion:
 
-- Confluence, Google Drive, SharePoint, Notion, and Zendesk/Intercom connectors.
-- Source provenance and sync metadata for managed collections.
+- Google Drive, SharePoint, Notion, and Zendesk/Intercom connectors.
 - Connector-level review and policy defaults.

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -472,7 +472,7 @@ export const contextSources = sqliteTable("context_sources", {
     .notNull()
     .references(() => contextCollections.id),
   name: text("name").notNull(),
-  type: text("type", { enum: ["manual", "github_repository", "file_upload", "s3_bucket"] }).notNull().default("manual"),
+  type: text("type", { enum: ["manual", "github_repository", "file_upload", "s3_bucket", "confluence_space"] }).notNull().default("manual"),
   externalId: text("external_id"),
   sourceUri: text("source_uri"),
   content: text("content").notNull().default(""),
@@ -499,7 +499,7 @@ export const contextConnectorCredentials = sqliteTable("context_connector_creden
   id: text("id").primaryKey(),
   tenantId: text("tenant_id"),
   name: text("name").notNull(),
-  type: text("type", { enum: ["github_token", "aws_access_key"] }).notNull(),
+  type: text("type", { enum: ["github_token", "aws_access_key", "confluence_api_token"] }).notNull(),
   encryptedValue: text("encrypted_value").notNull(),
   iv: text("iv").notNull(),
   authTag: text("auth_tag").notNull(),

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -3075,7 +3075,7 @@ components:
           maxLength: 200
         type:
           type: string
-          enum: [manual, github_repository, file_upload, s3_bucket]
+          enum: [manual, github_repository, file_upload, s3_bucket, confluence_space]
         externalId:
           type: string
           maxLength: 2000
@@ -3092,6 +3092,8 @@ components:
           $ref: "#/components/schemas/FileUploadContextSourceConfig"
         s3:
           $ref: "#/components/schemas/S3ContextSourceConfig"
+        confluence:
+          $ref: "#/components/schemas/ConfluenceContextSourceConfig"
         metadata:
           type: object
           additionalProperties: true
@@ -3145,6 +3147,44 @@ components:
           maximum: 100
           default: 100
 
+    ConfluenceContextSourceConfig:
+      type: object
+      required: [baseUrl, spaceKey, credentialId]
+      properties:
+        baseUrl:
+          type: string
+          format: uri
+          description: HTTPS Confluence Cloud site URL, with or without the /wiki suffix.
+          maxLength: 300
+        spaceKey:
+          type: string
+          minLength: 1
+          maxLength: 120
+        credentialId:
+          type: string
+          description: Tenant-scoped confluence_api_token connector credential id.
+        labels:
+          type: array
+          description: Optional Confluence labels to include in the page search.
+          maxItems: 20
+          items:
+            type: string
+            maxLength: 80
+        titleContains:
+          type: string
+          description: Optional Confluence title search filter.
+          maxLength: 120
+        maxPageBytes:
+          type: integer
+          minimum: 1
+          maximum: 250000
+          default: 250000
+        maxPages:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 100
+
     CreateContextConnectorCredentialRequest:
       type: object
       required: [name, value]
@@ -3155,12 +3195,12 @@ components:
           maxLength: 120
         type:
           type: string
-          enum: [github_token, aws_access_key]
+          enum: [github_token, aws_access_key, confluence_api_token]
         value:
           type: string
           minLength: 1
           maxLength: 20000
-          description: Secret token value. For aws_access_key, pass a JSON string with accessKeyId, secretAccessKey, and optional sessionToken. Only accepted on write and never returned.
+          description: Secret token value. For aws_access_key, pass a JSON string with accessKeyId, secretAccessKey, and optional sessionToken. For confluence_api_token, pass a JSON string with email and apiToken. Only accepted on write and never returned.
 
     ContextConnectorCredential:
       type: object
@@ -3175,7 +3215,7 @@ components:
           type: string
         type:
           type: string
-          enum: [github_token, aws_access_key]
+          enum: [github_token, aws_access_key, confluence_api_token]
         hasSecret:
           type: boolean
         lastUsedAt:
@@ -3312,7 +3352,7 @@ components:
           type: string
         type:
           type: string
-          enum: [manual, github_repository, file_upload, s3_bucket]
+          enum: [manual, github_repository, file_upload, s3_bucket, confluence_space]
         externalId:
           type: string
           nullable: true

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -42,12 +42,19 @@ const MAX_S3_PREFIX_CHARS = 1_000;
 const MAX_S3_EXTENSION_CHARS = 24;
 const MAX_S3_FILE_BYTES = 250_000;
 const MAX_S3_FILES = 100;
+const MAX_CONFLUENCE_BASE_URL_CHARS = 300;
+const MAX_CONFLUENCE_EMAIL_CHARS = 320;
+const MAX_CONFLUENCE_SPACE_KEY_CHARS = 120;
+const MAX_CONFLUENCE_LABEL_CHARS = 80;
+const MAX_CONFLUENCE_TITLE_FILTER_CHARS = 120;
+const MAX_CONFLUENCE_PAGE_BYTES = 250_000;
+const MAX_CONFLUENCE_PAGES = 100;
 const TARGET_BLOCK_CHARS = 1_800;
 const MIN_BOUNDARY_CHARS = 900;
 const BLOCK_INSERT_BATCH_SIZE = 50;
 
-type ContextSourceType = "manual" | "github_repository" | "file_upload" | "s3_bucket";
-type ContextConnectorCredentialType = "github_token" | "aws_access_key";
+type ContextSourceType = "manual" | "github_repository" | "file_upload" | "s3_bucket" | "confluence_space";
+type ContextConnectorCredentialType = "github_token" | "aws_access_key" | "confluence_api_token";
 
 export interface GitHubSourceConfig {
   owner: string;
@@ -76,10 +83,25 @@ export interface S3SourceConfig {
   credentialId: string;
 }
 
+export interface ConfluenceSourceConfig {
+  baseUrl: string;
+  spaceKey: string;
+  labels: string[];
+  titleContains?: string;
+  maxPageBytes: number;
+  maxPages: number;
+  credentialId: string;
+}
+
 interface AwsAccessKeyCredential {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken?: string;
+}
+
+interface ConfluenceApiTokenCredential {
+  email: string;
+  apiToken: string;
 }
 
 export interface ContextConnectorCredential {
@@ -215,6 +237,7 @@ export interface CreateContextSourceInput {
   github?: GitHubSourceConfig;
   file?: FileUploadSourceConfig;
   s3?: S3SourceConfig;
+  confluence?: ConfluenceSourceConfig;
 }
 
 export interface CreateContextConnectorCredentialInput {
@@ -256,6 +279,19 @@ interface S3SyncFile extends S3ObjectCandidate {
   content: string;
 }
 
+interface ConfluencePageCandidate {
+  id: string;
+  title: string;
+  version: string;
+  bodyHtml: string;
+  webUrl: string;
+  sizeBytes: number;
+}
+
+interface ConfluenceSyncPage extends ConfluencePageCandidate {
+  content: string;
+}
+
 export interface ContextSourceSyncOptions {
   fetch?: typeof fetch;
   githubToken?: string;
@@ -292,6 +328,21 @@ function normalizeS3Prefix(value: string | undefined): string | undefined {
   return trimmed || undefined;
 }
 
+function normalizeConfluenceBaseUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_CONFLUENCE_BASE_URL_CHARS) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") return null;
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/+$/, "").replace(/\/wiki$/, "");
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
 function parseAwsCredentialValue(value: string): AwsAccessKeyCredential | null {
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -302,6 +353,20 @@ function parseAwsCredentialValue(value: string): AwsAccessKeyCredential | null {
     const sessionToken = typeof raw.sessionToken === "string" && raw.sessionToken.trim() ? raw.sessionToken.trim() : undefined;
     if (!accessKeyId || !secretAccessKey) return null;
     return { accessKeyId, secretAccessKey, sessionToken };
+  } catch {
+    return null;
+  }
+}
+
+function parseConfluenceCredentialValue(value: string): ConfluenceApiTokenCredential | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    const raw = parsed as Record<string, unknown>;
+    const email = typeof raw.email === "string" ? raw.email.trim() : "";
+    const apiToken = typeof raw.apiToken === "string" ? raw.apiToken.trim() : "";
+    if (!email || email.length > MAX_CONFLUENCE_EMAIL_CHARS || !apiToken) return null;
+    return { email, apiToken };
   } catch {
     return null;
   }
@@ -383,6 +448,30 @@ function parseS3Config(metadata: Record<string, unknown>): S3SourceConfig {
 
   if (!bucket || !region || !credentialId) throw new Error("s3 bucket, region, and credentialId are required");
   return { bucket, region, prefix, extensions, maxFileBytes, maxFiles, credentialId };
+}
+
+function parseConfluenceConfig(metadata: Record<string, unknown>): ConfluenceSourceConfig {
+  const confluence = metadata.confluence;
+  if (typeof confluence !== "object" || confluence === null || Array.isArray(confluence)) {
+    throw new Error("confluence source config is required");
+  }
+  const raw = confluence as Record<string, unknown>;
+  const baseUrl = typeof raw.baseUrl === "string" ? normalizeConfluenceBaseUrl(raw.baseUrl) : null;
+  const spaceKey = typeof raw.spaceKey === "string" ? raw.spaceKey.trim() : "";
+  const labels = Array.isArray(raw.labels)
+    ? raw.labels.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean).slice(0, 20)
+    : [];
+  const titleContains = typeof raw.titleContains === "string" && raw.titleContains.trim() ? raw.titleContains.trim() : undefined;
+  const maxPageBytes = typeof raw.maxPageBytes === "number" && Number.isFinite(raw.maxPageBytes)
+    ? Math.min(Math.max(Math.trunc(raw.maxPageBytes), 1), MAX_CONFLUENCE_PAGE_BYTES)
+    : MAX_CONFLUENCE_PAGE_BYTES;
+  const maxPages = typeof raw.maxPages === "number" && Number.isFinite(raw.maxPages)
+    ? Math.min(Math.max(Math.trunc(raw.maxPages), 1), MAX_CONFLUENCE_PAGES)
+    : MAX_CONFLUENCE_PAGES;
+  const credentialId = typeof raw.credentialId === "string" ? raw.credentialId.trim() : "";
+
+  if (!baseUrl || !spaceKey || !credentialId) throw new Error("confluence baseUrl, spaceKey, and credentialId are required");
+  return { baseUrl, spaceKey, labels, titleContains, maxPageBytes, maxPages, credentialId };
 }
 
 function credentialFromRow(row: typeof contextConnectorCredentials.$inferSelect): ContextConnectorCredential {
@@ -642,8 +731,8 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
   const type = body.type === undefined ? "manual" : body.type;
-  if (type !== "manual" && type !== "github_repository" && type !== "file_upload" && type !== "s3_bucket") {
-    return { error: "type must be manual, github_repository, file_upload, or s3_bucket" };
+  if (type !== "manual" && type !== "github_repository" && type !== "file_upload" && type !== "s3_bucket" && type !== "confluence_space") {
+    return { error: "type must be manual, github_repository, file_upload, s3_bucket, or confluence_space" };
   }
   const externalId = trimOptional(body.externalId, "externalId", MAX_SOURCE_URI_CHARS);
   if (externalId.error) return { error: externalId.error };
@@ -803,6 +892,66 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
     };
   }
 
+  let confluence: ConfluenceSourceConfig | undefined;
+  if (type === "confluence_space") {
+    if (typeof body.confluence !== "object" || body.confluence === null || Array.isArray(body.confluence)) {
+      return { error: "confluence config is required" };
+    }
+    const raw = body.confluence as Record<string, unknown>;
+    const baseUrl = trimOptional(raw.baseUrl, "confluence.baseUrl", MAX_CONFLUENCE_BASE_URL_CHARS);
+    if (baseUrl.error) return { error: baseUrl.error };
+    if (!baseUrl.value) return { error: "confluence.baseUrl is required" };
+    const normalizedBaseUrl = normalizeConfluenceBaseUrl(baseUrl.value);
+    if (!normalizedBaseUrl) return { error: "confluence.baseUrl must be an https URL" };
+    const spaceKey = trimOptional(raw.spaceKey, "confluence.spaceKey", MAX_CONFLUENCE_SPACE_KEY_CHARS);
+    if (spaceKey.error) return { error: spaceKey.error };
+    if (!spaceKey.value) return { error: "confluence.spaceKey is required" };
+    if (!/^[A-Za-z0-9_-]+$/.test(spaceKey.value)) return { error: "confluence.spaceKey is invalid" };
+    const credentialId = trimOptional(raw.credentialId, "confluence.credentialId", MAX_SOURCE_URI_CHARS);
+    if (credentialId.error) return { error: credentialId.error };
+    if (!credentialId.value) return { error: "confluence.credentialId is required" };
+    const titleContains = trimOptional(raw.titleContains, "confluence.titleContains", MAX_CONFLUENCE_TITLE_FILTER_CHARS);
+    if (titleContains.error) return { error: titleContains.error };
+
+    let labels: string[] = [];
+    if (raw.labels !== undefined) {
+      if (!Array.isArray(raw.labels)) return { error: "confluence.labels must be an array" };
+      if (raw.labels.length > 20) return { error: "confluence.labels must contain at most 20 entries" };
+      labels = [];
+      for (const [index, entry] of raw.labels.entries()) {
+        if (typeof entry !== "string") return { error: `confluence.labels[${index}] must be a string` };
+        const label = entry.trim();
+        if (!label) continue;
+        if (label.length > MAX_CONFLUENCE_LABEL_CHARS) {
+          return { error: `confluence.labels[${index}] must be at most ${MAX_CONFLUENCE_LABEL_CHARS} characters` };
+        }
+        if (!/^[A-Za-z0-9_.:-]+$/.test(label)) return { error: `confluence.labels[${index}] is invalid` };
+        if (!labels.includes(label)) labels.push(label);
+      }
+    }
+
+    const maxPageBytes = raw.maxPageBytes === undefined ? MAX_CONFLUENCE_PAGE_BYTES : raw.maxPageBytes;
+    if (typeof maxPageBytes !== "number" || !Number.isFinite(maxPageBytes)) return { error: "confluence.maxPageBytes must be a number" };
+    if (maxPageBytes < 1 || maxPageBytes > MAX_CONFLUENCE_PAGE_BYTES) {
+      return { error: `confluence.maxPageBytes must be between 1 and ${MAX_CONFLUENCE_PAGE_BYTES}` };
+    }
+    const maxPages = raw.maxPages === undefined ? MAX_CONFLUENCE_PAGES : raw.maxPages;
+    if (typeof maxPages !== "number" || !Number.isFinite(maxPages)) return { error: "confluence.maxPages must be a number" };
+    if (maxPages < 1 || maxPages > MAX_CONFLUENCE_PAGES) {
+      return { error: `confluence.maxPages must be between 1 and ${MAX_CONFLUENCE_PAGES}` };
+    }
+
+    confluence = {
+      baseUrl: normalizedBaseUrl,
+      spaceKey: spaceKey.value,
+      labels,
+      titleContains: titleContains.value,
+      maxPageBytes: Math.trunc(maxPageBytes),
+      maxPages: Math.trunc(maxPages),
+      credentialId: credentialId.value,
+    };
+  }
+
   return {
     value: {
       name: name.value,
@@ -814,6 +963,7 @@ export function validateCreateContextSourceBody(value: unknown): ValidationResul
       github,
       file,
       s3,
+      confluence,
     },
   };
 }
@@ -827,13 +977,18 @@ export function validateCreateContextConnectorCredentialBody(value: unknown): Va
   if (name.error) return { error: name.error };
   if (!name.value) return { error: "name is required" };
   const type = body.type === undefined ? "github_token" : body.type;
-  if (type !== "github_token" && type !== "aws_access_key") return { error: "type must be github_token or aws_access_key" };
+  if (type !== "github_token" && type !== "aws_access_key" && type !== "confluence_api_token") {
+    return { error: "type must be github_token, aws_access_key, or confluence_api_token" };
+  }
   if (typeof body.value !== "string") return { error: "value is required" };
   const credentialValue = body.value.trim();
   if (!credentialValue) return { error: "value cannot be empty or whitespace-only" };
   if (credentialValue.length > MAX_CREDENTIAL_VALUE_CHARS) return { error: `value must be at most ${MAX_CREDENTIAL_VALUE_CHARS} characters` };
   if (type === "aws_access_key" && !parseAwsCredentialValue(credentialValue)) {
     return { error: "value must be a JSON object with accessKeyId and secretAccessKey" };
+  }
+  if (type === "confluence_api_token" && !parseConfluenceCredentialValue(credentialValue)) {
+    return { error: "value must be a JSON object with email and apiToken" };
   }
   return { value: { name: name.value, type, value: credentialValue } };
 }
@@ -1031,6 +1186,12 @@ export async function createContextSource(
     if (!credential) throw new Error("connector credential not found");
     if (credential.type !== "aws_access_key") throw new Error("connector credential must be aws_access_key");
   }
+  if (input.confluence?.credentialId) {
+    const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, input.confluence.credentialId));
+    const credential = await db.select({ id: contextConnectorCredentials.id, type: contextConnectorCredentials.type }).from(contextConnectorCredentials).where(credentialWhere).get();
+    if (!credential) throw new Error("connector credential not found");
+    if (credential.type !== "confluence_api_token") throw new Error("connector credential must be confluence_api_token");
+  }
 
   const now = new Date();
   const id = nanoid();
@@ -1038,6 +1199,8 @@ export async function createContextSource(
     ? { ...(input.metadata ?? {}), github: input.github, githubSyncedFiles: {} }
     : input.s3
       ? { ...(input.metadata ?? {}), s3: input.s3, s3SyncedObjects: {} }
+    : input.confluence
+      ? { ...(input.metadata ?? {}), confluence: input.confluence, confluenceSyncedPages: {} }
     : input.file
       ? { ...(input.metadata ?? {}), file: input.file }
       : input.metadata ?? {};
@@ -1046,6 +1209,8 @@ export async function createContextSource(
       ? `https://github.com/${input.github.owner}/${input.github.repo}/tree/${encodeURIComponent(input.github.branch)}`
       : input.s3
         ? `s3://${input.s3.bucket}/${input.s3.prefix ?? ""}`
+      : input.confluence
+        ? `${input.confluence.baseUrl}/wiki/spaces/${encodeURIComponent(input.confluence.spaceKey)}`
       : input.file
         ? `upload://${encodeURIComponent(input.file.filename)}`
         : null);
@@ -1054,6 +1219,8 @@ export async function createContextSource(
       ? `github:${input.github.owner}/${input.github.repo}:${input.github.branch}:${input.github.path ?? ""}`
       : input.s3
         ? `s3:${input.s3.bucket}:${input.s3.region}:${input.s3.prefix ?? ""}`
+      : input.confluence
+        ? `confluence:${input.confluence.baseUrl}:${input.confluence.spaceKey}:${input.confluence.labels.join(",")}:${input.confluence.titleContains ?? ""}`
       : input.file
         ? `upload:${hashContent(`${input.file.filename}:${input.content ?? ""}`).slice(0, 32)}`
         : id);
@@ -1067,7 +1234,7 @@ export async function createContextSource(
     externalId,
     sourceUri,
     content,
-    contentHash: hashContent(input.github ? JSON.stringify(input.github) : input.s3 ? JSON.stringify(input.s3) : content),
+    contentHash: hashContent(input.github ? JSON.stringify(input.github) : input.s3 ? JSON.stringify(input.s3) : input.confluence ? JSON.stringify(input.confluence) : content),
     syncStatus: "pending",
     documentCount: 0,
     metadata: JSON.stringify(metadata),
@@ -1277,6 +1444,16 @@ function getSyncedS3Objects(metadata: Record<string, unknown>): Record<string, s
   return result;
 }
 
+function getSyncedConfluencePages(metadata: Record<string, unknown>): Record<string, string> {
+  const pages = metadata.confluenceSyncedPages;
+  if (typeof pages !== "object" || pages === null || Array.isArray(pages)) return {};
+  const result: Record<string, string> = {};
+  for (const [id, version] of Object.entries(pages)) {
+    if (typeof version === "string") result[id] = version;
+  }
+  return result;
+}
+
 async function resolveGithubToken(
   db: Db,
   tenantId: string | null,
@@ -1323,6 +1500,34 @@ async function resolveAwsCredential(
       authTag: credential.authTag,
     }).replace(/[^\x20-\x7E\t\r\n]/g, "").trim();
     const parsed = parseAwsCredentialValue(raw);
+    if (!parsed) throw new Error("connector credential is invalid");
+    await db.update(contextConnectorCredentials).set({
+      lastUsedAt: new Date(),
+    }).where(eq(contextConnectorCredentials.id, credential.id)).run();
+    return parsed;
+  } catch (err) {
+    if (err instanceof Error && err.message === "connector credential is invalid") throw err;
+    throw new Error("connector credential could not be decrypted");
+  }
+}
+
+async function resolveConfluenceCredential(
+  db: Db,
+  tenantId: string | null,
+  credentialId: string,
+): Promise<ConfluenceApiTokenCredential> {
+  if (!hasMasterKey()) throw new Error("PROVARA_MASTER_KEY not set");
+  const credentialWhere = tenantScoped(contextConnectorCredentials.tenantId, tenantId, eq(contextConnectorCredentials.id, credentialId));
+  const credential = await db.select().from(contextConnectorCredentials).where(credentialWhere).get();
+  if (!credential) throw new Error("connector credential not found");
+  if (credential.type !== "confluence_api_token") throw new Error("connector credential must be confluence_api_token");
+  try {
+    const raw = decrypt({
+      encrypted: credential.encryptedValue,
+      iv: credential.iv,
+      authTag: credential.authTag,
+    }).replace(/[^\x20-\x7E\t\r\n]/g, "").trim();
+    const parsed = parseConfluenceCredentialValue(raw);
     if (!parsed) throw new Error("connector credential is invalid");
     await db.update(contextConnectorCredentials).set({
       lastUsedAt: new Date(),
@@ -1468,6 +1673,118 @@ async function fetchS3File(
   if (Buffer.byteLength(content, "utf8") > config.maxFileBytes) throw new Error(`S3 object exceeds maxFileBytes: ${candidate.key}`);
   if (!isSafeUploadedText(content)) throw new Error(`S3 object must be text: ${candidate.key}`);
   if (content.trim().length === 0) throw new Error(`S3 object is empty: ${candidate.key}`);
+  return { ...candidate, content };
+}
+
+function confluenceHeaders(credential: ConfluenceApiTokenCredential): HeadersInit {
+  return {
+    Accept: "application/json",
+    Authorization: `Basic ${Buffer.from(`${credential.email}:${credential.apiToken}`).toString("base64")}`,
+    "User-Agent": "provara-context-connector",
+  };
+}
+
+function confluenceApiUrl(config: ConfluenceSourceConfig): URL {
+  const url = new URL(`${config.baseUrl}/wiki/rest/api/content/search`);
+  const cqlParts = [`space="${config.spaceKey.replace(/"/g, "")}"`, "type=page"];
+  if (config.titleContains) cqlParts.push(`title~"${config.titleContains.replace(/"/g, "")}"`);
+  for (const label of config.labels) cqlParts.push(`label="${label.replace(/"/g, "")}"`);
+  url.searchParams.set("cql", cqlParts.join(" and "));
+  url.searchParams.set("limit", String(config.maxPages));
+  url.searchParams.set("expand", "body.storage,version,_links");
+  return url;
+}
+
+function confluencePageUrl(config: ConfluenceSourceConfig, links: Record<string, unknown>, id: string): string {
+  const webui = typeof links.webui === "string" ? links.webui : "";
+  if (webui) return `${config.baseUrl}${webui.startsWith("/") ? "" : "/"}${webui}`;
+  return `${config.baseUrl}/wiki/pages/${encodeURIComponent(id)}`;
+}
+
+function htmlToText(value: string): string {
+  return value
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<\/(p|div|h[1-6]|li|tr|table|ul|ol|blockquote)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_match, code: string) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code: string) => String.fromCharCode(Number.parseInt(code, 16)))
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, "\"")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchConfluenceJson(
+  fetchFn: typeof fetch,
+  url: URL,
+  credential: ConfluenceApiTokenCredential,
+): Promise<unknown> {
+  const response = await fetchFn(url, { headers: confluenceHeaders(credential) });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const detail = text ? `: ${text.slice(0, 200)}` : "";
+    throw new Error(`Confluence request failed (${response.status})${detail}`);
+  }
+  return response.json() as Promise<unknown>;
+}
+
+async function fetchConfluenceCandidates(
+  fetchFn: typeof fetch,
+  config: ConfluenceSourceConfig,
+  credential: ConfluenceApiTokenCredential,
+): Promise<ConfluencePageCandidate[]> {
+  const payload = await fetchConfluenceJson(fetchFn, confluenceApiUrl(config), credential);
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) throw new Error("Confluence response is invalid");
+  const results = (payload as { results?: unknown }).results;
+  if (!Array.isArray(results)) throw new Error("Confluence response is missing pages");
+  const pages: ConfluencePageCandidate[] = [];
+  for (const entry of results) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
+    const page = entry as Record<string, unknown>;
+    const id = typeof page.id === "string" ? page.id : "";
+    const title = typeof page.title === "string" ? page.title.trim() : "";
+    const versionRaw = typeof page.version === "object" && page.version !== null && !Array.isArray(page.version)
+      ? (page.version as Record<string, unknown>).number
+      : undefined;
+    const version = typeof versionRaw === "number" || typeof versionRaw === "string" ? String(versionRaw) : "";
+    const body = typeof page.body === "object" && page.body !== null && !Array.isArray(page.body)
+      ? (page.body as Record<string, unknown>).storage
+      : undefined;
+    const bodyHtml = typeof body === "object" && body !== null && !Array.isArray(body) && typeof (body as Record<string, unknown>).value === "string"
+      ? (body as Record<string, unknown>).value as string
+      : "";
+    const links = typeof page._links === "object" && page._links !== null && !Array.isArray(page._links)
+      ? page._links as Record<string, unknown>
+      : {};
+    const sizeBytes = Buffer.byteLength(bodyHtml, "utf8");
+    if (!id || !title || !version || sizeBytes <= 0 || sizeBytes > config.maxPageBytes) continue;
+    pages.push({
+      id,
+      title,
+      version,
+      bodyHtml,
+      webUrl: confluencePageUrl(config, links, id),
+      sizeBytes,
+    });
+    if (pages.length >= config.maxPages) break;
+  }
+  return pages.sort((left, right) => left.title.localeCompare(right.title)).slice(0, config.maxPages);
+}
+
+function confluenceSyncPage(config: ConfluenceSourceConfig, candidate: ConfluencePageCandidate): ConfluenceSyncPage {
+  if (candidate.sizeBytes > config.maxPageBytes) throw new Error(`Confluence page exceeds maxPageBytes: ${candidate.id}`);
+  const content = htmlToText(candidate.bodyHtml);
+  if (Buffer.byteLength(content, "utf8") > config.maxPageBytes) throw new Error(`Confluence page exceeds maxPageBytes: ${candidate.id}`);
+  if (!isSafeUploadedText(content)) throw new Error(`Confluence page must be text: ${candidate.id}`);
+  if (content.trim().length === 0) throw new Error(`Confluence page is empty: ${candidate.id}`);
   return { ...candidate, content };
 }
 
@@ -1678,6 +1995,109 @@ async function syncS3ContextSource(
   };
 }
 
+async function syncConfluenceContextSource(
+  db: Db,
+  tenantId: string | null,
+  sourceRow: typeof contextSources.$inferSelect,
+  collection: typeof contextCollections.$inferSelect,
+  options: ContextSourceSyncOptions,
+): Promise<{ source: ContextSource; collection: ContextCollection; document: ContextDocument | null; blocks: ContextBlock[]; synced: boolean }> {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  if (!fetchFn) throw new Error("fetch is unavailable");
+  const metadata = parseMetadata(sourceRow.metadata);
+  const config = parseConfluenceConfig(metadata);
+  const credential = await resolveConfluenceCredential(db, tenantId, config.credentialId);
+  const syncedPages = getSyncedConfluencePages(metadata);
+  const candidates = await fetchConfluenceCandidates(fetchFn, config, credential);
+  const changedCandidates = candidates.filter((candidate) => syncedPages[candidate.id] !== candidate.version);
+  const now = new Date();
+
+  if (changedCandidates.length === 0 && sourceRow.syncStatus === "synced") {
+    await db.update(contextSources).set({
+      lastSyncedAt: now,
+      lastError: null,
+      updatedAt: now,
+      metadata: JSON.stringify({
+        ...metadata,
+        confluenceLastSync: {
+          checkedAt: now.toISOString(),
+          matchedPages: candidates.length,
+          changedPages: 0,
+        },
+      }),
+    }).where(eq(contextSources.id, sourceRow.id)).run();
+    const unchangedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+    return {
+      source: sourceFromRow(unchangedSource ?? sourceRow),
+      collection: collectionFromRow(collection),
+      document: null,
+      blocks: [],
+      synced: false,
+    };
+  }
+
+  const allBlocks: ContextBlock[] = [];
+  let lastDocument: ContextDocument | null = null;
+  let latestCollection: ContextCollection = collectionFromRow(collection);
+  const nextSyncedPages = { ...syncedPages };
+
+  for (const candidate of changedCandidates) {
+    const page = confluenceSyncPage(config, candidate);
+    const result = await ingestContextDocument(db, tenantId, sourceRow.collectionId, {
+      title: page.title,
+      text: page.content,
+      source: `source:${sourceRow.type}`,
+      sourceUri: page.webUrl,
+      metadata: {
+        ...metadata,
+        confluenceSyncedPages: undefined,
+        contextSourceId: sourceRow.id,
+        contextSourceType: sourceRow.type,
+        externalId: sourceRow.externalId,
+        confluenceBaseUrl: config.baseUrl,
+        confluenceSpaceKey: config.spaceKey,
+        confluencePageId: page.id,
+        confluencePageTitle: page.title,
+        confluencePageVersion: page.version,
+        confluencePageSize: page.sizeBytes,
+      },
+    });
+    nextSyncedPages[page.id] = page.version;
+    latestCollection = result.collection;
+    lastDocument = result.document;
+    allBlocks.push(...result.blocks);
+  }
+
+  await db.update(contextSources).set({
+    syncStatus: "synced",
+    lastSyncedAt: now,
+    lastDocumentId: lastDocument?.id ?? sourceRow.lastDocumentId,
+    documentCount: sourceRow.documentCount + changedCandidates.length,
+    lastError: null,
+    contentHash: hashContent(candidates.map((candidate) => `${candidate.id}:${candidate.version}`).join("\n")),
+    metadata: JSON.stringify({
+      ...metadata,
+      confluenceSyncedPages: nextSyncedPages,
+      confluenceLastSync: {
+        checkedAt: now.toISOString(),
+        matchedPages: candidates.length,
+        changedPages: changedCandidates.length,
+      },
+    }),
+    updatedAt: now,
+  }).where(eq(contextSources.id, sourceRow.id)).run();
+
+  const syncedSource = await db.select().from(contextSources).where(eq(contextSources.id, sourceRow.id)).get();
+  if (!syncedSource) throw new Error("Failed to sync context source");
+  return {
+    source: sourceFromRow(syncedSource),
+    collection: latestCollection,
+    document: lastDocument,
+    blocks: allBlocks,
+    synced: changedCandidates.length > 0,
+  };
+}
+
 export async function syncContextSource(
   db: Db,
   tenantId: string | null,
@@ -1709,6 +2129,21 @@ export async function syncContextSource(
     const now = new Date();
     try {
       return await syncS3ContextSource(db, tenantId, sourceRow, collection, options);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to sync context source";
+      await db.update(contextSources).set({
+        syncStatus: "failed",
+        lastError: message,
+        updatedAt: now,
+      }).where(eq(contextSources.id, sourceId)).run();
+      throw new Error(message);
+    }
+  }
+
+  if (sourceRow.type === "confluence_space") {
+    const now = new Date();
+    try {
+      return await syncConfluenceContextSource(db, tenantId, sourceRow, collection, options);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to sync context source";
       await db.update(contextSources).set({

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -2176,6 +2176,205 @@ describe("managed context collections", () => {
     expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
   });
 
+  it("creates and idempotently syncs Confluence space sources with API token credentials", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const confluenceFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      expect(url.pathname).toBe("/wiki/rest/api/content/search");
+      expect(url.searchParams.get("cql")).toContain("space=\"SUP\"");
+      expect(url.searchParams.get("cql")).toContain("label=\"policy\"");
+      expect(url.searchParams.get("cql")).toContain("title~\"Refund\"");
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toContain("Basic ");
+      return githubJson({
+        results: [
+          {
+            id: "123",
+            type: "page",
+            title: "Refund Policy",
+            version: { number: 7 },
+            body: { storage: { value: "<h1>Refund Policy</h1><p>Refunds are available within 30 days.</p>" } },
+            _links: { webui: "/wiki/spaces/SUP/pages/123/Refund+Policy" },
+          },
+          {
+            id: "456",
+            type: "page",
+            title: "Escalation Guide",
+            version: { number: 2 },
+            body: { storage: { value: "<p>Escalate enterprise account issues to support leadership.</p>" } },
+            _links: { webui: "/wiki/spaces/SUP/pages/456/Escalation+Guide" },
+          },
+        ],
+      });
+    });
+    const app = buildApp(db, undefined, { githubFetch: confluenceFetch });
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Confluence Docs",
+        type: "confluence_api_token",
+        value: JSON.stringify({ email: "docs@example.com", apiToken: "conf-secret-token" }),
+      }),
+    });
+    expect(credentialRes.status).toBe(201);
+    const credentialBody = await credentialRes.json() as { credential: { id: string; type: string; hasSecret: boolean; value?: string } };
+    expect(credentialBody.credential).toMatchObject({ type: "confluence_api_token", hasSecret: true });
+    expect(credentialBody.credential.value).toBeUndefined();
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Confluence KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Support space",
+        type: "confluence_space",
+        confluence: {
+          baseUrl: "https://acme.atlassian.net/wiki",
+          spaceKey: "SUP",
+          labels: ["policy"],
+          titleContains: "Refund",
+          credentialId: credentialBody.credential.id,
+          maxPages: 10,
+          maxPageBytes: 10_000,
+        },
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as { source: { id: string; type: string; metadata: Record<string, unknown> } };
+    expect(sourceBody.source.type).toBe("confluence_space");
+    expect(sourceBody.source.metadata.confluence).toMatchObject({ baseUrl: "https://acme.atlassian.net", spaceKey: "SUP", labels: ["policy"] });
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+    const syncBody = await syncRes.json() as {
+      synced: boolean;
+      source: { syncStatus: string; documentCount: number; metadata: Record<string, unknown> };
+      collection: { documentCount: number; blockCount: number };
+      document: { source: string; sourceUri: string };
+      blocks: Array<{ source: string; content: string; metadata: Record<string, unknown> }>;
+    };
+    expect(syncBody.synced).toBe(true);
+    expect(syncBody.source).toMatchObject({ syncStatus: "synced", documentCount: 2 });
+    expect(syncBody.collection).toMatchObject({ documentCount: 2, blockCount: 2 });
+    expect(syncBody.document.source).toBe("source:confluence_space");
+    expect(syncBody.document.sourceUri).toContain("/wiki/spaces/SUP/pages/123");
+    expect(syncBody.blocks[0]).toMatchObject({
+      source: "source:confluence_space",
+      metadata: expect.objectContaining({ contextSourceId: sourceBody.source.id, confluenceSpaceKey: "SUP", confluencePageVersion: "2" }),
+    });
+    const storedBlocks = await db.select().from(contextBlocks).all();
+    expect(storedBlocks.map((block) => block.content).join("\n")).toContain("Refunds are available within 30 days.");
+    expect(syncBody.source.metadata.confluenceSyncedPages).toMatchObject({ "123": "7", "456": "2" });
+    const credentialRow = await db.select().from(contextConnectorCredentials).where(eq(contextConnectorCredentials.id, credentialBody.credential.id)).get();
+    expect(credentialRow?.lastUsedAt).toBeInstanceOf(Date);
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+
+    const syncAgainRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncAgainRes.status).toBe(200);
+    const syncAgainBody = await syncAgainRes.json() as { synced: boolean; source: { documentCount: number }; document: unknown; blocks: unknown[] };
+    expect(syncAgainBody).toMatchObject({ synced: false, source: { documentCount: 2 }, document: null, blocks: [] });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(2);
+  });
+
+  it("does not allow a Confluence source to bind another tenant's API token", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({
+        name: "Other Confluence",
+        type: "confluence_api_token",
+        value: JSON.stringify({ email: "other@example.com", apiToken: "other-secret" }),
+      }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Confluence Tenant Guard KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Blocked space",
+        type: "confluence_space",
+        confluence: {
+          baseUrl: "https://acme.atlassian.net",
+          spaceKey: "SUP",
+          credentialId: credentialBody.credential.id,
+        },
+      }),
+    });
+    expect(sourceRes.status).toBe(404);
+  });
+
+  it("persists failed Confluence source sync status without writing documents", async () => {
+    process.env.PROVARA_MASTER_KEY = "test-master-key";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const confluenceFetch = vi.fn(async () => githubJson({ message: "access denied" }, 403));
+    const app = buildApp(db, undefined, { githubFetch: confluenceFetch });
+    const credentialRes = await app.request("/v1/context/credentials", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Confluence Docs",
+        type: "confluence_api_token",
+        value: JSON.stringify({ email: "docs@example.com", apiToken: "conf-secret-token" }),
+      }),
+    });
+    const credentialBody = await credentialRes.json() as { credential: { id: string } };
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Confluence Failure KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const sourceRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Broken space",
+        type: "confluence_space",
+        confluence: {
+          baseUrl: "https://acme.atlassian.net",
+          spaceKey: "SUP",
+          credentialId: credentialBody.credential.id,
+        },
+      }),
+    });
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(500);
+    const rows = await db.select().from(contextSources).all();
+    expect(rows).toEqual([
+      expect.objectContaining({ type: "confluence_space", syncStatus: "failed", documentCount: 0 }),
+    ]);
+    expect(rows[0]?.lastError).toContain("Confluence request failed (403)");
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+  });
+
   it("creates and idempotently syncs GitHub repository sources", async () => {
     await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
     const githubFetch = vi.fn(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary
- Add `confluence_space` context sources with bounded config validation.
- Add encrypted `confluence_api_token` connector credentials scoped by tenant.
- Add Confluence Cloud content search sync with storage-body text extraction, page-version idempotency, and page provenance metadata.
- Add dashboard Confluence credential and source setup flows.
- Update OpenAPI, docs, roadmap, changelog, and test coverage.

## Verification
- `npm test --workspace @provara/gateway -- context-optimizer.test.ts`
- `npm test --workspace @provara/web -- context-optimizer-panel.test.tsx`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `npm test --workspace @provara/gateway`
- `npm test --workspace @provara/web`
- `npm run build --workspace @provara/gateway`
- `npm run build --workspace @provara/web`
- `git diff --check`

Closes #389

Last-code-by: Codex/GPT-5 (codex)