### PR TITLE
feat(#391): add R2 document storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,20 @@ ZAI_API_KEY=
 # PROVARA_CLOUD=true
 
 # ──────────────────────────────────────────────
+# Context document storage (OPTIONAL — R2)
+# ──────────────────────────────────────────────
+# When enabled, raw context documents are written to Cloudflare R2 before
+# Provara stores metadata and searchable blocks in the database. R2_ENDPOINT
+# may be either the account endpoint or a bucket URL.
+# DOCUMENT_STORAGE_DRIVER=r2
+# R2_ENDPOINT=https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com
+# R2_BUCKET=provara-contextdocs
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_REGION=auto
+# R2_PREFIX=contextdocs/
+
+# ──────────────────────────────────────────────
 # Operator email allowlist (OPTIONAL — Provara Cloud only)
 # ──────────────────────────────────────────────
 # Comma-separated list of emails for CoreLumen employees / contractors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable Provara changes are tracked here.
   - File upload connector v1 with bounded text upload validation, sanitized filename metadata, idempotent source sync, OpenAPI coverage, and dashboard creation controls.
   - S3 connector v1 with encrypted AWS access-key credentials, SigV4 ListObjectsV2/GetObject sync, prefix/extension/file-size/file-count bounds, ETag idempotency, OpenAPI coverage, and dashboard creation controls.
   - Confluence connector v1 with encrypted API-token credentials, bounded Confluence Cloud page search, storage-body text extraction, page-version idempotency, OpenAPI coverage, and dashboard creation controls.
+  - Optional R2 document storage for raw context documents, using `DOCUMENT_STORAGE_DRIVER=r2` plus R2 S3 API env vars while preserving DB metadata and searchable context blocks.
   - Context Optimizer dashboard configuration controls for optimizer modes, thresholds, risk scanning, local draft persistence, and copyable API payloads.
 - Prompt Injection Firewall preset for built-in instruction override, system prompt extraction, role takeover, and delimiter-injection signatures.
 - Source-aware firewall scan API: `POST /v1/admin/guardrails/scan` supports `user_input`, `retrieved_context`, `tool_output`, and `model_output`.

--- a/README.md
+++ b/README.md
@@ -967,6 +967,13 @@ PROVARA_EMAIL_FROM="Provara <noreply@yourdomain.com>"
 | `STRIPE_WEBHOOK_SECRET` | Cloud | Signature secret for verifying Stripe webhook deliveries |
 | `RESEND_API_KEY` | No | Enables transactional email (team invites, welcome). Without it, invites still persist and can be copy-pasted from the dashboard |
 | `PROVARA_EMAIL_FROM` | No | Sender address for transactional email (default: `Provara <noreply@provara.xyz>`) — must be on a Resend-verified domain |
+| `DOCUMENT_STORAGE_DRIVER` | No | Set to `r2` to store raw context documents in Cloudflare R2 before DB metadata/block writes |
+| `R2_ENDPOINT` | For R2 | Cloudflare R2 S3 endpoint. May be the account endpoint or a bucket URL; Provara normalizes either form |
+| `R2_BUCKET` | For R2 | R2 bucket for raw context documents, e.g. `provara-contextdocs` |
+| `R2_ACCESS_KEY_ID` | For R2 | R2 S3 API access key ID |
+| `R2_SECRET_ACCESS_KEY` | For R2 | R2 S3 API secret access key |
+| `R2_REGION` | No | R2 signing region, default `auto` |
+| `R2_PREFIX` | No | Object key prefix for context documents, default `context-documents/` |
 
 ### Web Dashboard
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -132,6 +132,20 @@ GET /v1/context/collections/{id}/export
 
 Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters.
 
+Raw context document object storage is optional. When `DOCUMENT_STORAGE_DRIVER=r2` is set on the API service, Provara writes the raw document text to Cloudflare R2 before committing the database document metadata and searchable blocks. Configure:
+
+```text
+DOCUMENT_STORAGE_DRIVER=r2
+R2_ENDPOINT=https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com
+R2_BUCKET=provara-contextdocs
+R2_ACCESS_KEY_ID=...
+R2_SECRET_ACCESS_KEY=...
+R2_REGION=auto
+R2_PREFIX=contextdocs/
+```
+
+`R2_ENDPOINT` may also be provided as the bucket URL, such as `https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com/provara-contextdocs`; Provara normalizes that form and keeps `R2_BUCKET` as the canonical bucket name. Stored document metadata includes the R2 bucket, object key, object URI, byte size, content hash, and storage timestamp. Secret values are never persisted in document metadata.
+
 Manual sources are the connector foundation. `POST /v1/context/collections/{id}/sources` creates a tenant-scoped source with content, source URI, external ID, and metadata. `POST /v1/context/sources/{id}/sync` ingests that source into the existing `context_documents` and `context_blocks` pipeline, records `synced` or `failed` status on the source, persists the last error for failed syncs, and skips unchanged already-synced sources without duplicating documents.
 
 File upload sources use `type: "file_upload"` with text content and a `file` metadata object:

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -13,6 +13,7 @@ import { and, asc, desc, eq, sql } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import { tenantFilter, tenantScoped } from "../auth/tenant.js";
 import { decrypt, encrypt, hasMasterKey } from "../crypto/index.js";
+import { storeContextDocumentObject } from "../storage/documents.js";
 import { estimateContextTokens } from "./optimizer.js";
 
 const MAX_COLLECTION_NAME_CHARS = 120;
@@ -1286,9 +1287,22 @@ export async function ingestContextDocument(
   if (rawBlocks.length === 0) throw new Error("text is required");
   const now = new Date();
   const documentId = nanoid();
+  const documentContentHash = hashContent(input.text);
+  const storage = await storeContextDocumentObject({
+    tenantId,
+    collectionId,
+    documentId,
+    title: input.title ?? input.source ?? "Untitled document",
+    text: input.text,
+    contentHash: documentContentHash,
+  });
+  const documentMetadata: Record<string, unknown> = {
+    ...(input.metadata ?? {}),
+    ...(storage ? { documentStorage: storage } : {}),
+  };
   const blockRows = rawBlocks.map((content, index) => {
     const metadata = {
-      ...(input.metadata ?? {}),
+      ...documentMetadata,
       sourceDocumentId: documentId,
       blockOrdinal: index,
     };
@@ -1315,8 +1329,8 @@ export async function ingestContextDocument(
     title: input.title ?? input.source ?? "Untitled document",
     source: input.source ?? null,
     sourceUri: input.sourceUri ?? null,
-    contentHash: hashContent(input.text),
-    metadata: JSON.stringify(input.metadata ?? {}),
+    contentHash: documentContentHash,
+    metadata: JSON.stringify(documentMetadata),
     blockCount: blockRows.length,
     tokenCount,
     createdAt: now,

--- a/packages/gateway/src/storage/documents.ts
+++ b/packages/gateway/src/storage/documents.ts
@@ -1,0 +1,161 @@
+import { createHash, createHmac } from "node:crypto";
+
+const DEFAULT_R2_REGION = "auto";
+const DEFAULT_R2_PREFIX = "context-documents/";
+
+export interface StoredDocumentObject {
+  driver: "r2";
+  bucket: string;
+  key: string;
+  uri: string;
+  sizeBytes: number;
+  contentHash: string;
+  storedAt: string;
+}
+
+interface R2DocumentStorageConfig {
+  endpoint: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  prefix: string;
+}
+
+interface StoreContextDocumentInput {
+  tenantId: string | null;
+  collectionId: string;
+  documentId: string;
+  title: string;
+  text: string;
+  contentHash: string;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hmac(key: Buffer | string, value: string): Buffer {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function normalizePrefix(value: string | undefined): string {
+  const trimmed = value?.trim().replace(/^\/+/, "") || DEFAULT_R2_PREFIX;
+  return trimmed.endsWith("/") ? trimmed : `${trimmed}/`;
+}
+
+function normalizeR2Endpoint(rawEndpoint: string, bucket: string): string {
+  const url = new URL(rawEndpoint.trim());
+  url.search = "";
+  url.hash = "";
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.at(-1) === bucket) parts.pop();
+  url.pathname = parts.length > 0 ? `/${parts.join("/")}` : "";
+  return url.toString().replace(/\/$/, "");
+}
+
+function getR2DocumentStorageConfig(): R2DocumentStorageConfig | null {
+  const driver = process.env.DOCUMENT_STORAGE_DRIVER?.trim().toLowerCase();
+  if (!driver) return null;
+  if (driver !== "r2") throw new Error("DOCUMENT_STORAGE_DRIVER must be r2 when set");
+
+  const bucket = process.env.R2_BUCKET?.trim();
+  const endpoint = process.env.R2_ENDPOINT?.trim();
+  const accessKeyId = process.env.R2_ACCESS_KEY_ID?.trim();
+  const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY?.trim();
+  if (!bucket) throw new Error("R2_BUCKET is required when DOCUMENT_STORAGE_DRIVER=r2");
+  if (!endpoint) throw new Error("R2_ENDPOINT is required when DOCUMENT_STORAGE_DRIVER=r2");
+  if (!accessKeyId) throw new Error("R2_ACCESS_KEY_ID is required when DOCUMENT_STORAGE_DRIVER=r2");
+  if (!secretAccessKey) throw new Error("R2_SECRET_ACCESS_KEY is required when DOCUMENT_STORAGE_DRIVER=r2");
+
+  return {
+    endpoint: normalizeR2Endpoint(endpoint, bucket),
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    region: process.env.R2_REGION?.trim() || DEFAULT_R2_REGION,
+    prefix: normalizePrefix(process.env.R2_PREFIX),
+  };
+}
+
+function encodeObjectKeyPath(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+function documentObjectKey(config: R2DocumentStorageConfig, input: StoreContextDocumentInput): string {
+  const tenant = input.tenantId ?? "pool";
+  const titleHash = sha256Hex(input.title).slice(0, 12);
+  return `${config.prefix}${tenant}/${input.collectionId}/${input.documentId}-${titleHash}.txt`;
+}
+
+function signR2PutRequest(
+  url: URL,
+  config: R2DocumentStorageConfig,
+  payloadHash: string,
+  now = new Date(),
+): Record<string, string> {
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, "");
+  const dateStamp = amzDate.slice(0, 8);
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+  const signedHeaders = Object.keys(headers).sort().join(";");
+  const canonicalHeaders = Object.keys(headers).sort().map((name) => `${name}:${headers[name]}\n`).join("");
+  const canonicalRequest = [
+    "PUT",
+    url.pathname || "/",
+    "",
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const credentialScope = `${dateStamp}/${config.region}/s3/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${config.secretAccessKey}`, dateStamp), config.region), "s3"), "aws4_request");
+  const signature = createHmac("sha256", signingKey).update(stringToSign).digest("hex");
+  return {
+    Host: headers.host,
+    "Content-Type": "text/plain; charset=utf-8",
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+    Authorization: `AWS4-HMAC-SHA256 Credential=${config.accessKeyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}
+
+export async function storeContextDocumentObject(input: StoreContextDocumentInput): Promise<StoredDocumentObject | null> {
+  const config = getR2DocumentStorageConfig();
+  if (!config) return null;
+  const fetchFn = globalThis.fetch;
+  if (!fetchFn) throw new Error("fetch is unavailable");
+
+  const key = documentObjectKey(config, input);
+  const url = new URL(`${config.endpoint}/${encodeURIComponent(config.bucket)}/${encodeObjectKeyPath(key)}`);
+  const payloadHash = sha256Hex(input.text);
+  const response = await fetchFn(url, {
+    method: "PUT",
+    headers: signR2PutRequest(url, config, payloadHash),
+    body: input.text,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    const detail = text ? `: ${text.slice(0, 200)}` : "";
+    throw new Error(`R2 document storage failed (${response.status})${detail}`);
+  }
+
+  return {
+    driver: "r2",
+    bucket: config.bucket,
+    key,
+    uri: `r2://${config.bucket}/${key}`,
+    sizeBytes: Buffer.byteLength(input.text, "utf8"),
+    contentHash: input.contentHash,
+    storedAt: new Date().toISOString(),
+  };
+}

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1578,18 +1578,47 @@ describe("POST /v1/context/optimize", () => {
 describe("managed context collections", () => {
   let db: Db;
   let originalMasterKey: string | undefined;
+  let originalDocumentStorageDriver: string | undefined;
+  let originalR2Endpoint: string | undefined;
+  let originalR2Bucket: string | undefined;
+  let originalR2AccessKeyId: string | undefined;
+  let originalR2SecretAccessKey: string | undefined;
+  let originalR2Region: string | undefined;
+  let originalR2Prefix: string | undefined;
 
   beforeEach(async () => {
     db = await makeTestDb();
     resetTierEnv();
     process.env.PROVARA_CLOUD = "true";
     originalMasterKey = process.env.PROVARA_MASTER_KEY;
+    originalDocumentStorageDriver = process.env.DOCUMENT_STORAGE_DRIVER;
+    originalR2Endpoint = process.env.R2_ENDPOINT;
+    originalR2Bucket = process.env.R2_BUCKET;
+    originalR2AccessKeyId = process.env.R2_ACCESS_KEY_ID;
+    originalR2SecretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+    originalR2Region = process.env.R2_REGION;
+    originalR2Prefix = process.env.R2_PREFIX;
   });
 
   afterEach(() => {
     resetTierEnv();
+    vi.unstubAllGlobals();
     if (originalMasterKey === undefined) delete process.env.PROVARA_MASTER_KEY;
     else process.env.PROVARA_MASTER_KEY = originalMasterKey;
+    if (originalDocumentStorageDriver === undefined) delete process.env.DOCUMENT_STORAGE_DRIVER;
+    else process.env.DOCUMENT_STORAGE_DRIVER = originalDocumentStorageDriver;
+    if (originalR2Endpoint === undefined) delete process.env.R2_ENDPOINT;
+    else process.env.R2_ENDPOINT = originalR2Endpoint;
+    if (originalR2Bucket === undefined) delete process.env.R2_BUCKET;
+    else process.env.R2_BUCKET = originalR2Bucket;
+    if (originalR2AccessKeyId === undefined) delete process.env.R2_ACCESS_KEY_ID;
+    else process.env.R2_ACCESS_KEY_ID = originalR2AccessKeyId;
+    if (originalR2SecretAccessKey === undefined) delete process.env.R2_SECRET_ACCESS_KEY;
+    else process.env.R2_SECRET_ACCESS_KEY = originalR2SecretAccessKey;
+    if (originalR2Region === undefined) delete process.env.R2_REGION;
+    else process.env.R2_REGION = originalR2Region;
+    if (originalR2Prefix === undefined) delete process.env.R2_PREFIX;
+    else process.env.R2_PREFIX = originalR2Prefix;
   });
 
   it("creates and lists tenant-scoped collections", async () => {
@@ -1683,6 +1712,92 @@ describe("managed context collections", () => {
     const rows = await db.select().from(contextBlocks).all();
     expect(rows).toHaveLength(1);
     expect(rows[0].content).toContain("Refunds require a receipt");
+  });
+
+  it("stores raw context documents in R2 when document storage is enabled", async () => {
+    process.env.DOCUMENT_STORAGE_DRIVER = "r2";
+    process.env.R2_ENDPOINT = "https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com/provara-contextdocs";
+    process.env.R2_BUCKET = "provara-contextdocs";
+    process.env.R2_ACCESS_KEY_ID = "r2-access";
+    process.env.R2_SECRET_ACCESS_KEY = "r2-secret";
+    process.env.R2_PREFIX = "contextdocs";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    const r2Fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      expect(init?.method).toBe("PUT");
+      expect(url.origin).toBe("https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com");
+      expect(url.pathname).toMatch(/^\/provara-contextdocs\/contextdocs\/tenant-pro\//);
+      expect((init?.headers as Record<string, string> | undefined)?.Authorization).toContain("AWS4-HMAC-SHA256");
+      expect(String(init?.body)).toContain("Refunds require a receipt");
+      return new Response("", { status: 200 });
+    });
+    vi.stubGlobal("fetch", r2Fetch);
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "R2 Policy KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const ingestRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        title: "Refund policy",
+        text: "Refunds require a receipt and must be requested within 30 days.",
+        source: "help-center",
+      }),
+    });
+
+    expect(ingestRes.status).toBe(201);
+    expect(r2Fetch).toHaveBeenCalledOnce();
+    const ingestBody = await ingestRes.json() as {
+      document: { metadata: Record<string, unknown> };
+      blocks: Array<{ metadata: Record<string, unknown> }>;
+    };
+    expect(ingestBody.document.metadata.documentStorage).toMatchObject({
+      driver: "r2",
+      bucket: "provara-contextdocs",
+      uri: expect.stringMatching(/^r2:\/\/provara-contextdocs\/contextdocs\/tenant-pro\//),
+      sizeBytes: expect.any(Number),
+      contentHash: expect.any(String),
+    });
+    expect(ingestBody.blocks[0]?.metadata.documentStorage).toMatchObject({
+      driver: "r2",
+      bucket: "provara-contextdocs",
+    });
+  });
+
+  it("fails context ingest before writing rows when enabled R2 storage fails", async () => {
+    process.env.DOCUMENT_STORAGE_DRIVER = "r2";
+    process.env.R2_ENDPOINT = "https://305aa000c2183ba4d6ef3be09b39cb4a.r2.cloudflarestorage.com";
+    process.env.R2_BUCKET = "provara-contextdocs";
+    process.env.R2_ACCESS_KEY_ID = "r2-access";
+    process.env.R2_SECRET_ACCESS_KEY = "r2-secret";
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("write denied", { status: 403 })));
+    const app = buildApp(db);
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "R2 Failure KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+
+    const ingestRes = await app.request(`/v1/context/collections/${collectionBody.collection.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        title: "Refund policy",
+        text: "Refunds require a receipt.",
+      }),
+    });
+
+    expect(ingestRes.status).toBe(500);
+    expect(await ingestRes.json()).toMatchObject({ error: { message: expect.stringContaining("R2 document storage failed (403)") } });
+    expect(await db.select().from(contextDocuments).all()).toHaveLength(0);
+    expect(await db.select().from(contextBlocks).all()).toHaveLength(0);
   });
 
   it("rejects invalid ingest requests before writing rows", async () => {


### PR DESCRIPTION
## Summary
- Add an optional R2 document storage adapter for raw context documents.
- Read `DOCUMENT_STORAGE_DRIVER=r2`, `R2_ENDPOINT`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_REGION`, and `R2_PREFIX` from the API environment.
- Normalize R2 endpoints supplied as either account endpoints or bucket URLs.
- Persist non-secret document-storage metadata on context documents and blocks.
- Fail ingestion before DB writes when enabled R2 storage cannot write.
- Update docs and env examples for the Railway R2 setup.

## Verification
- `npm test --workspace @provara/gateway -- context-optimizer.test.ts`
- `npx tsc --noEmit -p packages/gateway/tsconfig.json`
- `git diff --check`
- `npm test --workspace @provara/gateway`
- `npm run build --workspace @provara/gateway`

Closes #391

Last-code-by: Codex/GPT-5 (codex)