### PR TITLE
feat(context): delete managed collections

### DIFF
--- a/apps/web/src/app/docs/context-optimizer/page.tsx
+++ b/apps/web/src/app/docs/context-optimizer/page.tsx
@@ -55,6 +55,7 @@ const apiGroups = [
     endpoints: [
       "GET /v1/context/collections",
       "POST /v1/context/collections",
+      "DELETE /v1/context/collections/{id}",
       "POST /v1/context/collections/{id}/documents",
       "GET /v1/context/collections/{id}/sources",
       "POST /v1/context/collections/{id}/sources",
@@ -166,9 +167,15 @@ export default function ContextOptimizerDocsPage() {
               <Section id="collections" title="Managed Collections">
                 <p>
                   Collections are tenant-scoped containers for reusable context. The dashboard can
-                  create the first collection, then file upload and external connector sources bind
-                  to that collection. Document ingestion stores deterministic blocks with content
-                  hashes, token estimates, source metadata, and collection counters.
+                  create the first collection explicitly or auto-create a default collection when
+                  the first file upload or external connector source is submitted. Document
+                  ingestion stores deterministic blocks with content hashes, token estimates,
+                  source metadata, and collection counters.
+                </p>
+                <p>
+                  Deleting a collection removes its sources, documents, raw blocks, canonical
+                  blocks, and canonical review events. Connector credentials are tenant-level
+                  records and remain available for other collections.
                 </p>
                 <p>
                   Raw document object storage is optional. When the gateway runs with
@@ -240,9 +247,10 @@ export default function ContextOptimizerDocsPage() {
                   policy-check actions.
                 </p>
                 <p>
-                  For a fresh tenant, create a managed collection first. File upload and GitHub
-                  source buttons stay disabled until a collection exists and the required source
-                  fields are filled.
+                  For a fresh tenant, file upload and connector source creation can auto-create
+                  a default managed collection once the required source fields are filled. The
+                  collection table includes a delete action for removing a collection and its
+                  associated context.
                 </p>
               </Section>
 

--- a/apps/web/src/components/context-optimizer-panel.tsx
+++ b/apps/web/src/components/context-optimizer-panel.tsx
@@ -323,6 +323,16 @@ function formatTimestamp(value: string | null): string {
   return date.toLocaleString();
 }
 
+function formatDeletedCollectionMessage(deleted: { sources: number; documents: number; blocks: number; canonicalBlocks: number }): string {
+  const parts = [
+    `${formatInteger(deleted.sources)} ${deleted.sources === 1 ? "source" : "sources"}`,
+    `${formatInteger(deleted.documents)} ${deleted.documents === 1 ? "document" : "documents"}`,
+    `${formatInteger(deleted.blocks)} ${deleted.blocks === 1 ? "block" : "blocks"}`,
+    `${formatInteger(deleted.canonicalBlocks)} ${deleted.canonicalBlocks === 1 ? "canonical block" : "canonical blocks"}`,
+  ];
+  return `Collection deleted. Removed ${parts.join(", ")}.`;
+}
+
 function formatContextSourceType(type: ContextSource["type"]): string {
   if (type === "github_repository") return "GitHub";
   if (type === "file_upload") return "File Upload";
@@ -695,6 +705,7 @@ export function ContextOptimizerPanel() {
   const [bulkMessage, setBulkMessage] = useState<string | null>(null);
   const [collectionDraft, setCollectionDraft] = useState({ name: "", description: "" });
   const [collectionSubmitting, setCollectionSubmitting] = useState(false);
+  const [collectionDeletingId, setCollectionDeletingId] = useState<string | null>(null);
   const [collectionMessage, setCollectionMessage] = useState<string | null>(null);
   const [credentialDraft, setCredentialDraft] = useState({ name: "", value: "" });
   const [credentialSubmitting, setCredentialSubmitting] = useState(false);
@@ -988,6 +999,59 @@ export function ContextOptimizerPanel() {
     }
   }
 
+  async function ensureSourceCollection(): Promise<ContextCollection> {
+    if (firstCollection) return firstCollection;
+
+    const res = await gatewayFetchRaw("/v1/context/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Default Context Collection",
+        description: "Auto-created for connector sources.",
+      }),
+    });
+    if (!res.ok) throw new Error(await readGatewayErrorMessage(res, "Failed to create collection"));
+    const body = await res.json() as { collection: ContextCollection };
+    setState((prev) => ({
+      ...prev,
+      collections: [
+        body.collection,
+        ...prev.collections.filter((collection) => collection.id !== body.collection.id),
+      ],
+    }));
+    setCollectionMessage("Collection created.");
+    return body.collection;
+  }
+
+  async function deleteCollection(collection: ContextCollection) {
+    if (!window.confirm(`Delete ${collection.name} and all associated context?`)) return;
+    setCollectionDeletingId(collection.id);
+    setCollectionMessage(null);
+    try {
+      const res = await gatewayFetchRaw(`/v1/context/collections/${collection.id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(await readGatewayErrorMessage(res, "Failed to delete collection"));
+      const body = await res.json() as {
+        deleted: { sources: number; documents: number; blocks: number; canonicalBlocks: number; reviewEvents: number };
+      };
+      const deletedCanonicalIds = new Set(
+        state.canonicalBlocks
+          .filter((block) => block.collectionId === collection.id)
+          .map((block) => block.id),
+      );
+      setState((prev) => ({
+        ...prev,
+        collections: prev.collections.filter((row) => row.id !== collection.id),
+        sources: prev.sources.filter((source) => source.collectionId !== collection.id),
+        canonicalBlocks: prev.canonicalBlocks.filter((block) => block.collectionId !== collection.id),
+      }));
+      setSelectedCanonicalIds((prev) => prev.filter((id) => !deletedCanonicalIds.has(id)));
+      setCollectionMessage(formatDeletedCollectionMessage(body.deleted));
+    } catch (err) {
+      setCollectionMessage(err instanceof Error ? err.message : "Failed to delete collection");
+    } finally {
+      setCollectionDeletingId(null);
+    }
+  }
+
   async function createCredential() {
     if (!credentialDraft.name.trim() || !credentialDraft.value.trim()) return;
     setCredentialSubmitting(true);
@@ -1092,11 +1156,12 @@ export function ContextOptimizerPanel() {
   }
 
   async function createGitHubSource() {
-    if (!firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()) return;
+    if (!sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()) return;
     setSourceSubmitting(true);
     setSourceMessage(null);
     try {
-      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+      const collection = await ensureSourceCollection();
+      const res = await gatewayFetchRaw(`/v1/context/collections/${collection.id}/sources`, {
         method: "POST",
         body: JSON.stringify({
           name: sourceDraft.name.trim(),
@@ -1138,11 +1203,12 @@ export function ContextOptimizerPanel() {
   }
 
   async function createS3Source() {
-    if (!firstCollection || !s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId) return;
+    if (!s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId) return;
     setS3Submitting(true);
     setS3Message(null);
     try {
-      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+      const collection = await ensureSourceCollection();
+      const res = await gatewayFetchRaw(`/v1/context/collections/${collection.id}/sources`, {
         method: "POST",
         body: JSON.stringify({
           name: s3Draft.name.trim(),
@@ -1177,11 +1243,12 @@ export function ContextOptimizerPanel() {
   }
 
   async function createConfluenceSource() {
-    if (!firstCollection || !confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId) return;
+    if (!confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId) return;
     setConfluenceSubmitting(true);
     setConfluenceMessage(null);
     try {
-      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+      const collection = await ensureSourceCollection();
+      const res = await gatewayFetchRaw(`/v1/context/collections/${collection.id}/sources`, {
         method: "POST",
         body: JSON.stringify({
           name: confluenceDraft.name.trim(),
@@ -1238,7 +1305,10 @@ export function ContextOptimizerPanel() {
       ...prev,
       sources: prev.sources.map((source) => source.id === body.source.id ? body.source : source),
       collections: body.collection
-        ? prev.collections.map((collection) => collection.id === body.collection?.id ? body.collection as ContextCollection : collection)
+        ? [
+          body.collection,
+          ...prev.collections.filter((collection) => collection.id !== body.collection?.id),
+        ]
         : prev.collections,
     }));
   }
@@ -1250,11 +1320,12 @@ export function ContextOptimizerPanel() {
   }
 
   async function createFileUploadSource() {
-    if (!firstCollection || !fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()) return;
+    if (!fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()) return;
     setFileSubmitting(true);
     setFileMessage(null);
     try {
-      const res = await gatewayFetchRaw(`/v1/context/collections/${firstCollection.id}/sources`, {
+      const collection = await ensureSourceCollection();
+      const res = await gatewayFetchRaw(`/v1/context/collections/${collection.id}/sources`, {
         method: "POST",
         body: JSON.stringify({
           name: fileDraft.name.trim(),
@@ -1483,6 +1554,7 @@ export function ContextOptimizerPanel() {
                     <th className="px-4 py-3 text-right font-medium">Tokens</th>
                     <th className="px-4 py-3 text-left font-medium">Status</th>
                     <th className="px-4 py-3 text-left font-medium">Updated</th>
+                    <th className="px-4 py-3 text-right font-medium">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-zinc-800">
@@ -1516,6 +1588,17 @@ export function ContextOptimizerPanel() {
                       </td>
                       <td className="whitespace-nowrap px-4 py-3 text-zinc-400">
                         {formatTimestamp(collection.updatedAt)}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3 text-right">
+                        <button
+                          type="button"
+                          aria-label={`Delete collection ${collection.name}`}
+                          className="rounded-md border border-red-900 bg-red-950/30 px-3 py-1.5 text-xs font-medium text-red-100 hover:bg-red-900/40 disabled:cursor-not-allowed disabled:opacity-50"
+                          disabled={collectionDeletingId === collection.id}
+                          onClick={() => void deleteCollection(collection)}
+                        >
+                          {collectionDeletingId === collection.id ? "Deleting..." : "Delete"}
+                        </button>
                       </td>
                     </tr>
                   ))}
@@ -1762,7 +1845,7 @@ export function ContextOptimizerPanel() {
               <button
                 type="button"
                 className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={fileSubmitting || !firstCollection || !fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()}
+                disabled={fileSubmitting || !fileDraft.name.trim() || !fileDraft.filename.trim() || !fileDraft.content.trim()}
                 onClick={() => void createFileUploadSource()}
               >
                 {fileSubmitting ? "Creating..." : "Create File Source"}
@@ -1862,7 +1945,7 @@ export function ContextOptimizerPanel() {
               <button
                 type="button"
                 className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={s3Submitting || !firstCollection || !s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId}
+                disabled={s3Submitting || !s3Draft.name.trim() || !s3Draft.bucket.trim() || !s3Draft.region.trim() || !s3Draft.credentialId}
                 onClick={() => void createS3Source()}
               >
                 {s3Submitting ? "Creating..." : "Create S3 Source"}
@@ -1962,7 +2045,7 @@ export function ContextOptimizerPanel() {
               <button
                 type="button"
                 className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={confluenceSubmitting || !firstCollection || !confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId}
+                disabled={confluenceSubmitting || !confluenceDraft.name.trim() || !confluenceDraft.baseUrl.trim() || !confluenceDraft.spaceKey.trim() || !confluenceDraft.credentialId}
                 onClick={() => void createConfluenceSource()}
               >
                 {confluenceSubmitting ? "Creating..." : "Create Confluence Source"}
@@ -2071,7 +2154,7 @@ export function ContextOptimizerPanel() {
               <button
                 type="button"
                 className="rounded-md bg-blue-600 px-3 py-2 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={sourceSubmitting || !firstCollection || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()}
+                disabled={sourceSubmitting || !sourceDraft.name.trim() || !sourceDraft.owner.trim() || !sourceDraft.repo.trim()}
                 onClick={() => void createGitHubSource()}
               >
                 {sourceSubmitting ? "Creating..." : "Create Source"}

--- a/apps/web/tests/context-optimizer-panel.test.tsx
+++ b/apps/web/tests/context-optimizer-panel.test.tsx
@@ -1111,7 +1111,7 @@ describe("ContextOptimizerPanel", () => {
     expect(await screen.findByText("R2 document write failed (403)")).toBeInTheDocument();
   });
 
-  it("creates the first managed collection before enabling file and GitHub sources", async () => {
+  it("auto-creates the first managed collection when creating a source", async () => {
     mockedFetch.mockImplementation((path, init) => {
       if (path === "/v1/context/summary") {
         return Promise.resolve(jsonResponse({
@@ -1188,15 +1188,14 @@ describe("ContextOptimizerPanel", () => {
       if (path === "/v1/context/collections" && init?.method === "POST") {
         const parsed = JSON.parse(String(init.body)) as Record<string, unknown>;
         expect(parsed).toMatchObject({
-          name: "Support KB",
-          description: "Support documentation",
+          name: "Default Context Collection",
         });
         return Promise.resolve(jsonResponse({
           collection: {
             id: "collection-1",
             tenantId: "tenant-pro",
-            name: "Support KB",
-            description: "Support documentation",
+            name: "Default Context Collection",
+            description: "Auto-created for connector sources.",
             status: "active",
             documentCount: 0,
             blockCount: 0,
@@ -1208,6 +1207,36 @@ describe("ContextOptimizerPanel", () => {
           },
         }, { status: 201 }));
       }
+      if (path === "/v1/context/collections/collection-1/sources" && init?.method === "POST") {
+        const parsed = JSON.parse(String(init.body)) as Record<string, unknown>;
+        expect(parsed).toMatchObject({
+          name: "Uploaded guide",
+          type: "file_upload",
+          content: "Uploaded guide content for context.",
+          file: {
+            filename: "guide.md",
+            contentType: "text/markdown",
+          },
+        });
+        return Promise.resolve(jsonResponse({
+          source: {
+            id: "source-file",
+            collectionId: "collection-1",
+            name: "Uploaded guide",
+            type: "file_upload",
+            externalId: "upload:guide",
+            sourceUri: "upload://guide.md",
+            status: "active",
+            syncStatus: "pending",
+            lastSyncedAt: null,
+            lastDocumentId: null,
+            documentCount: 0,
+            lastError: null,
+            metadata: { file: { filename: "guide.md", contentType: "text/markdown", sizeBytes: 35 } },
+            updatedAt: "2026-05-01T22:10:00.000Z",
+          },
+        }));
+      }
       if (path === "/v1/context/collections") {
         return Promise.resolve(jsonResponse({ collections: [] }));
       }
@@ -1216,6 +1245,40 @@ describe("ContextOptimizerPanel", () => {
       }
       if (path === "/v1/context/collections/collection-1/sources") {
         return Promise.resolve(jsonResponse({ sources: [] }));
+      }
+      if (path === "/v1/context/sources/source-file/sync") {
+        return Promise.resolve(jsonResponse({
+          synced: true,
+          collection: {
+            id: "collection-1",
+            tenantId: "tenant-pro",
+            name: "Default Context Collection",
+            description: "Auto-created for connector sources.",
+            status: "active",
+            documentCount: 1,
+            blockCount: 1,
+            canonicalBlockCount: 0,
+            approvedBlockCount: 0,
+            tokenCount: 10,
+            createdAt: "2026-05-01T20:00:00.000Z",
+            updatedAt: "2026-05-01T22:11:00.000Z",
+          },
+          source: {
+            id: "source-file",
+            collectionId: "collection-1",
+            name: "Uploaded guide",
+            type: "file_upload",
+            externalId: "upload:guide",
+            sourceUri: "upload://guide.md",
+            syncStatus: "synced",
+            lastSyncedAt: "2026-05-01T22:11:00.000Z",
+            lastDocumentId: "doc-file",
+            documentCount: 1,
+            lastError: null,
+            metadata: { file: { filename: "guide.md", contentType: "text/markdown", sizeBytes: 35 } },
+            updatedAt: "2026-05-01T22:11:00.000Z",
+          },
+        }));
       }
       return Promise.resolve(jsonResponse({ events: [] }));
     });
@@ -1233,20 +1296,147 @@ describe("ContextOptimizerPanel", () => {
     const upload = new File(["Uploaded guide content for context."], "guide.md", { type: "text/markdown" });
     fireEvent.change(screen.getByLabelText("File"), { target: { files: [upload] } });
     expect(await screen.findByText("File loaded.")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("File Source Name"), { target: { value: "Uploaded guide" } });
     fireEvent.change(screen.getByLabelText("GitHub Source Name"), { target: { value: "Docs repo" } });
     fireEvent.change(screen.getByLabelText("Owner"), { target: { value: "acme" } });
     fireEvent.change(screen.getByLabelText("Repository"), { target: { value: "docs" } });
-    expect(createFileSource).toBeDisabled();
-    expect(createGithubSource).toBeDisabled();
-
-    fireEvent.change(screen.getByLabelText("Collection Name"), { target: { value: "Support KB" } });
-    fireEvent.change(screen.getByLabelText("Collection Description"), { target: { value: "Support documentation" } });
-    fireEvent.click(screen.getByRole("button", { name: "Create Collection" }));
-
-    expect(await screen.findByText("Collection created.")).toBeInTheDocument();
-    expect(screen.getByText("Support KB")).toBeInTheDocument();
     expect(createFileSource).toBeEnabled();
     expect(createGithubSource).toBeEnabled();
+
+    fireEvent.click(createFileSource);
+
+    expect(await screen.findByText("File uploaded and synced.")).toBeInTheDocument();
+    expect(screen.getByText("Default Context Collection")).toBeInTheDocument();
+  });
+
+  it("deletes a managed collection from the table", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockedFetch.mockImplementation((path, init) => {
+      if (path === "/v1/context/summary") {
+        return Promise.resolve(jsonResponse({
+          summary: {
+            eventCount: 0,
+            inputChunks: 0,
+            outputChunks: 0,
+            droppedChunks: 0,
+            nearDuplicateChunks: 0,
+            inputTokens: 0,
+            outputTokens: 0,
+            savedTokens: 0,
+            reductionPct: 0,
+            avgRelevanceScore: null,
+            lowRelevanceChunks: 0,
+            rerankedChunks: 0,
+            avgFreshnessScore: null,
+            staleChunks: 0,
+            conflictChunks: 0,
+            conflictGroups: 0,
+            compressedChunks: 0,
+            compressionSavedTokens: 0,
+            compressionRatePct: 0,
+            flaggedChunks: 0,
+            quarantinedChunks: 0,
+            latestAt: null,
+          },
+        }));
+      }
+      if (path === "/v1/context/quality/summary") {
+        return Promise.resolve(jsonResponse({ summary: { eventCount: 0, regressedCount: 0, avgRawScore: 0, avgOptimizedScore: 0, avgDelta: 0, latestAt: null } }));
+      }
+      if (path === "/v1/context/retrieval/summary") {
+        return Promise.resolve(jsonResponse({ summary: { eventCount: 0, avgUsedChunks: 0, avgUnusedChunks: 0, avgReuseRatePct: 0, latestAt: null } }));
+      }
+      if (path === "/v1/context/collections") {
+        return Promise.resolve(jsonResponse({
+          collections: [
+            {
+              id: "collection-1",
+              tenantId: "tenant-pro",
+              name: "Disposable KB",
+              description: "Temporary context",
+              status: "active",
+              documentCount: 1,
+              blockCount: 1,
+              canonicalBlockCount: 1,
+              approvedBlockCount: 0,
+              tokenCount: 20,
+              createdAt: "2026-05-01T20:00:00.000Z",
+              updatedAt: "2026-05-01T21:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (path === "/v1/context/collections/collection-1/sources") {
+        return Promise.resolve(jsonResponse({
+          sources: [
+            {
+              id: "source-1",
+              collectionId: "collection-1",
+              name: "Refund source",
+              type: "manual",
+              externalId: "manual:refunds",
+              sourceUri: "file://refunds.md",
+              syncStatus: "synced",
+              lastSyncedAt: "2026-05-01T21:00:00.000Z",
+              lastDocumentId: "doc-1",
+              documentCount: 1,
+              lastError: null,
+              metadata: {},
+              updatedAt: "2026-05-01T21:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (path === "/v1/context/collections/collection-1/canonical-blocks?reviewStatus=draft") {
+        return Promise.resolve(jsonResponse({
+          canonicalBlocks: [
+            {
+              id: "canonical-1",
+              collectionId: "collection-1",
+              content: "Refunds require a receipt.",
+              tokenCount: 5,
+              sourceBlockIds: ["block-1"],
+              sourceDocumentIds: ["doc-1"],
+              sourceCount: 1,
+              reviewStatus: "draft",
+              reviewNote: null,
+              reviewedByUserId: null,
+              reviewedAt: null,
+              policyStatus: "unchecked",
+              policyCheckedAt: null,
+              policyDetails: [],
+              metadata: {},
+              updatedAt: "2026-05-01T21:00:00.000Z",
+            },
+          ],
+        }));
+      }
+      if (path === "/v1/context/credentials") {
+        return Promise.resolve(jsonResponse({ credentials: [] }));
+      }
+      if (path === "/v1/context/collections/collection-1" && init?.method === "DELETE") {
+        return Promise.resolve(jsonResponse({
+          collection: { id: "collection-1", name: "Disposable KB" },
+          deleted: { sources: 1, documents: 1, blocks: 1, canonicalBlocks: 1, reviewEvents: 0 },
+        }));
+      }
+      return Promise.resolve(jsonResponse({ events: [] }));
+    });
+
+    try {
+      render(<ContextOptimizerPanel />);
+
+      expect(await screen.findByText("Disposable KB")).toBeInTheDocument();
+      expect(screen.getByText("Refund source")).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Delete collection Disposable KB" }));
+
+      expect(await screen.findByText("Collection deleted. Removed 1 source, 1 document, 1 block, 1 canonical block.")).toBeInTheDocument();
+      expect(screen.queryByText("Disposable KB")).not.toBeInTheDocument();
+      expect(screen.queryByText("Refund source")).not.toBeInTheDocument();
+      expect(confirmSpy).toHaveBeenCalledWith("Delete Disposable KB and all associated context?");
+    } finally {
+      confirmSpy.mockRestore();
+    }
   });
 
   it("updates and persists optimizer payload controls", async () => {

--- a/apps/web/tests/e2e/docs.spec.ts
+++ b/apps/web/tests/e2e/docs.spec.ts
@@ -104,7 +104,7 @@ test("/docs/context-optimizer: human docs render with key workflow sections", as
   await expect(page.getByRole("heading", { name: "Context Optimizer" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Connectors", exact: true })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Dashboard Workflow" })).toBeVisible();
-  await expect(page.getByText("create a managed collection first")).toBeVisible();
+  await expect(page.getByText("auto-create a default managed collection")).toBeVisible();
   await expect(page.getByRole("link", { name: "Open API Reference" })).toHaveAttribute("href", "/docs/api#tag/Context-Optimizer");
 });
 

--- a/docs/context-optimizer.md
+++ b/docs/context-optimizer.md
@@ -114,6 +114,7 @@ Managed collection APIs:
 ```text
 GET /v1/context/collections
 POST /v1/context/collections
+DELETE /v1/context/collections/{id}
 POST /v1/context/collections/{id}/documents
 GET /v1/context/collections/{id}/sources
 POST /v1/context/collections/{id}/sources
@@ -129,6 +130,8 @@ PATCH /v1/context/canonical-blocks/bulk-review
 GET /v1/context/canonical-review-events
 GET /v1/context/collections/{id}/export
 ```
+
+`DELETE /v1/context/collections/{id}` removes the collection and its associated context sources, documents, raw blocks, canonical blocks, and canonical review events. Connector credentials are tenant-level records, so deleting a collection does not delete stored GitHub, AWS, or Confluence credential metadata.
 
 Collections are tenant-scoped containers for reusable context. The document ingestion endpoint accepts plain text, source labels, source URIs, and metadata, then deterministically chunks the text into stored blocks with content hashes, token estimates, source provenance, and collection counters.
 
@@ -276,7 +279,7 @@ It shows five summary cards:
 
 The Configuration section lets operators draft optimizer settings for `dedupeMode`, `rankMode`, `freshnessMode`, `conflictMode`, `compressionMode`, `scanRisk`, and related thresholds. The draft is stored in browser local storage and can be copied as a `POST /v1/context/optimize` JSON payload.
 
-The Managed Collections section can create and list persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, AWS access-key credentials, Confluence API-token credentials, list credential metadata without secret values, create text file upload sources, create S3 bucket sources, create Confluence space sources, create GitHub repository sources for the first managed collection, and bind external sources to stored credentials. The Collection Sources section shows manual, file upload, GitHub, S3, and Confluence sources for the first managed collection, including source URI, filename metadata, repo/branch/path, bucket/prefix/region, or Confluence base URL/space/labels, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history. Manual source ingestion, distillation, review, and export are available through the API in this release; richer in-dashboard collection management remains a follow-up.
+The Managed Collections section can create, list, and delete persisted context collections, including document count, stored block count, canonical block count, approved block count, estimated token count, status, and last update time. The Connector Management section can create GitHub token credentials, AWS access-key credentials, Confluence API-token credentials, list credential metadata without secret values, create text file upload sources, create S3 bucket sources, create Confluence space sources, create GitHub repository sources for the first managed collection, auto-create a default collection for the first source when needed, and bind external sources to stored credentials. The Collection Sources section shows manual, file upload, GitHub, S3, and Confluence sources for the first managed collection, including source URI, filename metadata, repo/branch/path, bucket/prefix/region, or Confluence base URL/space/labels, auth-configured status, sync status, document count, last synced time, update time, and last sync error. Operators can manually sync a source row from the dashboard. The Canonical Review Queue shows draft canonical blocks from the first managed collection with content, source count, token count, policy status, policy evidence, review status, and update time. Reviewers can select visible rows, run bulk policy checks, and approve or reject selected draft blocks from the dashboard. The Alerts dashboard surfaces context policy failures and stale review queue alerts alongside existing operational alert history.
 
 The Recent Events table shows:
 

--- a/packages/gateway/openapi.yaml
+++ b/packages/gateway/openapi.yaml
@@ -518,6 +518,36 @@ paths:
         "409":
           description: Collection name already exists.
 
+  /v1/context/collections/{id}:
+    delete:
+      tags: [Context Optimizer]
+      summary: Delete a managed context collection
+      description: Deletes the collection and all associated context sources, documents, raw blocks, canonical blocks, and review events.
+      operationId: deleteContextCollection
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Deleted collection and context row counts
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [collection, deleted]
+                properties:
+                  collection:
+                    $ref: "#/components/schemas/ContextCollection"
+                  deleted:
+                    $ref: "#/components/schemas/DeletedContextCollectionCounts"
+        "402":
+          $ref: "#/components/responses/InsufficientTier"
+        "404":
+          description: Collection not found.
+
   /v1/context/collections/{id}/documents:
     post:
       tags: [Context Optimizer]
@@ -3304,6 +3334,21 @@ components:
         updatedAt:
           type: string
           format: date-time
+
+    DeletedContextCollectionCounts:
+      type: object
+      required: [sources, documents, blocks, canonicalBlocks, reviewEvents]
+      properties:
+        sources:
+          type: integer
+        documents:
+          type: integer
+        blocks:
+          type: integer
+        canonicalBlocks:
+          type: integer
+        reviewEvents:
+          type: integer
 
     ContextDocument:
       type: object

--- a/packages/gateway/src/context/store.ts
+++ b/packages/gateway/src/context/store.ts
@@ -131,6 +131,17 @@ export interface ContextCollection {
   updatedAt: Date;
 }
 
+export interface DeleteContextCollectionResult {
+  collection: ContextCollection;
+  deleted: {
+    sources: number;
+    documents: number;
+    blocks: number;
+    canonicalBlocks: number;
+    reviewEvents: number;
+  };
+}
+
 export interface ContextCanonicalBlock {
   id: string;
   tenantId: string | null;
@@ -1114,6 +1125,41 @@ export async function listContextCollections(db: Db, tenantId: string | null): P
     .orderBy(desc(contextCollections.updatedAt))
     .all();
   return rows.map(collectionFromRow);
+}
+
+export async function deleteContextCollection(
+  db: Db,
+  tenantId: string | null,
+  collectionId: string,
+): Promise<DeleteContextCollectionResult> {
+  const collectionWhere = tenantScoped(contextCollections.tenantId, tenantId, eq(contextCollections.id, collectionId));
+  const collectionRow = await db.select().from(contextCollections).where(collectionWhere).get();
+  if (!collectionRow) throw new Error("collection not found");
+  const collection = collectionFromRow(collectionRow);
+
+  const sourceCount = await db.select({ count: sql<number>`count(*)` }).from(contextSources).where(eq(contextSources.collectionId, collectionId)).get();
+  const documentCount = await db.select({ count: sql<number>`count(*)` }).from(contextDocuments).where(eq(contextDocuments.collectionId, collectionId)).get();
+  const blockCount = await db.select({ count: sql<number>`count(*)` }).from(contextBlocks).where(eq(contextBlocks.collectionId, collectionId)).get();
+  const canonicalBlockCount = await db.select({ count: sql<number>`count(*)` }).from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.collectionId, collectionId)).get();
+  const reviewEventCount = await db.select({ count: sql<number>`count(*)` }).from(contextCanonicalReviewEvents).where(eq(contextCanonicalReviewEvents.collectionId, collectionId)).get();
+
+  await db.delete(contextCanonicalReviewEvents).where(eq(contextCanonicalReviewEvents.collectionId, collectionId)).run();
+  await db.delete(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.collectionId, collectionId)).run();
+  await db.delete(contextBlocks).where(eq(contextBlocks.collectionId, collectionId)).run();
+  await db.delete(contextSources).where(eq(contextSources.collectionId, collectionId)).run();
+  await db.delete(contextDocuments).where(eq(contextDocuments.collectionId, collectionId)).run();
+  await db.delete(contextCollections).where(eq(contextCollections.id, collectionId)).run();
+
+  return {
+    collection,
+    deleted: {
+      sources: Number(sourceCount?.count ?? 0),
+      documents: Number(documentCount?.count ?? 0),
+      blocks: Number(blockCount?.count ?? 0),
+      canonicalBlocks: Number(canonicalBlockCount?.count ?? 0),
+      reviewEvents: Number(reviewEventCount?.count ?? 0),
+    },
+  };
 }
 
 export async function createContextConnectorCredential(

--- a/packages/gateway/src/routes/context.ts
+++ b/packages/gateway/src/routes/context.ts
@@ -32,6 +32,7 @@ import {
   createContextCollection,
   createContextConnectorCredential,
   createContextSource,
+  deleteContextCollection,
   distillContextCollection,
   exportApprovedContextBlocks,
   getContextCanonicalBlock,
@@ -666,6 +667,23 @@ export function createContextRoutes(db: Db, registry?: ProviderRegistry, routeOp
       return c.json(
         { error: { message, type: message.includes("already exists") ? "conflict_error" : "store_error" } },
         message.includes("already exists") ? 409 : 500,
+      );
+    }
+  });
+
+  app.delete("/collections/:id", async (c) => {
+    const tenantId = getTenantId(c.req.raw);
+    const collectionId = c.req.param("id");
+
+    try {
+      const result = await deleteContextCollection(db, tenantId, collectionId);
+      return c.json(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to delete context collection";
+      const notFound = message.includes("not found");
+      return c.json(
+        { error: { message, type: notFound ? "not_found" : "store_error" } },
+        notFound ? 404 : 500,
       );
     }
   });

--- a/packages/gateway/tests/context-optimizer.test.ts
+++ b/packages/gateway/tests/context-optimizer.test.ts
@@ -1659,6 +1659,99 @@ describe("managed context collections", () => {
     ]);
   });
 
+  it("deletes a collection and clears associated context rows", async () => {
+    await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
+    await grantIntelligenceAccess(db, "tenant-other", { tier: "pro" });
+    const app = buildApp(db);
+
+    const collectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({ name: "Disposable KB" }),
+    });
+    const collectionBody = await collectionRes.json() as { collection: { id: string } };
+    const collectionId = collectionBody.collection.id;
+
+    const otherCollectionRes = await app.request("/v1/context/collections", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-other" },
+      body: JSON.stringify({ name: "Other KB" }),
+    });
+    const otherCollectionBody = await otherCollectionRes.json() as { collection: { id: string } };
+
+    const sourceRes = await app.request(`/v1/context/collections/${collectionId}/sources`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro" },
+      body: JSON.stringify({
+        name: "Refund source",
+        type: "manual",
+        sourceUri: "file://refunds.md",
+        content: "Refunds require a receipt and must be requested within 30 days.",
+      }),
+    });
+    expect(sourceRes.status).toBe(201);
+    const sourceBody = await sourceRes.json() as { source: { id: string } };
+
+    const syncRes = await app.request(`/v1/context/sources/${sourceBody.source.id}/sync`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(syncRes.status).toBe(200);
+
+    const distillRes = await app.request(`/v1/context/collections/${collectionId}/distill`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(distillRes.status).toBe(200);
+    const distillBody = await distillRes.json() as { canonicalBlocks: Array<{ id: string }> };
+    const canonicalBlockId = distillBody.canonicalBlocks[0]?.id;
+    expect(canonicalBlockId).toEqual(expect.any(String));
+
+    const policyRes = await app.request(`/v1/context/canonical-blocks/${canonicalBlockId}/policy-check`, {
+      method: "POST",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(policyRes.status).toBe(200);
+    const reviewRes = await app.request(`/v1/context/canonical-blocks/${canonicalBlockId}/review`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-test-tenant": "tenant-pro", "x-test-user": "reviewer" },
+      body: JSON.stringify({ reviewStatus: "approved", note: "Ready." }),
+    });
+    expect(reviewRes.status).toBe(200);
+
+    const crossTenantDeleteRes = await app.request(`/v1/context/collections/${collectionId}`, {
+      method: "DELETE",
+      headers: { "x-test-tenant": "tenant-other" },
+    });
+    expect(crossTenantDeleteRes.status).toBe(404);
+
+    const deleteRes = await app.request(`/v1/context/collections/${collectionId}`, {
+      method: "DELETE",
+      headers: { "x-test-tenant": "tenant-pro" },
+    });
+    expect(deleteRes.status).toBe(200);
+    const deleteBody = await deleteRes.json() as {
+      collection: { id: string; name: string };
+      deleted: { sources: number; documents: number; blocks: number; canonicalBlocks: number; reviewEvents: number };
+    };
+    expect(deleteBody.collection).toMatchObject({ id: collectionId, name: "Disposable KB" });
+    expect(deleteBody.deleted).toMatchObject({
+      sources: 1,
+      documents: 1,
+      blocks: 1,
+      canonicalBlocks: 1,
+      reviewEvents: 1,
+    });
+
+    expect(await db.select().from(contextSources).where(eq(contextSources.collectionId, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextDocuments).where(eq(contextDocuments.collectionId, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextBlocks).where(eq(contextBlocks.collectionId, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextCanonicalBlocks).where(eq(contextCanonicalBlocks.collectionId, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextCanonicalReviewEvents).where(eq(contextCanonicalReviewEvents.collectionId, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextCollections).where(eq(contextCollections.id, collectionId)).all()).toHaveLength(0);
+    expect(await db.select().from(contextCollections).where(eq(contextCollections.id, otherCollectionBody.collection.id)).all()).toHaveLength(1);
+  });
+
   it("ingests text into deterministic blocks with provenance metadata", async () => {
     await grantIntelligenceAccess(db, "tenant-pro", { tier: "pro" });
     const app = buildApp(db);


### PR DESCRIPTION
## Summary
- Add a tenant-scoped DELETE /v1/context/collections/{id} API that clears collection sources, documents, raw blocks, canonical blocks, and review events.
- Add a dashboard delete action for managed collections and auto-create the first source collection when needed.
- Document the delete endpoint in OpenAPI and Context Optimizer human docs.

## Test Plan
- npm test --workspace @provara/gateway -- context-optimizer.test.ts
- npm test --workspace @provara/web -- context-optimizer-panel.test.tsx
- npm --workspace @provara/web run build